### PR TITLE
feat(backend): add health check endpoint and env configuration docs

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -116,6 +116,93 @@ done
 
 ---
 
+## Health Check
+
+### GET /health
+
+Returns the live status of all backend dependencies. No authentication required.
+
+```bash
+curl http://localhost:3001/health
+```
+
+**Response — all healthy (HTTP 200):**
+
+```json
+{
+  "status": "ok",
+  "indexer": "ok",
+  "supabase": "ok",
+  "timestamp": "2026-04-23T11:00:00.000Z"
+}
+```
+
+**Response — dependency down (HTTP 503):**
+
+```json
+{
+  "status": "degraded",
+  "indexer": "error",
+  "supabase": "ok",
+  "timestamp": "2026-04-23T11:00:00.000Z"
+}
+```
+
+| Field       | Values              | Description                                      |
+| ----------- | ------------------- | ------------------------------------------------ |
+| `status`    | `ok` / `degraded`   | Overall health — `degraded` if any check fails   |
+| `indexer`   | `ok` / `error`      | Reachability of tikka-indexer `/health`          |
+| `supabase`  | `ok` / `error`      | Reachability of Supabase REST endpoint           |
+| `timestamp` | ISO 8601 string     | Time the check was performed                     |
+
+The endpoint returns **HTTP 503** when `status` is `degraded`, so orchestrators (Kubernetes, Railway, Fly.io) can detect unhealthy instances automatically.
+
+---
+
+## Environment Variables
+
+Copy `.env.example` to `.env` and fill in the required values before starting the server.
+
+```bash
+cp .env.example .env
+```
+
+The app validates all variables at startup using Zod. Missing or invalid required vars cause an immediate startup failure with a clear error message listing every invalid field.
+
+### Required
+
+These must be set or the app will refuse to start:
+
+| Variable                   | Description                                                  |
+| -------------------------- | ------------------------------------------------------------ |
+| `SUPABASE_URL`             | Full URL of your Supabase project (e.g. `https://xyz.supabase.co`) |
+| `SUPABASE_SERVICE_ROLE_KEY`| Supabase service role key (not the anon key)                 |
+| `JWT_SECRET`               | Secret for signing JWTs — **minimum 32 characters**          |
+| `VITE_FRONTEND_URL`        | Frontend origin allowed by CORS (e.g. `https://app.tikka.io`) |
+| `ADMIN_TOKEN`              | Bearer token for `/admin/*` endpoints                        |
+
+### Optional (with defaults)
+
+| Variable                   | Default                    | Description                                      |
+| -------------------------- | -------------------------- | ------------------------------------------------ |
+| `PORT`                     | `3001`                     | HTTP port the server listens on                  |
+| `INDEXER_URL`              | `http://localhost:3002`    | Base URL of the tikka-indexer internal API       |
+| `INDEXER_TIMEOUT_MS`       | `5000`                     | HTTP timeout for indexer requests (ms)           |
+| `JWT_EXPIRES_IN`           | `7d`                       | JWT expiry duration (e.g. `1h`, `7d`)            |
+| `SIWS_DOMAIN`              | `tikka.io`                 | Domain shown in the SIWS sign-in message         |
+| `ADMIN_IP_ALLOWLIST`       | `""` (allow all)           | Comma-separated CIDRs/IPs for admin access       |
+| `FCM_ENABLED`              | `false`                    | Enable Firebase Cloud Messaging push notifications |
+| `FCM_SERVICE_ACCOUNT_JSON` | —                          | FCM service account JSON string (for CI/secrets) |
+| `FCM_SERVICE_ACCOUNT_PATH` | —                          | Path to FCM service account JSON file            |
+| `THROTTLE_DEFAULT_LIMIT`   | `100`                      | Max requests per window for public endpoints     |
+| `THROTTLE_DEFAULT_TTL`     | `60`                       | Rate-limit window size in seconds                |
+| `THROTTLE_AUTH_LIMIT`      | `10`                       | Max requests per window for `POST /auth/verify`  |
+| `THROTTLE_AUTH_TTL`        | `60`                       | Rate-limit window for auth tier (seconds)        |
+| `THROTTLE_NONCE_LIMIT`     | `30`                       | Max requests per window for `GET /auth/nonce`    |
+| `THROTTLE_NONCE_TTL`       | `60`                       | Rate-limit window for nonce tier (seconds)       |
+
+---
+
 ## Structure
 
 - `src/api/rest/` - raffles, users, leaderboard, stats, search, notifications

--- a/backend/package.json
+++ b/backend/package.json
@@ -13,6 +13,7 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
+    "@fastify/helmet": "^13.0.2",
     "@fastify/multipart": "^9.0.0",
     "@nestjs/common": "^10.4.0",
     "@nestjs/config": "^4.0.3",
@@ -20,6 +21,7 @@
     "@nestjs/jwt": "^10.2.0",
     "@nestjs/passport": "^10.0.3",
     "@nestjs/platform-fastify": "^11.1.17",
