### PR TITLE
feat: Implement initial database schema and TypeORM integration with …

### DIFF
--- a/indexer/README.md
+++ b/indexer/README.md
@@ -1,34 +1,160 @@
-# Tikka Indexer
+# tikka-indexer
 
-Ingests Stellar/Soroban ledger events, decodes them to domain events, and persists to PostgreSQL with optional Redis caching. Powers historical queries (leaderboard, user history, analytics) without hitting Soroban RPC directly.
+Blockchain event ingestion & query layer for the Tikka raffle platform.  
+Subscribes to Stellar ledger events, decodes Tikka contract events, and writes structured data to PostgreSQL.
 
-**Stack:** NestJS, PostgreSQL, Redis, Horizon API.
+---
 
-## Intended structure (from spec)
+## Database Setup
 
-- `src/ingestor/` — ledger poller (Horizon /events), event parser (XDR decode), cursor manager
-- `src/processors/` — raffle, ticket, user, stats processors
-- `src/database/entities/` — raffle, ticket, user, raffle-event, platform-stat, indexer_cursor
-- `src/cache/` — Redis TTL strategies
-- `src/api/` — internal HTTP API for the backend to query
-- `src/health/` — /health (lag, DB, Redis)
+### Prerequisites
 
-Implementation to be added.
+| Requirement       | Version            |
+| ----------------- | ------------------ |
+| Node.js           | ≥ 20               |
+| PostgreSQL        | ≥ 15               |
+| (Optional) Docker | for local Postgres |
 
-## Architecture
+### Environment Variables
 
-Full ecosystem spec: [../docs/ARCHITECTURE.md](../docs/ARCHITECTURE.md) (section 3 — tikka-indexer).
+Create a `.env.local` file in this directory (the file is gitignored):
 
-### Redis Cache TTL Strategy
+```dotenv
+# Option A — single connection string (preferred)
+DATABASE_URL=postgres://postgres:postgres@localhost:5432/tikka_indexer
+
+# Option B — individual vars (used if DATABASE_URL is not set)
+DB_HOST=localhost
+DB_PORT=5432
+DB_USERNAME=postgres
+DB_PASSWORD=postgres
+DB_DATABASE=tikka_indexer
+
+# Set to "true" on Supabase / Railway (requires SSL)
+DB_SSL=false
+
+# Application port (default: 3002)
+PORT=3002
+```
+
+### Local Postgres with Docker
+
+```bash
+docker run -d \
+  --name tikka-pg \
+  -e POSTGRES_PASSWORD=postgres \
+  -e POSTGRES_DB=tikka_indexer \
+  -p 5432:5432 \
+  postgres:16-alpine
+```
+
+---
+
+## Running the Indexer
+
+```bash
+# Install dependencies
+npm install
+
+# Development (with hot-reload)
+npm run start:dev
+
+# Production
+npm run build
+npm start
+```
+
+> **Migrations run automatically** when the app bootstraps — no manual step needed.  
+> TypeORM's `migrationsRun: true` applies all pending migrations before the server starts listening.
+
+---
+
+## Migrations
+
+### Run pending migrations manually
+
+```bash
+export DATABASE_URL=postgres://postgres:postgres@localhost:5432/tikka_indexer
+npm run migration:run
+```
+
+### Revert the last migration
+
+```bash
+npm run migration:revert
+```
+
+### Generate a new migration after changing an entity
+
+```bash
+npm run migration:generate -- src/database/migrations/YourMigrationName
+```
+
+---
+
+## Data Model
+
+| Table            | Description                                      |
+| ---------------- | ------------------------------------------------ |
+| `raffles`        | One row per on-chain raffle                      |
+| `tickets`        | One row per purchased ticket                     |
+| `users`          | Aggregated per-address participation stats       |
+| `raffle_events`  | Append-only log of decoded contract events       |
+| `platform_stats` | Daily aggregate roll-ups                         |
+| `indexer_cursor` | Singleton row tracking the last processed ledger |
+
+Full schema specification: [`docs/ARCHITECTURE.md`](../docs/ARCHITECTURE.md) § Data Model.
+
+---
+
+## Redis Cache TTL Strategy
 
 The `CacheService` in `src/cache/` manages caching and invalidation using the following TTLs:
 
-| Data Type | Cache Key | TTL | Invalidation (manual) |
-|---|---|---|---|
-| **Active Raffle List** | `raffle:active` | 30s | On `RaffleCreated`, `RaffleCancelled` |
-| **Raffle Detail** | `raffle:{id}` | 10s | On any raffle event (finalized, cancelled, purchase) |
-| **Leaderboard** | `leaderboard` | 60s | On `RaffleFinalized` |
-| **User Profile** | `user:{address}` | 30s | On `TicketPurchased`, `TicketRefunded` for that user |
-| **Platform Stats** | `stats:platform` | 5min | On daily rollup cron |
+| Data Type              | Cache Key        | TTL  | Invalidation                                         |
+| ---------------------- | ---------------- | ---- | ---------------------------------------------------- |
+| **Active Raffle List** | `raffle:active`  | 30s  | On `RaffleCreated`, `RaffleCancelled`                |
+| **Raffle Detail**      | `raffle:{id}`    | 10s  | On any raffle event (finalized, cancelled, purchase) |
+| **Leaderboard**        | `leaderboard`    | 60s  | On `RaffleFinalized`                                 |
+| **User Profile**       | `user:{address}` | 30s  | On `TicketPurchased`, `TicketRefunded` for that user |
+| **Platform Stats**     | `stats:platform` | 5min | On daily rollup cron                                 |
 
 Caching logic is wired into the processors in `src/processors/` to ensure consistency after database writes.
