### PR TITLE
feat(backend): implement geolocation service

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -41,6 +41,13 @@ FCM_SERVICE_ACCOUNT_PATH=
 # Frontend origin allowed by CORS
 VITE_FRONTEND_URL=http://localhost:5173
 
+# ── Geolocation ──────────────────────────────────────────────────────────────
+# Provider base URL for IP-to-country lookups.
+# Default uses ip-api.com free tier (HTTP, 45 req/min, no key needed).
+# For production, use a paid HTTPS endpoint (ip-api.com pro, ipinfo.io, etc.)
+GEO_PROVIDER_URL=http://ip-api.com/json
+GEO_TIMEOUT_MS=3000
+
 # ── Rate Limiting ────────────────────────────────────────────────────────────
 # Limits are per IP address. TTL values are in seconds.
 # All values have sensible defaults — only set these to override.

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,5 +1,5 @@
 
-import { Module } from "@nestjs/common";
+import { MiddlewareConsumer, Module, NestModule } from "@nestjs/common";
 import { ConfigModule, ConfigService } from "@nestjs/config";
 import { APP_GUARD } from "@nestjs/core";
 import { ThrottlerModule, seconds } from "@nestjs/throttler";
@@ -15,6 +15,8 @@ import { SupportModule } from "./api/rest/support/support.module";
 import { HealthModule } from "./health/health.module";
 import { MonitorModule } from "./api/rest/monitor/monitor.module";
 import { SupabaseModule } from "./services/supabase.module";
+import { GeoModule } from "./services/geo.module";
+import { GeoMiddleware } from "./middleware/geo.middleware";
 import { TikkaThrottlerGuard } from "./middleware/throttler.guard";
 import { validate } from "./config/env.schema";
 
@@ -61,6 +63,7 @@ import { validate } from "./config/env.schema";
     }),
 
     SupabaseModule,
+    GeoModule,
     AuthModule,
     RafflesModule,
     UsersModule,
@@ -79,4 +82,8 @@ import { validate } from "./config/env.schema";
     { provide: APP_GUARD, useClass: TikkaThrottlerGuard },
   ],
 })
-export class AppModule {}
+export class AppModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(GeoMiddleware).forRoutes('*');
+  }
+}

--- a/backend/src/config/env.config.ts
+++ b/backend/src/config/env.config.ts
@@ -32,4 +32,15 @@ export const env = {
     serviceAccountJson: process.env.FCM_SERVICE_ACCOUNT_JSON ?? undefined,
     serviceAccountPath: process.env.FCM_SERVICE_ACCOUNT_PATH ?? undefined,
   },
+  get geo() {
+    return {
+      /**
+       * Base URL for the geolocation provider.
+       * Default: ip-api.com free tier (HTTP only, 45 req/min).
+       * Override with a paid/HTTPS endpoint in production.
+       */
+      providerUrl: process.env.GEO_PROVIDER_URL ?? 'http://ip-api.com/json',
+      timeoutMs: parseInt(process.env.GEO_TIMEOUT_MS ?? '3000', 10),
+    };
+  },
 } as const;

--- a/backend/src/config/env.schema.ts
+++ b/backend/src/config/env.schema.ts
@@ -42,6 +42,10 @@ export const envSchema = z
     FCM_SERVICE_ACCOUNT_JSON: z.string().optional(),
     FCM_SERVICE_ACCOUNT_PATH: z.string().optional(),
 
+    // Geolocation
+    GEO_PROVIDER_URL: z.string().url().default('http://ip-api.com/json'),
+    GEO_TIMEOUT_MS: z.coerce.number().int().positive().default(3000),
+
     // Throttle — all optional with sensible defaults
     THROTTLE_DEFAULT_LIMIT: z.coerce.number().int().positive().default(100),
     THROTTLE_DEFAULT_TTL: z.coerce.number().int().positive().default(60),

