### PR TITLE
feat: enhance wallet integration with network switching and action gating

### DIFF
--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -5,9 +5,12 @@ import logo from "../assets/svg/logo.svg";
 import tikka from "../assets/svg/Tikka.svg";
 import WalletButton from "./WalletButton";
 import SignInButton from "./SignInButton";
+import { useWalletContext } from "../providers/WalletProvider";
+import { STELLAR_CONFIG } from "../config/stellar";
 
 const Navbar = ({ onStart }: { onStart?: () => void }) => {
     const [open, setOpen] = React.useState(false);
+    const { isConnected, isWrongNetwork, switchNetwork } = useWalletContext();
 
     const navItems = [
         { label: "Discover Raffles", href: "/home" },
@@ -15,6 +18,8 @@ const Navbar = ({ onStart }: { onStart?: () => void }) => {
         { label: "My Raffles", href: "/my-raffles" },
         { label: "Leaderboard", href: "/leaderboard" },
     ];
+
+    const targetNetwork = STELLAR_CONFIG.network.charAt(0).toUpperCase() + STELLAR_CONFIG.network.slice(1);
 
     return (
         <header className="w-full fixed-top">
@@ -47,6 +52,25 @@ const Navbar = ({ onStart }: { onStart?: () => void }) => {
                         )
                     )}
 
+                    {isConnected && (
+                        <div className="flex items-center gap-2 mr-2">
+                            {isWrongNetwork ? (
+                                <button
+                                    onClick={() => switchNetwork()}
+                                    className="flex items-center gap-2 rounded-full border border-red-500/50 bg-red-500/10 px-3 py-1.5 text-xs font-medium text-red-400 hover:bg-red-500/20 transition"
+                                >
+                                    <span className="inline-flex h-1.5 w-1.5 rounded-full bg-red-500 animate-pulse" />
+                                    Switch to {targetNetwork}
+                                </button>
+                            ) : (
+                                <div className="flex items-center gap-2 rounded-full border border-[#52E5A4]/30 bg-[#52E5A4]/5 px-3 py-1.5 text-xs font-medium text-[#52E5A4]">
+                                    <span className="inline-flex h-1.5 w-1.5 rounded-full bg-[#52E5A4]" />
+                                    {targetNetwork}
+                                </div>
+                            )}
+                        </div>
+                    )}
+
                     <WalletButton />
                     <SignInButton />
                 </div>
@@ -54,7 +78,7 @@ const Navbar = ({ onStart }: { onStart?: () => void }) => {
                 {/* Mobile: hamburger */}
                 <button
                     type="button"
-                    onClick={() => setOpen((s) => !s)}
+                    onClick={() => setOpen((s: boolean) => !s)}
                     className="lg:hidden inline-flex items-center justify-center rounded-lg p-2 hover:bg-white/5 focus:outline-none focus:ring-2 focus:ring-white/40"
                     aria-controls="mobile-menu"
                     aria-expanded={open}
@@ -98,9 +122,8 @@ const Navbar = ({ onStart }: { onStart?: () => void }) => {
             {/* Mobile panel */}
             <div
                 id="mobile-menu"
-                className={`lg:hidden overflow-hidden transition-[max-height,opacity] duration-300 ${
-                    open ? "max-h-96 opacity-100" : "max-h-0 opacity-0"
-                }`}
+                className={`lg:hidden overflow-hidden transition-[max-height,opacity] duration-300 ${open ? "max-h-96 opacity-100" : "max-h-0 opacity-0"
+                    }`}
             >
                 <div className="mx-auto flex max-w-7xl flex-col gap-1 px-6 pb-4 md:px-8">
                     {navItems.map((item) =>
@@ -125,12 +148,12 @@ const Navbar = ({ onStart }: { onStart?: () => void }) => {
                         )
                     )}
 
-nulla
+                    <a
                         onClick={() => {
                             setOpen(false);
                             if (onStart) onStart();
                         }}
-                        className="mt-2 rounded-xl px-6 py-3 text-center text-sm font-medium text-white hover:brightness-110 bg-[#FE3796]"
+                        className="mt-2 rounded-xl px-6 py-3 text-center text-sm font-medium text-white hover:brightness-110 bg-[#FE3796] cursor-pointer"
                     >
                         Get Started
                     </a>

--- a/client/src/hooks/useWallet.ts
+++ b/client/src/hooks/useWallet.ts
@@ -9,10 +9,13 @@ import {
     connectWallet,
     disconnectWallet,
     getAccountAddress,
+    getNetwork,
     isWalletConnected,
     isWalletInstalled,
+    setNetwork,
     signTransaction,
 } from "../services/walletService";
+import { STELLAR_CONFIG } from "../config/stellar";
 
 export interface WalletState {
     address: string | null;
@@ -21,6 +24,8 @@ export interface WalletState {
     isDisconnecting: boolean;
     error: string | null;
     isWalletAvailable: boolean;
+    network: string | null;
+    isWrongNetwork: boolean;
 }
 
 export interface UseWalletReturn extends WalletState {
@@ -28,6 +33,7 @@ export interface UseWalletReturn extends WalletState {
     disconnect: () => Promise<void>;
     refresh: () => Promise<void>;
     signTx: (transaction: any) => Promise<any>;
+    switchNetwork: () => Promise<void>;
 }
 
 /**
@@ -41,6 +47,8 @@ export function useWallet(): UseWalletReturn {
         isDisconnecting: false,
         error: null,
         isWalletAvailable: false,
+        network: null,
+        isWrongNetwork: false,
     });
 
     /**
@@ -51,16 +59,22 @@ export function useWallet(): UseWalletReturn {
             const available = await isWalletInstalled();
             const connected = await isWalletConnected();
             const address = connected ? await getAccountAddress() : null;
+            const network = connected ? await getNetwork() : null;
 
-            setState((prev) => ({
+            const isWrongNetwork = connected && network !== null &&
+                network !== STELLAR_CONFIG.networkPassphrase;
+
+            setState((prev: WalletState) => ({
                 ...prev,
                 isWalletAvailable: available,
                 isConnected: connected,
                 address,
+                network,
+                isWrongNetwork,
                 error: null,
             }));
         } catch (error) {
-            setState((prev) => ({
+            setState((prev: WalletState) => ({
                 ...prev,
                 error: error instanceof Error ? error.message : "Unknown error",
             }));
@@ -71,7 +85,7 @@ export function useWallet(): UseWalletReturn {
      * Connect to wallet
      */
     const connect = useCallback(async () => {
-        setState((prev) => ({
+        setState((prev: WalletState) => ({
             ...prev,
             isConnecting: true,
             error: null,
@@ -79,36 +93,31 @@ export function useWallet(): UseWalletReturn {
 
         try {
             const result = await connectWallet();
-            
+
             if (result.success && result.address) {
-                setState((prev) => ({
-                    ...prev,
-                    address: result.address || null,
-                    isConnected: true,
-                    isConnecting: false,
-                    error: null,
-                }));
+                // After connection, refresh to get network status
+                await refresh();
             } else {
-                setState((prev) => ({
+                setState((prev: WalletState) => ({
                     ...prev,
                     isConnecting: false,
                     error: result.error || "Failed to connect wallet",
                 }));
             }
         } catch (error) {
-            setState((prev) => ({
+            setState((prev: WalletState) => ({
                 ...prev,
                 isConnecting: false,
                 error: error instanceof Error ? error.message : "Failed to connect wallet",
             }));
         }
-    }, []);
+    }, [refresh]);
 
     /**
      * Disconnect wallet
      */
     const disconnect = useCallback(async () => {
-        setState((prev) => ({
+        setState((prev: WalletState) => ({
             ...prev,
             isDisconnecting: true,
             error: null,
@@ -116,22 +125,39 @@ export function useWallet(): UseWalletReturn {
 
         try {
             await disconnectWallet();
-            setState({
+            setState((prev: WalletState) => ({
                 address: null,
                 isConnected: false,
                 isConnecting: false,
                 isDisconnecting: false,
                 error: null,
-                isWalletAvailable: state.isWalletAvailable,
-            });
+                isWalletAvailable: prev.isWalletAvailable,
+                network: null,
+                isWrongNetwork: false,
+            }));
         } catch (error) {
-            setState((prev) => ({
+            setState((prev: WalletState) => ({
                 ...prev,
                 isDisconnecting: false,
                 error: error instanceof Error ? error.message : "Failed to disconnect wallet",
             }));
         }
     }, [state.isWalletAvailable]);
+
+    /**
+     * Switch network to the one required by the app
+     */
+    const switchNetwork = useCallback(async () => {
+        try {
+            await setNetwork(STELLAR_CONFIG.networkPassphrase);
+            await refresh();
+        } catch (error) {
+            setState((prev: WalletState) => ({
+                ...prev,
+                error: error instanceof Error ? error.message : "Failed to switch network",
+            }));
+        }
+    }, [refresh]);
 
     /**
      * Sign a transaction
@@ -141,20 +167,30 @@ export function useWallet(): UseWalletReturn {
             throw new Error("Wallet not connected");
         }
 
+        if (state.isWrongNetwork) {
+            throw new Error(`Wrong network. Please switch to ${STELLAR_CONFIG.network}`);
+        }
+
         try {
             return await signTransaction(transaction);
         } catch (error) {
-            setState((prev) => ({
+            setState((prev: WalletState) => ({
                 ...prev,
                 error: error instanceof Error ? error.message : "Failed to sign transaction",
             }));
             throw error;
         }
-    }, [state.isConnected]);
+    }, [state.isConnected, state.isWrongNetwork]);
 
     // Check wallet status on mount and when needed
     useEffect(() => {
         refresh();
+
+        // Setup a listener for account/network changes if the wallet extensions support it
+        // Most Stellar wallets don't emit standard events easily solvable here without a poller,
+        // but some kits handle it internally. For now we rely on explicit refreshes and mount check.
+        const interval = setInterval(refresh, 10000); // Poll every 10s as a fallback
+        return () => clearInterval(interval);
     }, [refresh]);
 
     return {
@@ -163,5 +199,6 @@ export function useWallet(): UseWalletReturn {
         disconnect,
         refresh,
         signTx,
+        switchNetwork,
     };
 }

--- a/client/tsconfig.app.json
+++ b/client/tsconfig.app.json
@@ -3,10 +3,13 @@
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
     "target": "ES2022",
     "useDefineForClassFields": true,
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "lib": [
+      "ES2022",
+      "DOM",
+      "DOM.Iterable"
+    ],
     "module": "ESNext",
     "skipLibCheck": true,
-
     /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
@@ -14,14 +17,18 @@
     "moduleDetection": "force",
     "noEmit": true,
     "jsx": "react-jsx",
-
     /* Linting */
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+    "types": [
+      "vite/client"
+    ]
   },
-  "include": ["src"]
+  "include": [
+    "src"
+  ]
 }


### PR DESCRIPTION
This PR improves the user experience for wallet connection and network management. It ensures users are on the correct Stellar network before performing actions and provides a more robust state management system for wallet interactions.

Key Changes
🔧 Core Logic & Service
walletService.ts
: Added 
getNetwork()
 and 
setNetwork()
 methods to interface with the stellar-wallets-kit. Implemented defensive environment checks for import.meta.env.
useWallet.ts
:
Added network and isWrongNetwork to the global wallet state.
Implemented switchNetwork() to allow users to trigger a network change UI from the wallet.
Added a polling fallback (10s interval) to detect network changes in wallets that do not consistently emit events.
🍱 UI Components
Navbar.tsx
:
Added a persistent network status badge.
Added a "Switch to [Network]" action button that appears only when a mismatch is detected.
CreateRaffleButton.tsx
 & 
EnterRaffleButton.tsx
:
Implemented Action Gating: These buttons now intelligently change their label based on state (Connect Wallet → Switch Network → Action).
Refactored components to use explicit prop typing for better robustness.

How to Test
Connect a Stellar wallet (e.g., Freighter).
Change the network in your wallet extension to "Public" (Mainnet).
Observe the 
Navbar
 badge turning red and offering a "Switch to Testnet" button.
Attempt to click "Publish Raffle" or "Enter Raffle" while on the wrong network—the button should prompt you to switch networks first.


closes #23