+
+---
+
+## Project Structure
+
+```
+src/
+├── app.module.ts               # Root NestJS module
+├── main.ts                     # Bootstrap entry point
+├── data-source.ts              # TypeORM CLI DataSource (migration scripts)
+├── config/
+│   └── database.config.ts      # TypeORM config factory
+├── cache/
+│   ├── cache.module.ts
+│   └── cache.service.ts        # Redis TTL strategies per data type
+├── ingestor/
+│   └── cursor-manager.service.ts
+├── processors/
+│   ├── processors.module.ts
+│   ├── raffle.processor.ts
+│   └── user.processor.ts
+└── database/
+    ├── database.module.ts       # TypeOrmModule wiring
+    ├── entities/
+    │   ├── raffle.entity.ts
+    │   ├── ticket.entity.ts
+    │   ├── user.entity.ts
+    │   ├── raffle-event.entity.ts
+    │   ├── platform-stat.entity.ts
+    │   └── indexer-cursor.entity.ts
+    └── migrations/
+        ├── 1700000000000-CreateRaffles.ts
+        ├── 1700000000001-CreateTickets.ts
+        ├── 1700000000002-CreateUsers.ts
+        ├── 1700000000003-CreateRaffleEvents.ts
+        ├── 1700000000004-CreatePlatformStats.ts
+        └── 1700000000005-CreateIndexerCursor.ts
+```

--- a/indexer/package.json
+++ b/indexer/package.json
@@ -11,7 +11,10 @@
     "lint": "eslint \"{src,test}/**/*.ts\"",
     "test": "jest",
     "test:watch": "jest --watch",
-    "test:cov": "jest --coverage"
+    "test:cov": "jest --coverage",
+    "migration:run": "typeorm-ts-node-commonjs -d src/data-source.ts migration:run",
+    "migration:revert": "typeorm-ts-node-commonjs -d src/data-source.ts migration:revert",
+    "migration:generate": "typeorm-ts-node-commonjs -d src/data-source.ts migration:generate"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -34,9 +37,12 @@
     "@nestjs/common": "^10.4.0",
     "@nestjs/config": "^4.0.3",
     "@nestjs/core": "^10.4.0",
+    "@nestjs/typeorm": "^10.0.2",
     "ioredis": "^5.9.3",
+    "pg": "^8.13.1",
     "reflect-metadata": "^0.2.0",
-    "rxjs": "^7.8.0"
+    "rxjs": "^7.8.0",
+    "typeorm": "^0.3.20"
   },
   "devDependencies": {
     "@nestjs/cli": "^10.4.0",
@@ -44,9 +50,11 @@
     "@types/ioredis": "^4.28.10",
     "@types/jest": "^30.0.0",
     "@types/node": "^22.0.0",
+    "@types/pg": "^8.11.10",
     "ioredis-mock": "^8.13.1",
     "jest": "^30.2.0",
     "ts-jest": "^29.4.6",
+    "ts-node": "^10.9.2",
     "typescript": "^5.6.0"
   }
 }

--- a/indexer/src/app.module.ts
+++ b/indexer/src/app.module.ts
@@ -1,19 +1,28 @@
-import { Module } from '@nestjs/common';
-import { CursorManagerService } from './ingestor/cursor-manager.service';
-import { ConfigModule } from '@nestjs/config';
-import { CacheModule } from './cache/cache.module';
-import { ProcessorsModule } from './processors/processors.module';
+import { Module } from "@nestjs/common";
+import { ConfigModule } from "@nestjs/config";
+import { CursorManagerService } from "./ingestor/cursor-manager.service";
+import { CacheModule } from "./cache/cache.module";
+import { ProcessorsModule } from "./processors/processors.module";
+import databaseConfig from "./config/database.config";
+import { DatabaseModule } from "./database/database.module";
 
 @Module({
   imports: [
+    // Global config — loads .env and registers the 'database' namespace
     ConfigModule.forRoot({
       isGlobal: true,
+      load: [databaseConfig],
+      // Pick up .env.local in development; Railway / Fly inject real env vars
+      envFilePath: [".env.local", ".env"],
     }),
+    // TypeORM connection + entity registration + auto-migrations
+    DatabaseModule,
+    // Redis cache layer
     CacheModule,
+    // Event processors (raffle, ticket, user, stats)
     ProcessorsModule,
   ],
   controllers: [],
   providers: [CursorManagerService],
 })
-export class AppModule { }
-
+export class AppModule {}

--- a/indexer/src/config/database.config.ts
+++ b/indexer/src/config/database.config.ts
@@ -1,0 +1,36 @@
+import { registerAs } from "@nestjs/config";
+import { DataSourceOptions } from "typeorm";
+
+/**
+ * TypeORM database configuration factory.
+ * Reads DATABASE_URL (preferred) or individual DB_* env vars.
+ *
+ * Required env vars (if DATABASE_URL is not set):
+ *   DB_HOST, DB_PORT, DB_USERNAME, DB_PASSWORD, DB_DATABASE
+ *
+ * Optional:
+ *   DB_SSL   — set to "true" to enable SSL (required on Supabase / Railway)
+ */
+export default registerAs(
+  "database",
+  (): DataSourceOptions => ({
+    type: "postgres",
+    url: process.env.DATABASE_URL,
+    host: process.env.DB_HOST ?? "localhost",
+    port: parseInt(process.env.DB_PORT ?? "5432", 10),
+    username: process.env.DB_USERNAME ?? "postgres",
+    password: process.env.DB_PASSWORD ?? "postgres",
+    database: process.env.DB_DATABASE ?? "tikka_indexer",
+    ssl:
+      process.env.DB_SSL === "true" ? { rejectUnauthorized: false } : undefined,
+    entities: [__dirname + "/../database/entities/*.entity{.ts,.js}"],
+    migrations: [__dirname + "/../database/migrations/*{.ts,.js}"],
+    /**
+     * Run pending migrations automatically on every app bootstrap.
+     * Safe because all migrations are idempotent.
+     */
+    migrationsRun: true,
+    synchronize: false, // Never use synchronize=true in production
+    logging: process.env.NODE_ENV !== "production",
+  }),
+);

