### PR TITLE
feat(oracle): implement deterministic PrngService for low-stakes raffles

### DIFF
--- a/oracle/src/randomness/prng.service.ts
+++ b/oracle/src/randomness/prng.service.ts
@@ -1,27 +1,90 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { RandomnessResult } from '../queue/queue.types';
 import * as crypto from 'crypto';
 
+/**
+ * PrngService — deterministic pseudo-random seed generator for low-stakes raffles.
+ *
+ * Design (from ARCHITECTURE.md §5 Randomness Design):
+ *   Low-stakes path (prize < 500 XLM) uses a secure hash-based PRNG instead
+ *   of a full VRF to save cost and latency.  The output must be:
+ *     • Reproducible  — same inputs always yield the same seed + proof.
+ *     • Unbiased      — SHA-256 output is uniformly distributed.
+ *     • Contract-compatible — seed is BytesN<32>, proof is BytesN<64>.
+ *
+ * Derivation:
+ *   seed  = SHA-256( requestId_bytes [|| raffleId_u32_big_endian] )   → 32 bytes
+ *   proof = SHA-256("PRNG:v1:1:" || requestId_bytes)
+ *        || SHA-256("PRNG:v1:2:" || requestId_bytes)                  → 64 bytes
+ *
+ * Both are returned as lowercase hex strings (64 and 128 chars respectively)
+ * to match the existing RandomnessResult interface consumed by RandomnessWorker
+ * and TxSubmitterService.
+ */
 @Injectable()
 export class PrngService {
+  private readonly logger = new Logger(PrngService.name);
+
+  /** Domain prefix bytes reused for proof halves — avoids allocating on every call */
+  private static readonly PROOF_PREFIX_1 = Buffer.from('PRNG:v1:1:', 'ascii');
+  private static readonly PROOF_PREFIX_2 = Buffer.from('PRNG:v1:2:', 'ascii');
+
   /**
-   * Computes pseudo-random seed for low-stakes raffles
-   * @param requestId Unique request identifier
-   * @returns Seed and empty proof (PRNG doesn't require cryptographic proof)
+   * Computes a deterministic seed and proof for a low-stakes randomness request.
+   *
+   * @param requestId  Unique request identifier emitted by the contract
+   *                   (`RandomnessRequested.request_id`).
+   * @param raffleId   Optional raffle ID — when provided it is mixed into the
+   *                   seed input so two different raffles with the same requestId
+   *                   (however unlikely) still produce distinct seeds.
+   * @returns          { seed, proof } as lowercase hex strings.
+   *                   seed  → 64 hex chars (32 bytes) for contract BytesN<32>
+   *                   proof → 128 hex chars (64 bytes) for contract BytesN<64>
    */
-  async compute(requestId: string): Promise<RandomnessResult> {
-    // Use cryptographically secure PRNG for low-stakes raffles
-    // Combines request ID with ledger timestamp for unpredictability
-    const seed = crypto
+  compute(requestId: string, raffleId?: number): RandomnessResult {
+    const reqBuf = Buffer.from(requestId, 'utf8');
+
+    // ── Seed ───────────────────────────────────────────────────────────────
+    // SHA-256( requestId_bytes [|| raffleId_u32_BE] )
+    const seedHasher = crypto.createHash('sha256').update(reqBuf);
+    if (raffleId !== undefined) {
+      seedHasher.update(this.encodeUint32BE(raffleId));
+    }
+    const seedBuf = seedHasher.digest(); // 32 bytes
+
+    // ── Proof (deterministic 64-byte value) ────────────────────────────────
+    // Two independent SHA-256 invocations with distinct domain prefixes give
+    // 64 bytes without requiring a multi-round hash.  The contract verifies
+    // this proof exists and has the right length; on the PRNG path it does
+    // not run a VRF check (the fixed prefix "PRNG:v1:…" makes path explicit).
+    const proofHalf1 = crypto
       .createHash('sha256')
-      .update(requestId)
-      .update(Date.now().toString())
-      .update(crypto.randomBytes(32))
-      .digest('hex');
+      .update(PrngService.PROOF_PREFIX_1)
+      .update(reqBuf)
+      .digest(); // 32 bytes
 
-    // PRNG doesn't require proof (low-stakes only)
-    const proof = '0'.repeat(128);
+    const proofHalf2 = crypto
+      .createHash('sha256')
+      .update(PrngService.PROOF_PREFIX_2)
+      .update(reqBuf)
+      .digest(); // 32 bytes
 
-    return { seed, proof };
+    const proofBuf = Buffer.concat([proofHalf1, proofHalf2]); // 64 bytes
+
+    this.logger.debug(`PRNG seed computed for requestId=${requestId} raffleId=${raffleId}`);
+
+    return {
+      seed: seedBuf.toString('hex'),   // 64 hex chars  → BytesN<32>
+      proof: proofBuf.toString('hex'), // 128 hex chars → BytesN<64>
+    };
+  }
+
+  // ── Helpers ──────────────────────────────────────────────────────────────
+
+  /** Encodes an unsigned 32-bit integer as 4 bytes big-endian. */
+  private encodeUint32BE(n: number): Buffer {
+    const buf = Buffer.allocUnsafe(4);
+    buf.writeUInt32BE(n >>> 0, 0); // >>> 0 coerces to uint32
+    return buf;
   }
 }

--- a/oracle/test/prng.service.spec.ts
+++ b/oracle/test/prng.service.spec.ts
@@ -1,0 +1,95 @@
+import { PrngService } from '../src/randomness/prng.service';
+
+describe('PrngService', () => {
+  let service: PrngService;
+
+  beforeEach(() => {
+    service = new PrngService();
+  });
+
+  // ── Output shape ──────────────────────────────────────────────────────────
+
+  describe('output format', () => {
+    it('should return a 64-char hex seed (BytesN<32>)', () => {
+      const { seed } = service.compute('req-abc');
+      expect(seed).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it('should return a 128-char hex proof (BytesN<64>)', () => {
+      const { proof } = service.compute('req-abc');
+      expect(proof).toMatch(/^[0-9a-f]{128}$/);
+    });
+  });
+
+  // ── Determinism ───────────────────────────────────────────────────────────
+
+  describe('determinism', () => {
+    it('should produce identical seed for the same requestId', () => {
+      const r1 = service.compute('req-deterministic');
+      const r2 = service.compute('req-deterministic');
+      expect(r1.seed).toBe(r2.seed);
+    });
+
+    it('should produce identical proof for the same requestId', () => {
+      const r1 = service.compute('req-deterministic');
+      const r2 = service.compute('req-deterministic');
+      expect(r1.proof).toBe(r2.proof);
+    });
+
+    it('should produce identical results with the same requestId + raffleId', () => {
+      const r1 = service.compute('req-with-raffle', 42);
+      const r2 = service.compute('req-with-raffle', 42);
+      expect(r1.seed).toBe(r2.seed);
+      expect(r1.proof).toBe(r2.proof);
+    });
+  });
+
+  // ── Uniqueness ────────────────────────────────────────────────────────────
+
+  describe('uniqueness', () => {
+    it('should produce different seeds for different requestIds', () => {
+      const { seed: s1 } = service.compute('req-001');
+      const { seed: s2 } = service.compute('req-002');
+      expect(s1).not.toBe(s2);
+    });
+
+    it('should produce different proofs for different requestIds', () => {
+      const { proof: p1 } = service.compute('req-001');
+      const { proof: p2 } = service.compute('req-002');
+      expect(p1).not.toBe(p2);
+    });
+
+    it('should produce different seeds when raffleId is included vs omitted', () => {
+      const { seed: withoutRaffle } = service.compute('req-same');
+      const { seed: withRaffle } = service.compute('req-same', 0);
+      expect(withoutRaffle).not.toBe(withRaffle);
+    });
+
+    it('should produce different seeds for the same requestId with different raffleIds', () => {
+      const { seed: s1 } = service.compute('req-same', 1);
+      const { seed: s2 } = service.compute('req-same', 2);
+      expect(s1).not.toBe(s2);
+    });
+  });
+
+  // ── Proof independence ────────────────────────────────────────────────────
+
+  describe('proof independence from raffleId', () => {
+    it('should produce the same proof regardless of raffleId (proof derives only from requestId)', () => {
+      const { proof: p1 } = service.compute('req-proof-test');
+      const { proof: p2 } = service.compute('req-proof-test', 99);
+      // proof mixes only requestId — raffleId is seed-only
+      expect(p1).toBe(p2);
+    });
+  });
+
+  // ── No randomness across calls ────────────────────────────────────────────
+
+  describe('no ambient randomness', () => {
+    it('should not be affected by time — results match across multiple fast calls', () => {
+      const results = Array.from({ length: 10 }, () => service.compute('req-time-invariant'));
+      const seeds = results.map((r) => r.seed);
+      expect(new Set(seeds).size).toBe(1); // all identical
+    });
+  });
+});


### PR DESCRIPTION
PR closes #40 
Replace the non-deterministic stub with a SHA-256-based PRNG that produces a reproducible 32-byte seed and 64-byte proof from request_id (and an optional raffle_id), satisfying the contract's BytesN<32>/ BytesN<64> interface on the low-stakes path (prize < 500 XLM).

- seed  = SHA-256(requestId [|| raffleId_u32_BE])
- proof = SHA-256("PRNG:v1:1:" || requestId) || SHA-256("PRNG:v1:2:" || requestId)
- Removes Date.now() / randomBytes() — output is now fully deterministic
- Adds optional raffleId param for per-raffle seed isolation
- Adds prng.service.spec.ts covering determinism, uniqueness, shape, and time-invariance