+    "@nestjs/swagger": "^11.4.1",
     "@nestjs/throttler": "^6.4.0",
     "@nestjs/typeorm": "^11.0.0",
     "@stellar/stellar-sdk": "^14.4.0",
@@ -27,6 +29,7 @@
     "class-transformer": "^0.5.1",
     "class-validator": "^0.15.1",
     "fastify": "^5.0.0",
+    "firebase-admin": "^13.8.0",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
     "pg": "^8.18.0",

--- a/backend/src/api/rest/raffles/pipes/zod-validation.pipe.ts
+++ b/backend/src/api/rest/raffles/pipes/zod-validation.pipe.ts
@@ -3,7 +3,7 @@ import {
   ArgumentMetadata,
   BadRequestException,
 } from "@nestjs/common";
-import { ZodSchema, ZodError } from "zod";
+import { ZodSchema, ZodTypeDef, ZodError } from "zod";
 
 /**
  * Creates a validation pipe using a Zod schema.
@@ -27,9 +27,9 @@ import { ZodSchema, ZodError } from "zod";
  * @returns PipeTransform class that validates and transforms data
  * @throws BadRequestException when validation fails
  */
-export function createZodPipe<T>(schema: ZodSchema<T>) {
+export function createZodPipe<Output, Input = Output>(schema: ZodSchema<Output, ZodTypeDef, Input>) {
   return class implements PipeTransform {
-    transform(value: unknown, _metadata: ArgumentMetadata): T {
+    transform(value: unknown, _metadata: ArgumentMetadata): Output {
       const result = schema.safeParse(value);
       if (!result.success) {
         const msg = result.error.errors.map((e) => e.message).join("; ");

--- a/backend/src/api/rest/search/search.controller.spec.ts
+++ b/backend/src/api/rest/search/search.controller.spec.ts
@@ -2,34 +2,7 @@ import { SearchController } from './search.controller';
 import { SearchService } from '../../../services/search.service';
 
 describe('SearchController', () => {
-  let controller: SearchController;
-  let searchService: { search: jest.Mock };
-
-  beforeEach(() => {
-    searchService = {
-      search: jest.fn(),
-    };
-
-    controller = new SearchController(searchService as unknown as SearchService);
-  });
-
-  it('passes a trimmed category filter to the search service', async () => {
-    searchService.search.mockResolvedValue([]);
-
-    await controller.search('raffle', '  Art  ');
-
-    expect(searchService.search).toHaveBeenCalledWith('raffle', 'Art');
-  });
-
-  it('treats an empty category as no filter', async () => {
-    searchService.search.mockResolvedValue([]);
-
-    await controller.search('raffle', '   ');
-
-    expect(searchService.search).toHaveBeenCalledWith('raffle', undefined);
-
-describe('SearchController', () => {
-  it('forwards q, limit, and offset and returns the service total', async () => {
+  it('forwards q, limit, and offset and returns the service result', async () => {
     const searchService = {
       search: jest.fn().mockResolvedValue({
         raffles: [
@@ -45,7 +18,7 @@ describe('SearchController', () => {
       }),
     };
 
-    const controller = new SearchController(searchService as any);
+    const controller = new SearchController(searchService as unknown as SearchService);
 
     await expect(
       (controller as any).search({ q: 'rare', limit: 1, offset: 5 }),
@@ -63,5 +36,16 @@ describe('SearchController', () => {
     });
 
     expect(searchService.search).toHaveBeenCalledWith('rare', 1, 5);
+  });
+
+  it('returns empty result when query is too short', async () => {
+    const searchService = { search: jest.fn() };
+    const controller = new SearchController(searchService as unknown as SearchService);
+
+    await expect(
+      (controller as any).search({ q: 'a' }),
+    ).resolves.toEqual({ raffles: [], total: 0 });
+
+    expect(searchService.search).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -25,8 +25,8 @@ async function bootstrap() {
     .addBearerAuth()
     .build();
 
-  const document = SwaggerModule.createDocument(app, config);
-  SwaggerModule.setup("docs", app, document);
+  const document = SwaggerModule.createDocument(app as any, config);
+  SwaggerModule.setup("docs", app as any, document);
   await configureSecurity(app);
 
   // Using 'as any' bypasses the type mismatch error between Fastify versions

--- a/backend/src/services/metadata.service.spec.ts
+++ b/backend/src/services/metadata.service.spec.ts
@@ -1,14 +1,15 @@
 import { MetadataService } from './metadata.service';
-import { SUPABASE_CLIENT } from './supabase.provider';
 
 describe('MetadataService', () => {
   let service: MetadataService;
   let queryBuilder: {
     select: jest.Mock;
     or: jest.Mock;
-    ilike: jest.Mock;
-    limit: jest.Mock;
+    range: jest.Mock;
+    eq: jest.Mock;
+    maybeSingle: jest.Mock;
     upsert: jest.Mock;
+    in: jest.Mock;
   };
   let client: { from: jest.Mock };
 
@@ -16,9 +17,11 @@ describe('MetadataService', () => {
     queryBuilder = {
       select: jest.fn().mockReturnThis(),
       or: jest.fn().mockReturnThis(),
-      ilike: jest.fn().mockReturnThis(),
-      limit: jest.fn(),
+      range: jest.fn().mockResolvedValue({ data: [], error: null, count: 0 }),
+      eq: jest.fn().mockReturnThis(),
+      maybeSingle: jest.fn().mockResolvedValue({ data: null, error: null }),
       upsert: jest.fn(),
+      in: jest.fn().mockReturnThis(),
     };
 
     client = {
@@ -28,12 +31,12 @@ describe('MetadataService', () => {
     service = new MetadataService(client as any);
   });
 
-  it('applies category filtering case-insensitively', async () => {
-    queryBuilder.limit.mockResolvedValue({ data: [], error: null });
+  it('searches metadata with ilike pattern', async () => {
+    await service.searchMetadata('raffle');
 
-    await service.searchMetadata('raffle', 'Art');
-
-    expect(queryBuilder.ilike).toHaveBeenCalledWith('category', 'Art');
+    expect(queryBuilder.or).toHaveBeenCalledWith(
+      expect.stringContaining('%raffle%'),
+    );
   });
 
   it('trims category values before upserting metadata', async () => {

--- a/backend/src/services/push-notification.service.ts
+++ b/backend/src/services/push-notification.service.ts
@@ -155,22 +155,22 @@ export class PushNotificationService {
       data: this.mapData(payload.data),
     };
 
-    let response;
+    let response: admin.messaging.BatchResponse;
     try {
-      response = await admin.messaging().sendMulticast(message);
+      response = await admin.messaging().sendEachForMulticast(message);
     } catch (error) {
-      this.logger.error('FCM sendMulticast failed', error);
+      this.logger.error('FCM sendEachForMulticast failed', error);
       throw new InternalServerErrorException('Failed to send push notification');
     }
 
     const invalidTokens = response.responses
-      .map((r, idx) => ({ result: r, token: tokens[idx] }))
-      .filter((entry) => !entry.result.success)
-      .filter((entry) => {
-        const code = (entry.result.error as any)?.code;
+      .map((r: admin.messaging.SendResponse, idx: number) => ({ result: r, token: tokens[idx] }))
+      .filter((entry: { result: admin.messaging.SendResponse; token: string }) => !entry.result.success)
+      .filter((entry: { result: admin.messaging.SendResponse; token: string }) => {
+        const code = (entry.result.error as admin.FirebaseError | undefined)?.code;
         return code === 'messaging/registration-token-not-registered' || code === 'messaging/invalid-registration-token';
       })
-      .map((entry) => entry.token);
+      .map((entry: { result: admin.messaging.SendResponse; token: string }) => entry.token);
 
     if (invalidTokens.length > 0) {
       await this.client


### PR DESCRIPTION
Closes #115

## What was changed

- README.md: added dedicated 'Health Check' section documenting GET /health — response shape, HTTP status codes (200 ok / 503 degraded), field descriptions, and orchestrator integration note.

- README.md: added 'Environment Variables' section with a full table of required vars (SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, JWT_SECRET, VITE_FRONTEND_URL, ADMIN_TOKEN) and all optional vars with their defaults, types, and descriptions. Covers PORT, INDEXER_URL, INDEXER_TIMEOUT_MS, JWT_EXPIRES_IN, SIWS_DOMAIN, FCM_*, THROTTLE_*, and ADMIN_IP_ALLOWLIST.

- Installed missing peer dependencies: @nestjs/swagger, @fastify/helmet, firebase-admin (added to package.json).

- zod-validation.pipe.ts: widened createZodPipe generic from ZodSchema<T> to ZodSchema<Output, ZodTypeDef, Input> so transform schemas (e.g. BatchMetadataQuerySchema) are accepted without a type error. Added ZodTypeDef import.

- main.ts: cast app to 'any' for SwaggerModule.createDocument / SwaggerModule.setup calls to resolve the NestFastifyApplication vs INestApplication type mismatch introduced by @nestjs/swagger.

- push-notification.service.ts: replaced removed sendMulticast() with sendEachForMulticast() (firebase-admin v12+ API); added explicit types to map/filter callbacks to eliminate implicit-any TS errors.

- metadata.service.spec.ts: aligned test with actual searchMetadata(query, limit, offset) signature — second argument is a number (limit), not a category string.

- search.controller.spec.ts: removed stale tests that called controller.search() with the old two-arg (query, category) signature; fixed unclosed describe block causing a TS syntax error; kept the correct DTO-based test.

## Why it was needed

Issue #115 requires GET /health and centralized env config. Both were already implemented (HealthModule, env.schema.ts, env.config.ts, .env.example) but the README had no documentation for either feature. This PR adds the missing documentation and unblocks CI by fixing four pre-existing test/build failures that prevented the test suite from running cleanly on master.

## Assumptions

- The existing HealthService (indexer + Supabase reachability checks), HealthController (GET /health, 503 on degraded), HealthModule, and env.schema.ts Zod validation are the correct implementation — no structural changes were needed.
- Pre-existing build/test failures in main.ts, push-notification, metadata spec, and search spec are fixed here as they block CI for all backend work.