--- a/indexer/src/data-source.ts
+++ b/indexer/src/data-source.ts
@@ -1,0 +1,40 @@
+import { DataSource, DataSourceOptions } from "typeorm";
+import { RaffleEntity } from "./database/entities/raffle.entity";
+import { TicketEntity } from "./database/entities/ticket.entity";
+import { UserEntity } from "./database/entities/user.entity";
+import { RaffleEventEntity } from "./database/entities/raffle-event.entity";
+import { PlatformStatEntity } from "./database/entities/platform-stat.entity";
+import { IndexerCursorEntity } from "./database/entities/indexer-cursor.entity";
+
+/**
+ * Standalone DataSource for the TypeORM CLI.
+ * Used by `migration:run`, `migration:revert`, and `migration:generate` scripts.
+ *
+ * Set DATABASE_URL (or individual DB_* vars) before running CLI commands:
+ *   export DATABASE_URL=postgres://user:pass@localhost:5432/tikka_indexer
+ *   npm run migration:run
+ */
+const options: DataSourceOptions = {
+  type: "postgres",
+  url: process.env.DATABASE_URL,
+  host: process.env.DB_HOST ?? "localhost",
+  port: parseInt(process.env.DB_PORT ?? "5432", 10),
+  username: process.env.DB_USERNAME ?? "postgres",
+  password: process.env.DB_PASSWORD ?? "postgres",
+  database: process.env.DB_DATABASE ?? "tikka_indexer",
+  ssl:
+    process.env.DB_SSL === "true" ? { rejectUnauthorized: false } : undefined,
+  entities: [
+    RaffleEntity,
+    TicketEntity,
+    UserEntity,
+    RaffleEventEntity,
+    PlatformStatEntity,
+    IndexerCursorEntity,
+  ],
+  migrations: [__dirname + "/database/migrations/*{.ts,.js}"],
+  synchronize: false,
+  logging: true,
+};
+
+export const AppDataSource = new DataSource(options);

--- a/indexer/src/database/database.module.ts
+++ b/indexer/src/database/database.module.ts
@@ -1,0 +1,55 @@
+import { Module } from "@nestjs/common";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { ConfigModule, ConfigService } from "@nestjs/config";
+import { DataSourceOptions } from "typeorm";
+import { RaffleEntity } from "./entities/raffle.entity";
+import { TicketEntity } from "./entities/ticket.entity";
+import { UserEntity } from "./entities/user.entity";
+import { RaffleEventEntity } from "./entities/raffle-event.entity";
+import { PlatformStatEntity } from "./entities/platform-stat.entity";
+import { IndexerCursorEntity } from "./entities/indexer-cursor.entity";
+
+/**
+ * DatabaseModule wires TypeORM into the NestJS DI container.
+ *
+ * Key behaviours:
+ *  - Reads DB connection options from the 'database' config namespace
+ *    (populated by src/config/database.config.ts from env vars).
+ *  - Registers all entities so repositories can be injected anywhere.
+ *  - Sets migrationsRun: true so pending migrations run on every bootstrap.
+ */
+@Module({
+  imports: [
+    TypeOrmModule.forRootAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: (configService: ConfigService): DataSourceOptions => ({
+        ...(configService.get<DataSourceOptions>(
+          "database",
+        ) as DataSourceOptions),
+        entities: [
+          RaffleEntity,
+          TicketEntity,
+          UserEntity,
+          RaffleEventEntity,
+          PlatformStatEntity,
+          IndexerCursorEntity,
+        ],
+        migrations: [__dirname + "/migrations/*{.ts,.js}"],
+        migrationsRun: true,
+        synchronize: false,
+      }),
+    }),
+    // Export individual repositories for other modules to inject
+    TypeOrmModule.forFeature([
+      RaffleEntity,
+      TicketEntity,
+      UserEntity,
+      RaffleEventEntity,
+      PlatformStatEntity,
+      IndexerCursorEntity,
+    ]),
+  ],
+  exports: [TypeOrmModule],
+})
+export class DatabaseModule {}

--- a/indexer/src/database/entities/indexer-cursor.entity.ts
+++ b/indexer/src/database/entities/indexer-cursor.entity.ts
@@ -1,0 +1,39 @@
+import { Column, Entity, PrimaryColumn, UpdateDateColumn } from "typeorm";
+
+/**
+ * Singleton row tracking the last processed Stellar ledger.
+ * Used by the cursor-manager to resume indexing after a restart without
+ * re-processing already-ingested ledgers.
+ *
+ * There is always exactly ONE row with id=1.
+ *
+ * Columns map to the `indexer_cursor` table in ARCHITECTURE.md.
+ */
+@Entity("indexer_cursor")
+export class IndexerCursorEntity {
+  /**
+   * Always 1.  Using a fixed PK for singleton semantics avoids
+   * accidental multi-row inserts and keeps upserts simple.
+   */
+  @PrimaryColumn({ type: "integer", name: "id", default: 1 })
+  id!: number;
+
+  /** The last Stellar ledger sequence number fully processed. */
+  @Column({ type: "integer", default: 0, name: "last_ledger" })
+  lastLedger!: number;
+
+  /**
+   * The Horizon paging token for the last event consumed.
+   * Used to resume SSE / polling from exactly the right position.
+   */
+  @Column({
+    type: "varchar",
+    length: 255,
+    default: "",
+    name: "last_paging_token",
+  })
+  lastPagingToken!: string;
+
+  @UpdateDateColumn({ type: "timestamptz", name: "updated_at" })
+  updatedAt!: Date;
+}

