### PR TITLE
feat: Implement API rate limiting with a custom ThrottlerGuard, confi…

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -15,3 +15,19 @@ SIWS_DOMAIN=tikka.io
 
 # Server
 PORT=3001
+
+# ── Rate Limiting ────────────────────────────────────────────────────────────
+# Limits are per IP address. TTL values are in seconds.
+# All values have sensible defaults — only set these to override.
+
+# Default tier — applies to all public API endpoints
+THROTTLE_DEFAULT_LIMIT=100   # max requests per window
+THROTTLE_DEFAULT_TTL=60      # window size in seconds
+
+# Auth tier — POST /auth/verify (brute-force protection)
+THROTTLE_AUTH_LIMIT=10
+THROTTLE_AUTH_TTL=60
+
+# Nonce tier — GET /auth/nonce
+THROTTLE_NONCE_LIMIT=30
+THROTTLE_NONCE_TTL=60

--- a/backend/package.json
+++ b/backend/package.json
@@ -19,6 +19,7 @@
     "@nestjs/common": "^10.4.0",
     "@nestjs/core": "^10.4.0",
     "@nestjs/platform-fastify": "^10.4.0",
+    "@nestjs/throttler": "^6.4.0",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.0",
     "@supabase/supabase-js": "^2.45.0",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,16 +1,57 @@
-import { Module } from '@nestjs/common';
-import { ConfigModule } from '@nestjs/config';
-import { APP_GUARD } from '@nestjs/core';
-import { AuthModule } from './auth/auth.module';
-import { JwtAuthGuard } from './auth/guards/jwt-auth.guard';
-import { RafflesModule } from './api/rest/raffles/raffles.module';
-import { UsersModule } from './api/rest/users/users.module';
-import { LeaderboardModule } from './api/rest/leaderboard/leaderboard.module';
-import { StatsModule } from './api/rest/stats/stats.module';
+import { Module } from "@nestjs/common";
+import { ConfigModule, ConfigService } from "@nestjs/config";
+import { APP_GUARD } from "@nestjs/core";
+import { ThrottlerModule, seconds } from "@nestjs/throttler";
+import { AuthModule } from "./auth/auth.module";
+import { JwtAuthGuard } from "./auth/guards/jwt-auth.guard";
+import { RafflesModule } from "./api/rest/raffles/raffles.module";
+import { UsersModule } from "./api/rest/users/users.module";
+import { LeaderboardModule } from "./api/rest/leaderboard/leaderboard.module";
+import { StatsModule } from "./api/rest/stats/stats.module";
+import { TikkaThrottlerGuard } from "./middleware/throttler.guard";
 
 @Module({
   imports: [
     ConfigModule.forRoot({ isGlobal: true }),
+
+    /**
+     * Named throttler tiers — each applied by the TikkaThrottlerGuard.
+     *
+     * Tier          Limit      Window    Applies to
+     * ──────────────────────────────────────────────────────────────
+     * default       100 req    60 s      All public endpoints
+     * auth          10  req    60 s      POST /auth/verify
+     * nonce         30  req    60 s      GET  /auth/nonce
+     *
+     * Override limits via env vars (see .env.example):
+     *   THROTTLE_DEFAULT_LIMIT / THROTTLE_DEFAULT_TTL
+     *   THROTTLE_AUTH_LIMIT    / THROTTLE_AUTH_TTL
+     *   THROTTLE_NONCE_LIMIT   / THROTTLE_NONCE_TTL
+     */
+    ThrottlerModule.forRootAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: (config: ConfigService) => ({
+        throttlers: [
+          {
+            name: "default",
+            limit: config.get<number>("THROTTLE_DEFAULT_LIMIT", 100),
+            ttl: seconds(config.get<number>("THROTTLE_DEFAULT_TTL", 60)),
+          },
+          {
+            name: "auth",
+            limit: config.get<number>("THROTTLE_AUTH_LIMIT", 10),
+            ttl: seconds(config.get<number>("THROTTLE_AUTH_TTL", 60)),
+          },
+          {
+            name: "nonce",
+            limit: config.get<number>("THROTTLE_NONCE_LIMIT", 30),
+            ttl: seconds(config.get<number>("THROTTLE_NONCE_TTL", 60)),
+          },
+        ],
+      }),
+    }),
+
     AuthModule,
     RafflesModule,
     UsersModule,
@@ -18,7 +59,10 @@ import { StatsModule } from './api/rest/stats/stats.module';
     StatsModule,
   ],
   providers: [
+    // 1. JWT guard first — authenticates the request (sets req.user)
     { provide: APP_GUARD, useClass: JwtAuthGuard },
+    // 2. Throttler guard second — rate limits by IP across all named tiers
+    { provide: APP_GUARD, useClass: TikkaThrottlerGuard },
   ],
 })
 export class AppModule {}

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -5,22 +5,29 @@ import {
   Body,
   Query,
   BadRequestException,
-} from '@nestjs/common';
-import { AuthService } from './auth.service';
-import { Public } from './decorators/public.decorator';
+} from "@nestjs/common";
+import { AuthService } from "./auth.service";
+import { Public } from "./decorators/public.decorator";
+import { Throttle } from "../middleware/throttle.decorator";
 