--- a/backend/src/middleware/geo.middleware.ts
+++ b/backend/src/middleware/geo.middleware.ts
@@ -1,0 +1,65 @@
+import { Injectable, Logger, NestMiddleware } from '@nestjs/common';
+import { FastifyRequest, FastifyReply } from 'fastify';
+import { GeoService } from '../services/geo.service';
+
+/**
+ * GeoMiddleware — resolves the client's country from their IP address
+ * and attaches it as the `x-country-code` request header.
+ *
+ * Downstream handlers (guards, services) can read:
+ *   request.headers['x-country-code']  →  e.g. "US", "NG", "GB"
+ *
+ * The header is set to an empty string when geo lookup fails or the IP
+ * is private, so consumers must always handle the empty-string case.
+ *
+ * Registration: applied globally in AppModule via configure(consumer).
+ */
+@Injectable()
+export class GeoMiddleware implements NestMiddleware {
+  private readonly logger = new Logger(GeoMiddleware.name);
+
+  constructor(private readonly geoService: GeoService) {}
+
+  /**
+   * NestJS with the Fastify adapter passes the full FastifyRequest object
+   * (not the raw IncomingMessage) as `req` in middleware.
+   * We cast accordingly so we can mutate `req.headers` directly.
+   */
+  async use(req: FastifyRequest, _res: FastifyReply, next: () => void): Promise<void> {
+    try {
+      const ip = this.extractIp(req);
+      const geo = await this.geoService.lookupIp(ip);
+      const countryCode = geo?.countryCode ?? '';
+
+      // Fastify exposes headers as a plain object on the request.
+      // Mutating it here makes the value available to all downstream
+      // guards and handlers via request.headers['x-country-code'].
+      (req.headers as Record<string, string>)['x-country-code'] = countryCode;
+
+      if (countryCode) {
+        this.logger.debug(`IP ${ip} resolved to country: ${countryCode}`);
+      }
+    } catch (err) {
+      // Never block the request due to a geo error
+      const message = err instanceof Error ? err.message : String(err);
+      this.logger.warn(`GeoMiddleware error: ${message}`);
+    }
+
+    next();
+  }
+
+  /**
+   * Extract the real client IP, respecting x-forwarded-for set by proxies
+   * (Railway, Fly.io, Nginx, etc.).
+   */
+  private extractIp(req: FastifyRequest): string {
+    const forwarded = req.headers['x-forwarded-for'];
+    if (forwarded) {
+      const first = Array.isArray(forwarded) ? forwarded[0] : forwarded.split(',')[0];
+      return first.trim();
+    }
+
+    // Fastify exposes the parsed IP directly
+    return req.ip ?? req.raw.socket?.remoteAddress ?? 'unknown';
+  }
+}

--- a/backend/src/services/geo.module.ts
+++ b/backend/src/services/geo.module.ts
@@ -1,0 +1,9 @@
+import { Global, Module } from '@nestjs/common';
+import { GeoService } from './geo.service';
+
+@Global()
+@Module({
+  providers: [GeoService],
+  exports: [GeoService],
+})
+export class GeoModule {}