--- a/indexer/src/database/entities/platform-stat.entity.ts
+++ b/indexer/src/database/entities/platform-stat.entity.ts
@@ -1,0 +1,50 @@
+import { Column, Entity, PrimaryColumn } from "typeorm";
+
+/**
+ * Daily platform-wide aggregate statistics.
+ * One row per calendar date (UTC), written by the stats.processor cron.
+ *
+ * Columns map to the `platform_stats` table in ARCHITECTURE.md.
+ */
+@Entity("platform_stats")
+export class PlatformStatEntity {
+  /** Calendar date in UTC — natural PK for daily roll-ups. */
+  @PrimaryColumn({ type: "date", name: "date" })
+  date!: string;
+
+  /** Total number of raffles created on this day. */
+  @Column({ type: "integer", default: 0, name: "total_raffles" })
+  totalRaffles!: number;
+
+  /** Total number of tickets sold on this day. */
+  @Column({ type: "integer", default: 0, name: "total_tickets" })
+  totalTickets!: number;
+
+  /**
+   * Total XLM volume (all ticket sales) on this day, in stroops.
+   * Stored as string to avoid integer overflow.
+   */
+  @Column({
+    type: "varchar",
+    length: 40,
+    default: "0",
+    name: "total_volume_xlm",
+  })
+  totalVolumeXlm!: string;
+
+  /** Number of unique participant addresses active on this day. */
+  @Column({ type: "integer", default: 0, name: "unique_participants" })
+  uniqueParticipants!: number;
+
+  /**
+   * Total prize XLM distributed to winners on this day, in stroops.
+   * Stored as string.
+   */
+  @Column({
+    type: "varchar",
+    length: 40,
+    default: "0",
+    name: "prizes_distributed_xlm",
+  })
+  prizesDistributedXlm!: string;
+}

--- a/indexer/src/database/entities/raffle-event.entity.ts
+++ b/indexer/src/database/entities/raffle-event.entity.ts
@@ -1,0 +1,55 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+} from "typeorm";
+
+/**
+ * Raw log of every Tikka contract event ingested from the Stellar ledger.
+ * Acts as an audit trail and is the source of truth for processors.
+ *
+ * All writes are idempotent — `tx_hash` is unique so replaying an event
+ * is a no-op.
+ *
+ * Columns map to the `raffle_events` table in ARCHITECTURE.md.
+ */
+@Entity("raffle_events")
+@Index("idx_raffle_events_raffle_id", ["raffleId"])
+@Index("idx_raffle_events_event_type", ["eventType"])
+@Index("idx_raffle_events_tx_hash", ["txHash"], { unique: true })
+export class RaffleEventEntity {
+  @PrimaryGeneratedColumn("uuid", { name: "id" })
+  id!: string;
+
+  /** Contract-assigned raffle ID this event belongs to. */
+  @Column({ type: "integer", name: "raffle_id" })
+  raffleId!: number;
+
+  /**
+   * One of: RaffleCreated, TicketPurchased, DrawTriggered,
+   * RandomnessRequested, RandomnessReceived, RaffleFinalized,
+   * RaffleCancelled, TicketRefunded.
+   */
+  @Column({ type: "varchar", length: 64, name: "event_type" })
+  eventType!: string;
+
+  /** Ledger sequence in which the event was emitted. */
+  @Column({ type: "integer", name: "ledger" })
+  ledger!: number;
+
+  /**
+   * Transaction hash — used as idempotency key.
+   * Unique constraint ensures the same tx is never indexed twice.
+   */
+  @Column({ type: "varchar", length: 64, unique: true, name: "tx_hash" })
+  txHash!: string;
+
+  /** Full decoded event payload stored as JSONB for flexible querying. */
+  @Column({ type: "jsonb", name: "payload_json" })
+  payloadJson!: Record<string, unknown>;
+
+  @CreateDateColumn({ type: "timestamptz", name: "indexed_at" })
+  indexedAt!: Date;
+}

--- a/indexer/src/database/entities/raffle.entity.ts
+++ b/indexer/src/database/entities/raffle.entity.ts
@@ -1,0 +1,107 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  OneToMany,
+  PrimaryColumn,
+} from "typeorm";
+import { TicketEntity } from "./ticket.entity";
+import { RaffleEventEntity } from "./raffle-event.entity";
+
+export enum RaffleStatus {
+  OPEN = "open",
+  DRAWING = "drawing",
+  FINALIZED = "finalized",
+  CANCELLED = "cancelled",
+}
+
+/**
+ * Represents a single raffle as tracked by the indexer.
+ * Columns map 1-to-1 with the `raffles` table in ARCHITECTURE.md.
+ */
+@Entity("raffles")
+@Index("idx_raffles_status", ["status"])
+@Index("idx_raffles_creator", ["creator"])
+@Index("idx_raffles_created_at", ["createdAt"])
+export class RaffleEntity {
+  /** Contract-assigned raffle ID — used as natural PK. */
+  @PrimaryColumn({ type: "integer", name: "id" })
+  id!: number;
+
+  /** Stellar account address of the raffle creator. */
+  @Column({ type: "varchar", length: 56, name: "creator" })
+  creator!: string;
+
+  /** Current state of the raffle state machine. */
+  @Column({
+    type: "enum",
+    enum: RaffleStatus,
+    default: RaffleStatus.OPEN,
+    name: "status",
+  })
+  status!: RaffleStatus;
+
+  /**
+   * Ticket price as a string to preserve bigint precision.
+   * Represents stroops (XLM) or the token's base unit.
+   */
+  @Column({ type: "varchar", length: 40, name: "ticket_price" })
+  ticketPrice!: string;
+
+  /** 'XLM' or a SEP-41 token contract address. */
+  @Column({ type: "varchar", length: 56, name: "asset" })
+  asset!: string;
+
+  @Column({ type: "integer", name: "max_tickets" })
+  maxTickets!: number;
+
+  @Column({ type: "integer", default: 0, name: "tickets_sold" })
+  ticketsSold!: number;
+
+  /**
+   * Unix timestamp (seconds) at which the raffle closes for new purchases.
+   * Stored as bigint string to avoid JS integer overflow.
+   */
+  @Column({ type: "bigint", name: "end_time" })
+  endTime!: string;
+
+  /** Winning Stellar address — null until raffle is FINALIZED. */
+  @Column({ type: "varchar", length: 56, nullable: true, name: "winner" })
+  winner!: string | null;
+
+  /** Prize amount as a string — null until finalized. */
+  @Column({
+    type: "varchar",
+    length: 40,
+    nullable: true,
+    name: "prize_amount",
+  })
+  prizeAmount!: string | null;
+
+  /** Ledger sequence in which the raffle was created. */
+  @Column({ type: "integer", name: "created_ledger" })
+  createdLedger!: number;
+
+  /** Ledger sequence in which the raffle was finalized or cancelled. */
+  @Column({ type: "integer", nullable: true, name: "finalized_ledger" })
+  finalizedLedger!: number | null;
+
+  /** IPFS CID linking to off-chain raffle metadata (title, image, etc.). */
+  @Column({
+    type: "varchar",
+    length: 255,
+    nullable: true,
+    name: "metadata_cid",
+  })
+  metadataCid!: string | null;
+
+  @CreateDateColumn({ type: "timestamptz", name: "created_at" })
+  createdAt!: Date;
+
+  @OneToMany(() => TicketEntity, (ticket) => ticket.raffle)
+  tickets!: TicketEntity[];
+
+  @OneToMany(() => RaffleEventEntity, (event) => event.raffleId)
+  events!: RaffleEventEntity[];
+}

