### PR TITLE
feat: add 'Add to Calendar' button for raffle end times (#190)

### DIFF
--- a/client/src/components/cards/FeaturedRaffleCard.tsx
+++ b/client/src/components/cards/FeaturedRaffleCard.tsx
@@ -2,6 +2,7 @@
 import React from "react";
 import { ProgressBar } from "../ui/ProgressBar";
 import Line from "../../assets/svg/Line";
+import AddToCalendar from "../ui/AddToCalendar";
 
 type Countdown = {
     days: string;
@@ -17,6 +18,7 @@ type FeaturedRaffleCardProps = {
     prizeValue: string;
     prizeCurrency?: string; // default "ETH"
     countdown: Countdown;
+    endTimeUnix?: number; // Unix timestamp for calendar
     ticketPrice: string;
     entries: number;
     progress: number; // 0–100
@@ -31,6 +33,7 @@ const FeaturedRaffleCard: React.FC<FeaturedRaffleCardProps> = ({
     prizeValue,
     prizeCurrency = "ETH",
     countdown,
+    endTimeUnix,
     ticketPrice,
     entries,
     progress,
@@ -92,6 +95,11 @@ const FeaturedRaffleCard: React.FC<FeaturedRaffleCardProps> = ({
                                     {countdown.seconds}s
                                 </span>
                             </div>
+                            {endTimeUnix && (
+                                <div className="mt-2 flex justify-start sm:justify-end">
+                                    <AddToCalendar title={title} endTimeUnix={endTimeUnix} />
+                                </div>
+                            )}
                         </div>
                     </div>
 

--- a/client/src/components/ui/AddToCalendar.tsx
+++ b/client/src/components/ui/AddToCalendar.tsx
@@ -1,0 +1,138 @@
+import { useState, useRef, useEffect } from "react";
+import { CalendarPlus } from "lucide-react";
+
+interface AddToCalendarProps {
+    title: string;
+    endTimeUnix: number; // Unix timestamp (seconds)
+    url?: string;
+}
+
+function formatIcsDate(date: Date): string {
+    return date.toISOString().replace(/[-:]/g, "").split(".")[0] + "Z";
+}
+
+function generateIcs(title: string, endDate: Date, url: string): string {
+    const now = formatIcsDate(new Date());
+    const end = formatIcsDate(endDate);
+    // Event starts 1 hour before end
+    const start = formatIcsDate(new Date(endDate.getTime() - 60 * 60 * 1000));
+    const uid = `raffle-${endDate.getTime()}@tikka`;
+
+    return [
+        "BEGIN:VCALENDAR",
+        "VERSION:2.0",
+        "PRODID:-//Tikka//Raffle Calendar//EN",
+        "BEGIN:VEVENT",
+        `UID:${uid}`,
+        `DTSTAMP:${now}`,
+        `DTSTART:${start}`,
+        `DTEND:${end}`,
+        `SUMMARY:${title} – Raffle Ends`,
+        `DESCRIPTION:Don't miss the end of this raffle! ${url}`,
+        `URL:${url}`,
+        "END:VEVENT",
+        "END:VCALENDAR",
+    ].join("\r\n");
+}
+
+function googleCalendarUrl(title: string, endDate: Date, url: string): string {
+    const end = endDate.toISOString().replace(/[-:]/g, "").split(".")[0] + "Z";
+    const start = new Date(endDate.getTime() - 60 * 60 * 1000)
+        .toISOString()
+        .replace(/[-:]/g, "")
+        .split(".")[0] + "Z";
+    const params = new URLSearchParams({
+        action: "TEMPLATE",
+        text: `${title} – Raffle Ends`,
+        dates: `${start}/${end}`,
+        details: `Don't miss the end of this raffle! ${url}`,
+        location: url,
+    });
+    return `https://calendar.google.com/calendar/render?${params.toString()}`;
+}
+
+function outlookCalendarUrl(title: string, endDate: Date, url: string): string {
+    const start = new Date(endDate.getTime() - 60 * 60 * 1000).toISOString();
+    const params = new URLSearchParams({
+        path: "/calendar/action/compose",
+        rru: "addevent",
+        subject: `${title} – Raffle Ends`,
+        startdt: start,
+        enddt: endDate.toISOString(),
+        body: `Don't miss the end of this raffle! ${url}`,
+        location: url,
+    });
+    return `https://outlook.live.com/calendar/0/deeplink/compose?${params.toString()}`;
+}
+
+const AddToCalendar = ({ title, endTimeUnix, url }: AddToCalendarProps) => {
+    const [open, setOpen] = useState(false);
+    const ref = useRef<HTMLDivElement>(null);
+    const endDate = new Date(endTimeUnix * 1000);
+    const raffleUrl = url || window.location.href;
+
+    useEffect(() => {
+        const handler = (e: MouseEvent) => {
+            if (ref.current && !ref.current.contains(e.target as Node)) {
+                setOpen(false);
+            }
+        };
+        document.addEventListener("mousedown", handler);
+        return () => document.removeEventListener("mousedown", handler);
+    }, []);
+
+    const downloadIcs = () => {
+        const content = generateIcs(title, endDate, raffleUrl);
+        const blob = new Blob([content], { type: "text/calendar;charset=utf-8" });
+        const link = document.createElement("a");
+        link.href = URL.createObjectURL(blob);
+        link.download = `${title.replace(/\s+/g, "-")}-raffle.ics`;
+        link.click();
+        URL.revokeObjectURL(link.href);
+        setOpen(false);
+    };
+
+    return (
+        <div className="relative" ref={ref}>
+            <button
+                onClick={() => setOpen((v) => !v)}
+                title="Add to Calendar"
+                className="flex items-center space-x-1 text-xs text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors"
+            >
+                <CalendarPlus className="w-4 h-4" />
+                <span>Add to Calendar</span>
+            </button>
+
+            {open && (
+                <div className="absolute right-0 mt-2 w-48 bg-white dark:bg-[#1A2035] border border-gray-200 dark:border-white/10 rounded-xl shadow-xl z-50 overflow-hidden">
+                    <a
+                        href={googleCalendarUrl(title, endDate, raffleUrl)}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        onClick={() => setOpen(false)}
+                        className="flex items-center px-4 py-3 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-white/5 transition-colors"
+                    >
+                        Google Calendar
+                    </a>
+                    <a
+                        href={outlookCalendarUrl(title, endDate, raffleUrl)}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        onClick={() => setOpen(false)}
+                        className="flex items-center px-4 py-3 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-white/5 transition-colors"
+                    >
+                        Outlook Calendar
+                    </a>
+                    <button
+                        onClick={downloadIcs}
+                        className="w-full text-left flex items-center px-4 py-3 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-white/5 transition-colors"
+                    >
+                        Download .ics
+                    </button>
+                </div>
+            )}
+        </div>
+    );
+};
+
+export default AddToCalendar;

--- a/client/src/pages/RafflePage.tsx
+++ b/client/src/pages/RafflePage.tsx
@@ -21,6 +21,7 @@ import {
     ExternalLink,
     Bell
 } from "lucide-react";
+import AddToCalendar from "../components/ui/AddToCalendar";
 import Line from "../assets/svg/Line";
 import detailimage from "../assets/detailimage.png";
 import { Breadcrumbs } from "../components/ui/Breadcrumbs";
@@ -239,6 +240,12 @@ const RafflePage = () => {
                                     <span className="bg-gray-300 dark:bg-white/10 px-2 py-0.5 rounded text-gray-900 dark:text-white">{countdown.minutes}m</span>
                                 </div>
                             </div>
+                            {isActive && (
+                                <AddToCalendar
+                                    title={title}
+                                    endTimeUnix={raffle.endTime}
+                                />
+                            )}
                             <Line />
                             <div className="flex items-center justify-between">
                                 <span className="text-sm text-gray-400">Total Participants</span>


### PR DESCRIPTION
- Create AddToCalendar component with Google Calendar, Outlook, and .ics download options
- ICS file generated client-side without external dependencies
- Button renders next to 'Ends In' countdown in RafflePage (active raffles only)
- Add optional endTimeUnix prop to FeaturedRaffleCard for backward compatibility
- Dropdown closes on outside click
closes #190 