--- a/backend/src/services/geo.service.ts
+++ b/backend/src/services/geo.service.ts
@@ -1,0 +1,168 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { env } from '../config/env.config';
+
+/**
+ * Response shape from ip-api.com (free tier, no API key required).
+ * Docs: https://ip-api.com/docs/api:json
+ */
+interface IpApiResponse {
+  status: 'success' | 'fail';
+  countryCode: string;
+  country: string;
+  message?: string;
+}
+
+/**
+ * Result returned by GeoService lookups.
+ */
+export interface GeoLookupResult {
+  /** ISO 3166-1 alpha-2 country code (e.g. "US", "NG", "GB") */
+  countryCode: string;
+  /** Full country name */
+  country: string;
+}
+
+/**
+ * GeoService — detects user country via IP using ip-api.com.
+ *
+ * ip-api.com free tier:
+ *   - No API key required
+ *   - 45 requests/minute per IP
+ *   - HTTPS requires a paid plan; HTTP is used for the free tier
+ *
+ * For production, set GEO_PROVIDER_URL to a paid/self-hosted endpoint
+ * that supports HTTPS (e.g. ip-api.com pro, ipinfo.io, MaxMind GeoIP2).
+ */
+@Injectable()
+export class GeoService {
+  private readonly logger = new Logger(GeoService.name);
+  private readonly providerUrl: string;
+  private readonly timeoutMs: number;
+
+  constructor() {
+    this.providerUrl = env.geo.providerUrl;
+    this.timeoutMs = env.geo.timeoutMs;
+  }
+
+  /**
+   * Look up the country for a given IP address.
+   *
+   * Returns null when:
+   *  - The IP is private/loopback (127.x, 10.x, 192.168.x, ::1)
+   *  - The provider returns a non-success status
+   *  - The request times out or fails
+   *
+   * @param ip - IPv4 or IPv6 address string
+   */
+  async lookupIp(ip: string): Promise<GeoLookupResult | null> {
+    if (this.isPrivateIp(ip)) {
+      this.logger.debug(`Skipping geo lookup for private IP: ${ip}`);
+      return null;
+    }
+
+    const url = `${this.providerUrl}/${encodeURIComponent(ip)}?fields=status,message,country,countryCode`;
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    try {
+      const res = await fetch(url, { signal: controller.signal });
+      clearTimeout(timeoutId);
+
+      if (!res.ok) {
+        this.logger.warn(`Geo provider returned HTTP ${res.status} for IP ${ip}`);
+        return null;
+      }
+
+      const data = (await res.json()) as IpApiResponse;
+
+      if (data.status !== 'success') {
+        this.logger.warn(`Geo lookup failed for IP ${ip}: ${data.message ?? 'unknown reason'}`);
+        return null;
+      }
+
+      return { countryCode: data.countryCode, country: data.country };
+    } catch (err) {
+      clearTimeout(timeoutId);
+      const message = err instanceof Error ? err.message : String(err);
+      this.logger.warn(`Geo lookup error for IP ${ip}: ${message}`);
+      return null;
+    }
+  }
+
+  /**
+   * Check whether a user is allowed to access a specific raffle based on
+   * their detected country and the raffle's geo-restriction list.
+   *
+   * Signature matches the issue spec: checkAccess(address, raffleId)
+   * where `address` is the client IP address (resolved from the request
+   * by GeoMiddleware or the caller).
+   *
+   * @param address       - Client IP address (IPv4 or IPv6)
+   * @param raffleId      - Raffle identifier (for logging / future DB lookup)
+   * @param blockedCountries - ISO 3166-1 alpha-2 codes that are NOT allowed
+   *                          (empty array = no geo restrictions)
+   */
+  async checkAccess(
+    address: string,
+    raffleId: number | string,
+    blockedCountries: string[] = [],
+  ): Promise<{ allowed: boolean; countryCode: string | null; reason?: string }> {
+    const ip = address;
+    if (blockedCountries.length === 0) {
+      return { allowed: true, countryCode: null };
+    }
+
+    const geo = await this.lookupIp(ip);
+
+    if (!geo) {
+      // Cannot determine location — fail open (allow) to avoid blocking legitimate users
+      this.logger.warn(
+        `Could not determine country for IP ${ip} on raffle ${raffleId}; allowing access`,
+      );
+      return { allowed: true, countryCode: null, reason: 'geo_lookup_failed' };
+    }
+
+    const blocked = blockedCountries
+      .map((c) => c.toUpperCase())
+      .includes(geo.countryCode.toUpperCase());
+
+    if (blocked) {
+      this.logger.log(
+        `Access denied for raffle ${raffleId}: country ${geo.countryCode} is restricted`,
+      );
+      return {
+        allowed: false,
+        countryCode: geo.countryCode,
+        reason: `country_restricted:${geo.countryCode}`,
+      };
+    }
+
+    return { allowed: true, countryCode: geo.countryCode };
+  }
+
+  // ── Helpers ────────────────────────────────────────────────────────────────
+
+  /**
+   * Returns true for RFC-1918 private ranges, loopback, and link-local addresses.
+   * These IPs cannot be geo-located and should be skipped.
+   */
+  private isPrivateIp(ip: string): boolean {
+    // IPv6 loopback
+    if (ip === '::1' || ip === '::ffff:127.0.0.1') return true;
+
+    // Strip IPv6-mapped IPv4 prefix (::ffff:x.x.x.x)
+    const normalized = ip.startsWith('::ffff:') ? ip.slice(7) : ip;
+
+    const parts = normalized.split('.').map(Number);
+    if (parts.length !== 4 || parts.some(isNaN)) return false;
+
+    const [a, b] = parts;
+    return (
+      a === 127 ||                        // 127.0.0.0/8  loopback
+      a === 10 ||                         // 10.0.0.0/8   private
+      (a === 172 && b >= 16 && b <= 31) || // 172.16.0.0/12 private
+      (a === 192 && b === 168) ||          // 192.168.0.0/16 private
+      (a === 169 && b === 254)             // 169.254.0.0/16 link-local
+    );
+  }
+}


### PR DESCRIPTION
- Add GeoService (src/services/geo.service.ts) using ip-api.com free tier
  - lookupIp(ip): resolves IP to ISO 3166-1 alpha-2 country code
  - checkAccess(address, raffleId, blockedCountries[]): checks raffle geo access
  - Private/loopback IP detection (RFC-1918, link-local, IPv6)
  - Graceful fail-open on lookup errors to avoid blocking legitimate users

- Add GeoMiddleware (src/middleware/geo.middleware.ts)
  - Runs on every request via AppModule configure()
  - Attaches x-country-code header for downstream guards/services
  - Respects x-forwarded-for for proxy environments (Railway, Fly.io)

- Add GeoModule (src/services/geo.module.ts) as a global NestJS module

- Register GeoModule and GeoMiddleware in AppModule

- Add GEO_PROVIDER_URL and GEO_TIMEOUT_MS to env config, schema, and .env.example

Closes #174 