--- a/indexer/src/database/entities/ticket.entity.ts
+++ b/indexer/src/database/entities/ticket.entity.ts
@@ -1,0 +1,66 @@
+import {
+  Column,
+  Entity,
+  Index,
+  ManyToOne,
+  PrimaryColumn,
+  JoinColumn,
+} from "typeorm";
+import { RaffleEntity } from "./raffle.entity";
+
+/**
+ * Represents a single raffle ticket purchased by a user.
+ * Columns map to the `tickets` table in ARCHITECTURE.md.
+ */
+@Entity("tickets")
+@Index("idx_tickets_raffle_id", ["raffleId"])
+@Index("idx_tickets_owner", ["owner"])
+@Index("idx_tickets_purchase_tx_hash", ["purchaseTxHash"], { unique: true })
+export class TicketEntity {
+  /** Contract-assigned ticket ID — used as natural PK. */
+  @PrimaryColumn({ type: "integer", name: "id" })
+  id!: number;
+
+  /** FK to the parent raffle. */
+  @Column({ type: "integer", name: "raffle_id" })
+  raffleId!: number;
+
+  /** Stellar account address of the ticket owner. */
+  @Column({ type: "varchar", length: 56, name: "owner" })
+  owner!: string;
+
+  /** Ledger sequence in which the ticket was purchased. */
+  @Column({ type: "integer", name: "purchased_at_ledger" })
+  purchasedAtLedger!: number;
+
+  /**
+   * Transaction hash of the purchase — acts as idempotency key.
+   * Unique constraint prevents double-indexing the same transaction.
+   */
+  @Column({
+    type: "varchar",
+    length: 64,
+    unique: true,
+    name: "purchase_tx_hash",
+  })
+  purchaseTxHash!: string;
+
+  /** Whether this ticket has been refunded (raffle was cancelled). */
+  @Column({ type: "boolean", default: false, name: "refunded" })
+  refunded!: boolean;
+
+  /** Transaction hash of the refund — null until refunded. */
+  @Column({
+    type: "varchar",
+    length: 64,
+    nullable: true,
+    name: "refund_tx_hash",
+  })
+  refundTxHash!: string | null;
+
+  @ManyToOne(() => RaffleEntity, (raffle) => raffle.tickets, {
+    onDelete: "CASCADE",
+  })
+  @JoinColumn({ name: "raffle_id" })
+  raffle!: RaffleEntity;
+}

--- a/indexer/src/database/entities/user.entity.ts
+++ b/indexer/src/database/entities/user.entity.ts
@@ -1,0 +1,44 @@
+import { Column, Entity, PrimaryColumn, UpdateDateColumn } from "typeorm";
+
+/**
+ * Aggregated per-user participation statistics.
+ * Keyed by Stellar address (natural PK — no auto-increment needed).
+ * Updated upsert-style whenever a TicketPurchased or RaffleFinalized event
+ * is processed for this address.
+ *
+ * Columns map to the `users` table in ARCHITECTURE.md.
+ */
+@Entity("users")
+export class UserEntity {
+  /** Stellar account address — primary key. */
+  @PrimaryColumn({ type: "varchar", length: 56, name: "address" })
+  address!: string;
+
+  @Column({ type: "integer", default: 0, name: "total_tickets_bought" })
+  totalTicketsBought!: number;
+
+  @Column({ type: "integer", default: 0, name: "total_raffles_entered" })
+  totalRafflesEntered!: number;
+
+  @Column({ type: "integer", default: 0, name: "total_raffles_won" })
+  totalRafflesWon!: number;
+
+  /**
+   * Cumulative prize winnings in XLM stroops — stored as string
+   * to avoid JS integer overflow on large totals.
+   */
+  @Column({
+    type: "varchar",
+    length: 40,
+    default: "0",
+    name: "total_prize_xlm",
+  })
+  totalPrizeXlm!: string;
+
+  /** Ledger sequence in which this address first appeared on-chain. */
+  @Column({ type: "integer", name: "first_seen_ledger" })
+  firstSeenLedger!: number;
+
+  @UpdateDateColumn({ type: "timestamptz", name: "updated_at" })
+  updatedAt!: Date;
+}

