### PR TITLE
feat(indexer): add status CLI for monitoring indexer lag and DB stats

### DIFF
--- a/indexer/package.json
+++ b/indexer/package.json
@@ -13,6 +13,7 @@
     "test:watch": "jest --watch --testPathIgnorePatterns=integration",
     "test:cov": "jest --coverage --testPathIgnorePatterns=integration",
     "test:integration": "jest --config jest.integration.config.js --forceExit --runInBand",
+    "status": "ts-node --transpile-only src/cli/status.command.ts",
     "archive:raffle-events": "ts-node src/maintenance/archive-raffle-events.ts",
     "migration:run": "typeorm-ts-node-commonjs -d src/data-source.ts migration:run",
     "migration:revert": "typeorm-ts-node-commonjs -d src/data-source.ts migration:revert",

--- a/indexer/src/cli/status-display.ts
+++ b/indexer/src/cli/status-display.ts
@@ -1,0 +1,60 @@
+import { StatusResult } from './status.service';
+
+const RESET  = '\x1b[0m';
+const BOLD   = '\x1b[1m';
+const DIM    = '\x1b[2m';
+const GREEN  = '\x1b[32m';
+const YELLOW = '\x1b[33m';
+const RED    = '\x1b[31m';
+const CYAN   = '\x1b[36m';
+
+function colorLag(lag: number | null): string {
+  if (lag === null) return `${DIM}n/a${RESET}`;
+  if (lag <= 10)   return `${GREEN}${lag}${RESET}`;
+  if (lag <= 100)  return `${YELLOW}${lag}${RESET}`;
+  return `${RED}${lag}${RESET}`;
+}
+
+function colorDbStatus(s: 'ok' | 'error'): string {
+  return s === 'ok' ? `${GREEN}ok${RESET}` : `${RED}error${RESET}`;
+}
+
+function pad(s: string | number, width: number): string {
+  return String(s).padEnd(width);
+}
+
+export function renderTable(result: StatusResult): string {
+  const lines: string[] = [];
+
+  lines.push(`${BOLD}${CYAN}Tikka Indexer Status${RESET}  ${DIM}${result.timestamp}${RESET}`);
+  lines.push('─'.repeat(50));
+
+  lines.push(`${BOLD}Ledger${RESET}`);
+  lines.push(`  ${pad('Current (indexed)', 26)} ${result.indexer.current_ledger}`);
+  lines.push(`  ${pad('Horizon (latest)', 26)} ${result.indexer.horizon_ledger ?? `${DIM}n/a${RESET}`}`);
+  lines.push(`  ${pad('Lag', 26)} ${colorLag(result.indexer.lag_ledgers)} ledgers`);
+
+  lines.push('');
+
+  lines.push(`${BOLD}Events${RESET}`);
+  lines.push(`  ${pad('Total processed', 26)} ${result.events.total_processed.toLocaleString()}`);
+  lines.push(`  ${pad('Last 24 h', 26)} ${result.events.last_24h.toLocaleString()}`);
+
+  lines.push('');
+
+  lines.push(`${BOLD}Database${RESET}`);
+  lines.push(`  ${pad('Status', 26)} ${colorDbStatus(result.db.status)}`);
+  if (result.db.pool) {
+    const { total, idle, waiting } = result.db.pool;
+    lines.push(`  ${pad('Pool (total / idle / wait)', 26)} ${total} / ${idle} / ${waiting}`);
+  } else {
+    lines.push(`  ${pad('Pool', 26)} ${DIM}n/a${RESET}`);
+  }
+
+  lines.push('─'.repeat(50));
+  return lines.join('\n');
+}
+
+export function renderJson(result: StatusResult): string {
+  return JSON.stringify(result, null, 2);
+}