-@Controller('auth')
+@Controller("auth")
 @Public()
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
   /**
    * GET /auth/nonce?address=G... — Get signing nonce for SIWS.
+   *
+   * Rate limit: 30 req / 60 s per IP  (nonce tier).
+   * Stricter than the default tier because this endpoint is stateful
+   * (each call stores a nonce in memory/DB) and could be used to
+   * exhaust nonce storage if left unlimited.
    */
-  @Get('nonce')
-  async getNonce(@Query('address') address?: string) {
+  @Throttle({ nonce: { limit: 30, ttl: 60000 } })
+  @Get("nonce")
+  async getNonce(@Query("address") address?: string) {
     if (!address) {
-      throw new BadRequestException('address is required');
+      throw new BadRequestException("address is required");
     }
     return this.authService.getNonce(address);
   }
@@ -28,27 +35,28 @@ export class AuthController {
   /**
    * POST /auth/verify — Verify wallet signature, issue JWT.
    * Body: { address, signature, nonce [, issuedAt] }
+   *
+   * Rate limit: 10 req / 60 s per IP  (auth tier).
+   * Very strict — prevents brute-force signature/nonce guessing.
    */
-  @Post('verify')
+  @Throttle({ auth: { limit: 10, ttl: 60000 } })
+  @Post("verify")
   async verify(
-    @Body('address') address?: string,
-    @Body('signature') signature?: string,
-    @Body('nonce') nonce?: string,
-    @Body('issuedAt') issuedAt?: string,
+    @Body("address") address?: string,
+    @Body("signature") signature?: string,
+    @Body("nonce") nonce?: string,
+    @Body("issuedAt") issuedAt?: string,
   ) {
     if (!address || !signature || !nonce) {
-      throw new BadRequestException('address, signature, and nonce are required');
+      throw new BadRequestException(
+        "address, signature, and nonce are required",
+      );
     }
     try {
-      return await this.authService.verify(
-        address,
-        signature,
-        nonce,
-        issuedAt,
-      );
+      return await this.authService.verify(address, signature, nonce, issuedAt);
     } catch (err) {
       throw new BadRequestException(
-        err instanceof Error ? err.message : 'Verification failed',
+        err instanceof Error ? err.message : "Verification failed",
       );
     }
   }

--- a/backend/src/auth/decorators/current-user.decorator.ts
+++ b/backend/src/auth/decorators/current-user.decorator.ts
@@ -1,11 +1,14 @@
-import { createParamDecorator, ExecutionContext } from '@nestjs/common';
-import { JwtPayload } from '../jwt.strategy';
+import { createParamDecorator, ExecutionContext } from "@nestjs/common";
+import { JwtPayload } from "../jwt.strategy";
 
 /** Extract the authenticated user payload from the request. */
 export const CurrentUser = createParamDecorator(
-  (data: keyof JwtPayload | undefined, ctx: ExecutionContext): JwtPayload | string => {
+  (
+    data: keyof JwtPayload | undefined,
+    ctx: ExecutionContext,
+  ): JwtPayload | string => {
     const request = ctx.switchToHttp().getRequest();
     const user = request.user as JwtPayload;
-    return data ? user?.[data] : user;
+    return data ? (user?.[data] as string) : user;
   },
 );

--- a/backend/src/middleware/throttle.decorator.ts
+++ b/backend/src/middleware/throttle.decorator.ts
@@ -1,0 +1,11 @@
+/**
+ * Re-exports @nestjs/throttler decorators so controllers don't need
+ * to import from the library directly.
+ *
+ * Usage examples:
+ *
+ *   @Throttle({ auth: { limit: 10, ttl: 60000 } })      // override a named tier
+ *   @SkipThrottle()                                       // skip for internal/health routes
+ *   @SkipThrottle({ default: true })                      // skip only the default tier
+ */
+export { Throttle, SkipThrottle } from "@nestjs/throttler";

--- a/backend/src/middleware/throttler.guard.ts
+++ b/backend/src/middleware/throttler.guard.ts
@@ -1,0 +1,65 @@
+import { Injectable, ExecutionContext } from "@nestjs/common";
+import { ThrottlerGuard, ThrottlerRequest } from "@nestjs/throttler";
+import { FastifyRequest } from "fastify";
+
+/**
+ * Custom ThrottlerGuard for the Fastify adapter.
+ *
+ * Overrides `getTracker()` to extract the real client IP from:
+ *   1. `x-forwarded-for` header (set by Railway / Fly.io / reverse proxies)
+ *   2. The raw Fastify request IP as fallback
+ *
+ * This prevents a single IP from bypassing limits by sitting behind a proxy.
+ */
+@Injectable()
+export class TikkaThrottlerGuard extends ThrottlerGuard {
+  protected async getTracker(req: ThrottlerRequest): Promise<string> {
+    const fastifyReq = req as unknown as FastifyRequest;
+
+    const forwarded = fastifyReq.headers["x-forwarded-for"];
+    if (forwarded) {
+      // x-forwarded-for can be a comma-separated list: "client, proxy1, proxy2"
+      const firstIp = Array.isArray(forwarded)
+        ? forwarded[0]
+        : forwarded.split(",")[0];
+      return firstIp.trim();
+    }
+
+    return fastifyReq.ip ?? "unknown";
+  }
+
+  /**
+   * Return a helpful 429 response body that includes Retry-After seconds.
+   * NestJS Throttler sets the Retry-After header automatically; we just
+   * override the error message for clarity.
+   */
+  protected throwThrottlingException(
+    _context: ExecutionContext,
+    _throttlerLimitDetail: {
+      ttl: number;
+      limit: number;
+      key: string;
+      tracker: string;
+      totalHits: number;
+      timeToExpire: number;
+      isBlocked: boolean;
+      timeToBlockExpire: number;
+    },
+  ): Promise<void> {
+    throw Object.assign(
+      new (require("@nestjs/common").HttpException)(
+        {
+          statusCode: 429,
+          error: "Too Many Requests",
+          message: "Rate limit exceeded. Please slow down and try again.",
+          retryAfter: Math.ceil(_throttlerLimitDetail.timeToExpire / 1000),
+        },
+        429,
+        {
+          cause: undefined,
+          description: "Too Many Requests",
+        },
+      ),
+    );
+  }
+}


### PR DESCRIPTION
…gurable tiers, and updated documentation.

## feat(backend): add tiered rate limiting middleware — closes #15
### Summary
Protects all public REST endpoints and auth routes from abuse using `@nestjs/throttler` with three named, independently configurable rate limit tiers.
---
### Changes
#### [src/middleware/throttler.guard.ts](cci:7://file:///Users/macbookpro/Desktop/tikka/backend/src/middleware/throttler.guard.ts:0:0-0:0) _(new)_
Custom [TikkaThrottlerGuard](cci:2://file:///Users/macbookpro/Desktop/tikka/backend/src/middleware/throttler.guard.ts:13:0-64:1) extending [ThrottlerGuard](cci:2://file:///Users/macbookpro/Desktop/tikka/backend/src/middleware/throttler.guard.ts:13:0-64:1):
- Extracts real client IP from `x-forwarded-for` header (proxy-aware) with fallback to raw Fastify request IP
- Returns a structured **HTTP 429** body including `retryAfter` (seconds until limit resets)
#### [src/middleware/throttle.decorator.ts](cci:7://file:///Users/macbookpro/Desktop/tikka/backend/src/middleware/throttle.decorator.ts:0:0-0:0) _(new)_
Barrel re-export of `@Throttle` and `@SkipThrottle` from `@nestjs/throttler` for cleaner controller imports.
#### [src/app.module.ts](cci:7://file:///Users/macbookpro/Desktop/tikka/backend/src/app.module.ts:0:0-0:0)
- Registered `ThrottlerModule.forRootAsync` with three named throttlers, all limits driven by `ConfigService`
- Added [TikkaThrottlerGuard](cci:2://file:///Users/macbookpro/Desktop/tikka/backend/src/middleware/throttler.guard.ts:13:0-64:1) as a second global `APP_GUARD` (after `JwtAuthGuard`)
#### [src/auth/auth.controller.ts](cci:7://file:///Users/macbookpro/Desktop/tikka/backend/src/auth/auth.controller.ts:0:0-0:0)
Applied per-route throttle overrides:
- `GET /auth/nonce` → `nonce` tier (30 req / 60 s)
- `POST /auth/verify` → `auth` tier (10 req / 60 s)
#### [.env.example](cci:7://file:///Users/macbookpro/Desktop/tikka/backend/.env.example:0:0-0:0)
Added all `THROTTLE_*` env vars with inline documentation.
#### [package.json](cci:7://file:///Users/macbookpro/Desktop/tikka/indexer/package.json:0:0-0:0)
Added `@nestjs/throttler ^6.4.0`.
#### [README.md](cci:7://file:///Users/macbookpro/Desktop/tikka/backend/README.md:0:0-0:0)
Added **Rate Limiting** section — tier table, 429 response format, env var reference, smoke-test command.
---
### Rate Limit Tiers
| Tier | Endpoints | Default limit |
|---|---|---|
| `default` | All public API (`/raffles`, `/users`, `/leaderboard`, `/stats`) | **100 req / 60 s** per IP |
| `nonce` | `GET /auth/nonce` | **30 req / 60 s** per IP |
| `auth` | `POST /auth/verify` | **10 req / 60 s** per IP |
All limits are configurable via env vars without code changes.
### 429 Response
```json
{
  "statusCode": 429,
  "error": "Too Many Requests",
  "message": "Rate limit exceeded. Please slow down and try again.",
  "retryAfter": 42
}