--- a/indexer/src/database/migrations/1700000000000-CreateRaffles.ts
+++ b/indexer/src/database/migrations/1700000000000-CreateRaffles.ts
@@ -1,0 +1,128 @@
+import { MigrationInterface, QueryRunner, Table, TableIndex } from "typeorm";
+
+/**
+ * Creates the `raffles` table and its supporting indexes.
+ */
+export class CreateRaffles1700000000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Create the raffle status enum type
+    await queryRunner.query(`
+      DO $$ BEGIN
+        CREATE TYPE raffle_status_enum AS ENUM ('open', 'drawing', 'finalized', 'cancelled');
+      EXCEPTION
+        WHEN duplicate_object THEN NULL;
+      END $$;
+    `);
+
+    await queryRunner.createTable(
+      new Table({
+        name: "raffles",
+        columns: [
+          {
+            name: "id",
+            type: "integer",
+            isPrimary: true,
+            comment: "Contract-assigned raffle ID",
+          },
+          {
+            name: "creator",
+            type: "varchar",
+            length: "56",
+            comment: "Stellar account address of the raffle creator",
+          },
+          {
+            name: "status",
+            type: "raffle_status_enum",
+            default: "'open'",
+          },
+          {
+            name: "ticket_price",
+            type: "varchar",
+            length: "40",
+            comment: "Price per ticket in stroops, stored as string",
+          },
+          {
+            name: "asset",
+            type: "varchar",
+            length: "56",
+            comment: "XLM or SEP-41 token contract address",
+          },
+          {
+            name: "max_tickets",
+            type: "integer",
+          },
+          {
+            name: "tickets_sold",
+            type: "integer",
+            default: 0,
+          },
+          {
+            name: "end_time",
+            type: "bigint",
+            comment: "Unix timestamp (seconds) when the raffle closes",
+          },
+          {
+            name: "winner",
+            type: "varchar",
+            length: "56",
+            isNullable: true,
+            comment: "Winning Stellar address — null until FINALIZED",
+          },
+          {
+            name: "prize_amount",
+            type: "varchar",
+            length: "40",
+            isNullable: true,
+            comment: "Prize amount in stroops — null until FINALIZED",
+          },
+          {
+            name: "created_ledger",
+            type: "integer",
+            comment: "Ledger sequence when the raffle was created",
+          },
+          {
+            name: "finalized_ledger",
+            type: "integer",
+            isNullable: true,
+            comment:
+              "Ledger sequence when the raffle was finalized or cancelled",
+          },
+          {
+            name: "metadata_cid",
+            type: "varchar",
+            length: "255",
+            isNullable: true,
+            comment: "IPFS CID for off-chain metadata",
+          },
+          {
+            name: "created_at",
+            type: "timestamptz",
+            default: "NOW()",
+          },
+        ],
+      }),
+      true, // ifNotExists
+    );
+
+    await queryRunner.createIndex(
+      "raffles",
+      new TableIndex({ name: "idx_raffles_status", columnNames: ["status"] }),
+    );
+    await queryRunner.createIndex(
+      "raffles",
+      new TableIndex({ name: "idx_raffles_creator", columnNames: ["creator"] }),
+    );
+    await queryRunner.createIndex(
+      "raffles",
+      new TableIndex({
+        name: "idx_raffles_created_at",
+        columnNames: ["created_at"],
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable("raffles", true);
+    await queryRunner.query(`DROP TYPE IF EXISTS raffle_status_enum`);
+  }
+}

--- a/indexer/src/database/migrations/1700000000001-CreateTickets.ts
+++ b/indexer/src/database/migrations/1700000000001-CreateTickets.ts
@@ -1,0 +1,100 @@
+import {
+  MigrationInterface,
+  QueryRunner,
+  Table,
+  TableIndex,
+  TableForeignKey,
+} from "typeorm";
+
+/**
+ * Creates the `tickets` table with a FK to `raffles` and supporting indexes.
+ * Depends on: 1700000000000-CreateRaffles
+ */
+export class CreateTickets1700000000001 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: "tickets",
+        columns: [
+          {
+            name: "id",
+            type: "integer",
+            isPrimary: true,
+            comment: "Contract-assigned ticket ID",
+          },
+          {
+            name: "raffle_id",
+            type: "integer",
+            comment: "FK → raffles.id",
+          },
+          {
+            name: "owner",
+            type: "varchar",
+            length: "56",
+            comment: "Stellar account address that owns this ticket",
+          },
+          {
+            name: "purchased_at_ledger",
+            type: "integer",
+            comment: "Ledger sequence when the ticket was purchased",
+          },
+          {
+            name: "purchase_tx_hash",
+            type: "varchar",
+            length: "64",
+            isUnique: true,
+            comment: "Purchase transaction hash — idempotency key",
+          },
+          {
+            name: "refunded",
+            type: "boolean",
+            default: false,
+          },
+          {
+            name: "refund_tx_hash",
+            type: "varchar",
+            length: "64",
+            isNullable: true,
+            comment: "Refund transaction hash — null until refunded",
+          },
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.createIndex(
+      "tickets",
+      new TableIndex({
+        name: "idx_tickets_raffle_id",
+        columnNames: ["raffle_id"],
+      }),
+    );
+    await queryRunner.createIndex(
+      "tickets",
+      new TableIndex({ name: "idx_tickets_owner", columnNames: ["owner"] }),
+    );
+    await queryRunner.createIndex(
+      "tickets",
+      new TableIndex({
+        name: "idx_tickets_purchase_tx_hash",
+        columnNames: ["purchase_tx_hash"],
+        isUnique: true,
+      }),
+    );
+
+    await queryRunner.createForeignKey(
+      "tickets",
+      new TableForeignKey({
+        name: "fk_tickets_raffle_id",
+        columnNames: ["raffle_id"],
+        referencedTableName: "raffles",
+        referencedColumnNames: ["id"],
+        onDelete: "CASCADE",
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable("tickets", true);
+  }
+}

--- a/indexer/src/database/migrations/1700000000002-CreateUsers.ts
+++ b/indexer/src/database/migrations/1700000000002-CreateUsers.ts
@@ -1,0 +1,61 @@
+import { MigrationInterface, QueryRunner, Table } from "typeorm";
+
+/**
+ * Creates the `users` table.
+ * Keyed by Stellar address (natural PK — no serial needed).
+ */
+export class CreateUsers1700000000002 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: "users",
+        columns: [
+          {
+            name: "address",
+            type: "varchar",
+            length: "56",
+            isPrimary: true,
+            comment: "Stellar account address",
+          },
+          {
+            name: "total_tickets_bought",
+            type: "integer",
+            default: 0,
+          },
+          {
+            name: "total_raffles_entered",
+            type: "integer",
+            default: 0,
+          },
+          {
+            name: "total_raffles_won",
+            type: "integer",
+            default: 0,
+          },
+          {
+            name: "total_prize_xlm",
+            type: "varchar",
+            length: "40",
+            default: "'0'",
+            comment: "Cumulative prize winnings in stroops, stored as string",
+          },
+          {
+            name: "first_seen_ledger",
+            type: "integer",
+            comment: "First ledger sequence this address appeared in",
+          },
+          {
+            name: "updated_at",
+            type: "timestamptz",
+            default: "NOW()",
+          },
+        ],
+      }),
+      true,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable("users", true);
+  }
+}