--- a/indexer/src/cli/status.command.ts
+++ b/indexer/src/cli/status.command.ts
@@ -1,0 +1,94 @@
+#!/usr/bin/env ts-node
+/**
+ * Tikka Indexer — status CLI
+ *
+ * Usage:
+ *   pnpm run status
+ *   pnpm run status -- --json
+ *   pnpm run status -- --watch
+ *   pnpm run status -- --watch 5000
+ *
+ * Options:
+ *   --json          Output machine-readable JSON instead of the table.
+ *   --watch [ms]    Refresh every <ms> milliseconds (default: 3000).
+ *                   Press Ctrl-C to exit.
+ */
+
+import * as path from 'path';
+import * as fs from 'fs';
+
+/**
+ * Minimal .env loader — runs synchronously before any other module code
+ * so that DATABASE_URL etc. are available when TypeORM initialises.
+ * Does not override values already present in process.env.
+ */
+function loadEnvFile(file: string): void {
+  const full = path.resolve(process.cwd(), file);
+  if (!fs.existsSync(full)) return;
+  for (const line of fs.readFileSync(full, 'utf8').split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eqIdx = trimmed.indexOf('=');
+    if (eqIdx === -1) continue;
+    const key = trimmed.slice(0, eqIdx).trim();
+    const val = trimmed.slice(eqIdx + 1).trim().replace(/^["']|["']$/g, '');
+    if (!(key in process.env)) process.env[key] = val;
+  }
+}
+
+// Load env before importing service modules so DATABASE_URL is set in time.
+loadEnvFile('.env.local');
+loadEnvFile('.env');
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { fetchStatus } = require('./status.service') as typeof import('./status.service');
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { renderTable, renderJson } = require('./status-display') as typeof import('./status-display');
+
+const args = process.argv.slice(2);
+const jsonMode      = args.includes('--json');
+const watchIdx      = args.indexOf('--watch');
+const watchMode     = watchIdx !== -1;
+const watchInterval = watchMode
+  ? (parseInt(args[watchIdx + 1] ?? '', 10) || 3000)
+  : 0;
+
+async function run(): Promise<void> {
+  const result = await fetchStatus();
+  const output = jsonMode ? renderJson(result) : renderTable(result);
+
+  if (watchMode && !jsonMode) {
+    // Clear screen for a clean refresh in watch mode
+    process.stdout.write('\x1b[2J\x1b[H');
+  }
+
+  console.log(output);
+}
+
+async function main(): Promise<void> {
+  if (!watchMode) {
+    await run();
+    return;
+  }
+
+  // Watch mode: run immediately, then repeat on interval
+  await run();
+  const timer = setInterval(async () => {
+    try {
+      await run();
+    } catch (err) {
+      console.error('Status fetch error:', err);
+    }
+  }, watchInterval);
+
+  process.on('SIGINT', () => {
+    clearInterval(timer);
+    console.log('\nExiting watch mode.');
+    process.exit(0);
+  });
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/indexer/src/cli/status.service.ts
+++ b/indexer/src/cli/status.service.ts
@@ -1,0 +1,135 @@
+import 'reflect-metadata';
+import { DataSource, DataSourceOptions } from 'typeorm';
+import { IndexerCursorEntity } from '../database/entities/indexer-cursor.entity';
+import { RaffleEventEntity } from '../database/entities/raffle-event.entity';
+
+export interface DbPoolStats {
+  total: number;
+  idle: number;
+  waiting: number;
+}
+
+export interface StatusResult {
+  timestamp: string;
+  indexer: {
+    current_ledger: number;
+    horizon_ledger: number | null;
+    lag_ledgers: number | null;
+  };
+  events: {
+    total_processed: number;
+    last_24h: number;
+  };
+  db: {
+    status: 'ok' | 'error';
+    pool: DbPoolStats | null;
+  };
+}
+
+function buildDataSource(): DataSource {
+  const ssl =
+    process.env.DB_SSL === 'true' ? { rejectUnauthorized: false } : undefined;
+
+  const options: DataSourceOptions = {
+    type: 'postgres',
+    url: process.env.DATABASE_URL,
+    host: process.env.DB_HOST ?? 'localhost',
+    port: parseInt(process.env.DB_PORT ?? '5432', 10),
+    username: process.env.DB_USERNAME ?? 'postgres',
+    password: process.env.DB_PASSWORD ?? 'postgres',
+    database: process.env.DB_DATABASE ?? 'tikka_indexer',
+    ssl,
+    entities: [IndexerCursorEntity, RaffleEventEntity],
+    synchronize: false,
+    logging: false,
+  };
+
+  return new DataSource(options);
+}
+
+async function fetchHorizonLedger(horizonUrl: string): Promise<number | null> {
+  try {
+    const url = horizonUrl.replace(/\/$/, '');
+    const res = await fetch(`${url}/ledgers?order=desc&limit=1`, {
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!res.ok) return null;
+    const json = (await res.json()) as {
+      _embedded?: { records?: Array<{ sequence: string }> };
+    };
+    const seq = json._embedded?.records?.[0]?.sequence;
+    return seq != null ? parseInt(seq, 10) : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function fetchStatus(): Promise<StatusResult> {
+  const horizonUrl = process.env.HORIZON_URL ?? 'https://horizon.stellar.org';
+
+  const ds = buildDataSource();
+  let dbStatus: 'ok' | 'error' = 'error';
+  let currentLedger = 0;
+  let totalEvents = 0;
+  let last24hEvents = 0;
+  let pool: DbPoolStats | null = null;
+
+  try {
+    await ds.initialize();
+    dbStatus = 'ok';
+
+    // Last processed ledger from the cursor singleton row
+    const cursorRow = await ds
+      .getRepository(IndexerCursorEntity)
+      .findOne({ where: { id: 1 } });
+    currentLedger = cursorRow?.lastLedger ?? 0;
+
+    // Event counts
+    const eventRepo = ds.getRepository(RaffleEventEntity);
+    totalEvents = await eventRepo.count();
+
+    const since = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+    last24hEvents = await eventRepo
+      .createQueryBuilder('e')
+      .where('e.indexedAt >= :since', { since })
+      .getCount();
+
+    // DB pool stats via pg driver internals (best-effort)
+    const driver = ds.driver as any;
+    const pgPool = driver?.master ?? driver?.pool;
+    if (pgPool) {
+      pool = {
+        total: pgPool.totalCount ?? pgPool._clients?.length ?? 0,
+        idle: pgPool.idleCount ?? pgPool._idleQueue?.length ?? 0,
+        waiting: pgPool.waitingCount ?? pgPool._pendingQueue?.length ?? 0,
+      };
+    }
+  } catch {
+    // dbStatus stays 'error'
+  } finally {
+    if (ds.isInitialized) await ds.destroy();
+  }
+
+  const horizonLedger = await fetchHorizonLedger(horizonUrl);
+  const lagLedgers =
+    horizonLedger != null && currentLedger > 0
+      ? Math.max(0, horizonLedger - currentLedger)
+      : null;
+
+  return {
+    timestamp: new Date().toISOString(),
+    indexer: {
+      current_ledger: currentLedger,
+      horizon_ledger: horizonLedger,
+      lag_ledgers: lagLedgers,
+    },
+    events: {
+      total_processed: totalEvents,
+      last_24h: last24hEvents,
+    },
+    db: {
+      status: dbStatus,
+      pool,
+    },
+  };
+}


### PR DESCRIPTION
- Add src/cli/status.service.ts: fetches current ledger from indexer_cursor, Horizon latest ledger, lag calculation, event counts (total + last 24h), and DB pool stats via TypeORM pg driver internals
- Add src/cli/status-display.ts: colour-coded table renderer and JSON renderer
- Add src/cli/status.command.ts: CLI entry point with --json and --watch [ms] flags, minimal .env loader so DATABASE_URL is available before TypeORM initialises
- Add 'status' script to package.json using ts-node --transpile-only

Closes #205 