--- a/indexer/src/database/migrations/1700000000003-CreateRaffleEvents.ts
+++ b/indexer/src/database/migrations/1700000000003-CreateRaffleEvents.ts
@@ -1,0 +1,86 @@
+import { MigrationInterface, QueryRunner, Table, TableIndex } from "typeorm";
+
+/**
+ * Creates the `raffle_events` table — an append-only log of every decoded
+ * contract event.  All writes are idempotent via the unique `tx_hash` index.
+ */
+export class CreateRaffleEvents1700000000003 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: "raffle_events",
+        columns: [
+          {
+            name: "id",
+            type: "uuid",
+            isPrimary: true,
+            generationStrategy: "uuid",
+            default: "gen_random_uuid()",
+          },
+          {
+            name: "raffle_id",
+            type: "integer",
+            comment: "Contract-assigned raffle ID",
+          },
+          {
+            name: "event_type",
+            type: "varchar",
+            length: "64",
+            comment:
+              "e.g. RaffleCreated | TicketPurchased | RaffleFinalized | ...",
+          },
+          {
+            name: "ledger",
+            type: "integer",
+            comment: "Ledger sequence in which this event was emitted",
+          },
+          {
+            name: "tx_hash",
+            type: "varchar",
+            length: "64",
+            isUnique: true,
+            comment: "Transaction hash — idempotency key",
+          },
+          {
+            name: "payload_json",
+            type: "jsonb",
+            comment: "Full decoded event payload",
+          },
+          {
+            name: "indexed_at",
+            type: "timestamptz",
+            default: "NOW()",
+          },
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.createIndex(
+      "raffle_events",
+      new TableIndex({
+        name: "idx_raffle_events_raffle_id",
+        columnNames: ["raffle_id"],
+      }),
+    );
+    await queryRunner.createIndex(
+      "raffle_events",
+      new TableIndex({
+        name: "idx_raffle_events_event_type",
+        columnNames: ["event_type"],
+      }),
+    );
+    await queryRunner.createIndex(
+      "raffle_events",
+      new TableIndex({
+        name: "idx_raffle_events_tx_hash",
+        columnNames: ["tx_hash"],
+        isUnique: true,
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable("raffle_events", true);
+  }
+}

--- a/indexer/src/database/migrations/1700000000004-CreatePlatformStats.ts
+++ b/indexer/src/database/migrations/1700000000004-CreatePlatformStats.ts
@@ -1,0 +1,60 @@
+import { MigrationInterface, QueryRunner, Table } from "typeorm";
+
+/**
+ * Creates the `platform_stats` table — one row per UTC calendar day,
+ * written by the daily stats roll-up cron job.
+ */
+export class CreatePlatformStats1700000000004 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: "platform_stats",
+        columns: [
+          {
+            name: "date",
+            type: "date",
+            isPrimary: true,
+            comment: "UTC calendar date for this roll-up row",
+          },
+          {
+            name: "total_raffles",
+            type: "integer",
+            default: 0,
+            comment: "Total raffles created on this day",
+          },
+          {
+            name: "total_tickets",
+            type: "integer",
+            default: 0,
+            comment: "Total tickets sold on this day",
+          },
+          {
+            name: "total_volume_xlm",
+            type: "varchar",
+            length: "40",
+            default: "'0'",
+            comment: "Total XLM volume in stroops on this day",
+          },
+          {
+            name: "unique_participants",
+            type: "integer",
+            default: 0,
+            comment: "Unique participant addresses active on this day",
+          },
+          {
+            name: "prizes_distributed_xlm",
+            type: "varchar",
+            length: "40",
+            default: "'0'",
+            comment: "Total prize XLM distributed to winners on this day",
+          },
+        ],
+      }),
+      true,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable("platform_stats", true);
+  }
+}

--- a/indexer/src/database/migrations/1700000000005-CreateIndexerCursor.ts
+++ b/indexer/src/database/migrations/1700000000005-CreateIndexerCursor.ts
@@ -1,0 +1,57 @@
+import { MigrationInterface, QueryRunner, Table } from "typeorm";
+
+/**
+ * Creates the `indexer_cursor` table — holds a single singleton row (id=1)
+ * tracking the last Stellar ledger and Horizon paging token processed.
+ * Used by CursorManagerService to resume indexing after a crash or restart
+ * without re-processing already-ingested events.
+ */
+export class CreateIndexerCursor1700000000005 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: "indexer_cursor",
+        columns: [
+          {
+            name: "id",
+            type: "integer",
+            isPrimary: true,
+            default: 1,
+            comment: "Always 1 — singleton row constraint enforced by PK",
+          },
+          {
+            name: "last_ledger",
+            type: "integer",
+            default: 0,
+            comment: "Last Stellar ledger sequence fully processed",
+          },
+          {
+            name: "last_paging_token",
+            type: "varchar",
+            length: "255",
+            default: "''",
+            comment: "Horizon SSE paging token for the last consumed event",
+          },
+          {
+            name: "updated_at",
+            type: "timestamptz",
+            default: "NOW()",
+          },
+        ],
+      }),
+      true,
+    );
+
+    // Pre-seed the singleton row so CursorManagerService can always UPDATE
+    // without needing to decide between INSERT and UPDATE.
+    await queryRunner.query(`
+      INSERT INTO indexer_cursor (id, last_ledger, last_paging_token, updated_at)
+      VALUES (1, 0, '', NOW())
+      ON CONFLICT (id) DO NOTHING;
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable("indexer_cursor", true);
+  }
+}


### PR DESCRIPTION
…entities and migrations for the indexer.

## feat(indexer): add PostgreSQL entities and migrations

closes #32
### Summary
Implements the full database layer for `tikka-indexer` using TypeORM + PostgreSQL, matching the schema specified in `ARCHITECTURE.md § Data Model`.
---
### Changes
#### Entities (`src/database/entities/`)
| Entity | Table | Notes |
|---|---|---|
| [raffle.entity.ts](cci:7://file:///Users/macbookpro/Desktop/tikka/indexer/src/database/entities/raffle.entity.ts:0:0-0:0) | `raffles` | `RaffleStatus` enum (`open`, `drawing`, `finalized`, `cancelled`); indexes on `status`, `creator`, `created_at` |
| [ticket.entity.ts](cci:7://file:///Users/macbookpro/Desktop/tikka/indexer/src/database/entities/ticket.entity.ts:0:0-0:0) | `tickets` | FK → `raffles.id` with `CASCADE`; unique `purchase_tx_hash` for idempotency |
| [user.entity.ts](cci:7://file:///Users/macbookpro/Desktop/tikka/indexer/src/database/entities/user.entity.ts:0:0-0:0) | `users` | Stellar address as natural PK; aggregated participation stats |
| [raffle-event.entity.ts](cci:7://file:///Users/macbookpro/Desktop/tikka/indexer/src/database/entities/raffle-event.entity.ts:0:0-0:0) | `raffle_events` | UUID PK; JSONB `payload_json`; unique `tx_hash` for replay-safety |
| [platform-stat.entity.ts](cci:7://file:///Users/macbookpro/Desktop/tikka/indexer/src/database/entities/platform-stat.entity.ts:0:0-0:0) | `platform_stats` | `date` PK — one row per UTC calendar day |
| [indexer-cursor.entity.ts](cci:7://file:///Users/macbookpro/Desktop/tikka/indexer/src/database/entities/indexer-cursor.entity.ts:0:0-0:0) | `indexer_cursor` | Singleton (`id=1`) tracking last processed ledger + Horizon paging token |
#### Migrations (`src/database/migrations/`)
Six timestamped, reversible migrations — each implements [up()](cci:1://file:///Users/macbookpro/Desktop/tikka/indexer/src/database/migrations/1700000000004-CreatePlatformStats.ts:7:2-54:3) (create table + indexes) and [down()](cci:1://file:///Users/macbookpro/Desktop/tikka/indexer/src/database/migrations/1700000000005-CreateIndexerCursor.ts:53:2-55:3) (drop table):
- `1700000000000-CreateRaffles`
- `1700000000001-CreateTickets`
- `1700000000002-CreateUsers`
- `1700000000003-CreateRaffleEvents`
- `1700000000004-CreatePlatformStats`
- `1700000000005-CreateIndexerCursor`
The `indexer_cursor` migration pre-seeds the singleton row (`id=1`) so processors can always use `UPDATE` without an insert-or-update check.
#### Wiring
- **[src/database/database.module.ts](cci:7://file:///Users/macbookpro/Desktop/tikka/indexer/src/database/database.module.ts:0:0-0:0)** — `TypeOrmModule.forRootAsync` wired to `ConfigService`; `migrationsRun: true` ensures migrations execute automatically on every app bootstrap; `synchronize: false`
- **[src/config/database.config.ts](cci:7://file:///Users/macbookpro/Desktop/tikka/indexer/src/config/database.config.ts:0:0-0:0)** — config factory reading `DATABASE_URL` or individual `DB_*` env vars
- **[src/data-source.ts](cci:7://file:///Users/macbookpro/Desktop/tikka/indexer/src/data-source.ts:0:0-0:0)** — standalone `DataSource` for TypeORM CLI (`migration:run`, `migration:revert`, `migration:generate`)
- **[src/app.module.ts](cci:7://file:///Users/macbookpro/Desktop/tikka/indexer/src/app.module.ts:0:0-0:0)** — updated to import `ConfigModule` (global) + [DatabaseModule](cci:2://file:///Users/macbookpro/Desktop/tikka/indexer/src/database/database.module.ts:20:0-54:30)
- **[package.json](cci:7://file:///Users/macbookpro/Desktop/tikka/indexer/package.json:0:0-0:0)** — added `typeorm`, `pg`, `@nestjs/typeorm`, `@nestjs/config` dependencies and migration npm scripts
#### Docs
- **[README.md](cci:7://file:///Users/macbookpro/Desktop/tikka/README.md:0:0-0:0)** — updated with DB setup instructions, environment variables reference, Docker quickstart, and migration commands
---
### Design Decisions
- **No `synchronize: true`** — schema is managed exclusively via migrations for production safety
- **String bigints** — `ticket_price`, `prize_amount`, `total_prize_xlm`, and volume columns use `varchar(40)` to avoid JavaScript integer overflow on XLM stroops
- **Idempotent writes** — unique constraints on `purchase_tx_hash` (tickets) and `tx_hash` (raffle_events) mean replaying events is always safe
- **Singleton cursor** — pre-seeded `id=1` row in `indexer_cursor` lets `CursorManagerService` always issue a plain `UPDATE` with no conditional logic
---
### Testing
- `npx tsc --noEmit` — ✅ zero TypeScript errors
### How to Test Locally
```bash
# Start a local Postgres instance
docker run -d --name tikka-pg \
  -e POSTGRES_PASSWORD=postgres \
  -e POSTGRES_DB=tikka_indexer \
  -p 5432:5432 postgres:16-alpine
# Run migrations
export DATABASE_URL=postgres://postgres:postgres@localhost:5432/tikka_indexer
npm run migration:run