### PR TITLE
feat: implement idempotent UserProcessor with atomic increments

### DIFF
--- a/indexer/src/database/entities/user.entity.ts
+++ b/indexer/src/database/entities/user.entity.ts
@@ -39,6 +39,14 @@ export class UserEntity {
   @Column({ type: "integer", name: "first_seen_ledger" })
   firstSeenLedger!: number;
 
+  /**
+   * Transaction hash of the last event applied to this user row.
+   * Acts as an idempotency key — processors skip re-applying an event
+   * whose tx_hash matches this value.
+   */
+  @Column({ type: "varchar", length: 64, nullable: true, name: "last_tx_hash" })
+  lastTxHash!: string | null;
+
   @UpdateDateColumn({ type: "timestamptz", name: "updated_at" })
   updatedAt!: Date;
 }

--- a/indexer/src/database/migrations/1720000000001-AddUserLastTxHash.ts
+++ b/indexer/src/database/migrations/1720000000001-AddUserLastTxHash.ts
@@ -1,0 +1,22 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+/**
+ * Adds `last_tx_hash` to the `users` table.
+ * Used as an idempotency key in UserProcessor — prevents double-applying
+ * the same event if the ingestion pipeline replays a transaction.
+ */
+export class AddUserLastTxHash1720000000001 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE users
+      ADD COLUMN IF NOT EXISTS last_tx_hash VARCHAR(64) NULL
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE users
+      DROP COLUMN IF EXISTS last_tx_hash
+    `);
+  }
+}

--- a/indexer/src/processors/ticket.processor.ts
+++ b/indexer/src/processors/ticket.processor.ts
@@ -69,6 +69,7 @@ export class TicketProcessor {
       await this.userProcessor.handleTicketPurchased(
         raffleId,
         buyer,
+        ticketIds.length,
         ledger,
         txHash,
         queryRunner,

--- a/indexer/src/processors/user.processor.ts
+++ b/indexer/src/processors/user.processor.ts
@@ -2,8 +2,6 @@ import { Injectable, Logger } from '@nestjs/common';
 import { DataSource, QueryRunner } from 'typeorm';
 import { CacheService } from '../cache/cache.service';
 import { UserEntity } from '../database/entities/user.entity';
-import { TicketEntity } from '../database/entities/ticket.entity';
-import { RaffleEntity } from '../database/entities/raffle.entity';
 
 @Injectable()
 export class UserProcessor {
@@ -13,23 +11,31 @@ export class UserProcessor {
 
   /**
    * Called when a TicketPurchased event is indexed.
-   * Invalidates the buyer's user profile cache and the raffle detail.
+   *
+   * Upserts the buyer row and atomically increments:
+   *   - total_tickets_bought  by the number of tickets in this purchase
+   *   - total_raffles_entered by 1 (only when this is the buyer's first ticket in this raffle)
+   *
+   * Idempotent: skips the update if last_tx_hash already equals txHash.
+   * Runs inside the caller's QueryRunner when provided (ticket.processor shares its tx).
    */
   async handleTicketPurchased(
     raffleId: number,
     buyer: string,
+    ticketCount: number,
     ledger: number,
     txHash: string,
     queryRunner?: QueryRunner,
   ) {
     this.logger.log(`Handling TicketPurchased for ${buyer} in raffle ${raffleId}`);
     const runner = queryRunner ?? this.dataSource.createQueryRunner();
-    const startedTx = !queryRunner;
-    if (!queryRunner) {
+    const ownTx = !queryRunner;
+    if (ownTx) {
       await runner.connect();
       await runner.startTransaction();
     }
     try {
+      // 1. Ensure the user row exists
       await runner.manager
         .createQueryBuilder()
         .insert()
@@ -37,54 +43,55 @@ export class UserProcessor {
         .values({
           address: buyer,
           firstSeenLedger: ledger,
+          lastTxHash: null,
         })
         .orIgnore()
         .execute();
 
-      await runner.manager
-        .createQueryBuilder()
-        .update(UserEntity)
-        .set({
-          firstSeenLedger: () => `LEAST(first_seen_ledger, ${ledger})`,
-        })
-        .where('address = :buyer', { buyer })
-        .execute();
-
-      const ticketCounts = await runner.manager
-        .createQueryBuilder(TicketEntity, 't')
-        .select('COUNT(*)', 'total')
-        .addSelect('COUNT(DISTINCT t.raffle_id)', 'distinctRaffles')
-        .where('t.owner = :buyer', { buyer })
-        .getRawOne();
-
-      const totalTickets = Number(ticketCounts?.total ?? 0);
-      const distinctRaffles = Number(ticketCounts?.distinctRaffles ?? 0);
-
-      await runner.manager
-        .createQueryBuilder()
-        .update(UserEntity)
-        .set({
-          totalTicketsBought: totalTickets,
-          totalRafflesEntered: distinctRaffles,
-        })
-        .where('address = :buyer', { buyer })
-        .execute();
-
-      if (startedTx) {
-        await runner.commitTransaction();
+      // 2. Idempotency check — skip if this tx was already applied
+      const existing = await runner.manager.findOne(UserEntity, {
+        where: { address: buyer },
+        select: ['lastTxHash', 'firstSeenLedger'],
+      });
+      if (existing?.lastTxHash === txHash) {
+        this.logger.debug(`TicketPurchased ${txHash} already applied for ${buyer}, skipping`);
+        if (ownTx) await runner.commitTransaction();
+        return;
       }
+
+      // 3. Determine whether this is the buyer's first ticket in this raffle
+      //    (within the same tx so the count is consistent)
+      const priorTicketInRaffle = await runner.query(
+        `SELECT 1 FROM tickets WHERE owner = $1 AND raffle_id = $2 AND purchase_tx_hash != $3 LIMIT 1`,
+        [buyer, raffleId, txHash],
+      );
+      const isFirstEntryInRaffle = priorTicketInRaffle.length === 0;
+
+      // 4. Atomic increments + update first_seen_ledger + stamp last_tx_hash
+      await runner.manager
+        .createQueryBuilder()
+        .update(UserEntity)
+        .set({
+          totalTicketsBought: () => `total_tickets_bought + ${ticketCount}`,
+          totalRafflesEntered: () =>
+            isFirstEntryInRaffle
+              ? `total_raffles_entered + 1`
+              : `total_raffles_entered`,
+          firstSeenLedger: () => `LEAST(first_seen_ledger, ${ledger})`,
+          lastTxHash: txHash,
+        })
+        .where('address = :buyer', { buyer })
+        .execute();
+
+      if (ownTx) await runner.commitTransaction();
 
       await this.cacheService.invalidateUserProfile(buyer);
       await this.cacheService.invalidateRaffleDetail(raffleId.toString());
     } catch (e) {
-      if (startedTx) {
-        await runner.rollbackTransaction();
-      }
+      if (ownTx) await runner.rollbackTransaction();
       throw e;
     } finally {
-      if (startedTx) {
-        await runner.release();
-      }
+      if (ownTx) await runner.release();
     }
   }
 
@@ -99,6 +106,17 @@ export class UserProcessor {
     await this.cacheService.invalidateRaffleDetail(raffleId);
   }
 
+  /**
+   * Called when a RaffleFinalized event is indexed.
+   *
+   * Upserts the winner row and atomically increments:
+   *   - total_raffles_won by 1
+   *   - total_prize_xlm   by prizeAmount (bigint string addition via PostgreSQL numeric cast)
+   *
+   * Idempotent: keyed by a synthetic tx_hash derived from raffleId so a replay
+   * of the same finalization is a no-op.
+   * Runs inside the caller's QueryRunner when provided (raffle.processor shares its tx).
+   */
   async handleRaffleFinalized(
     raffleId: number,
     winner: string | null,
@@ -106,14 +124,19 @@ export class UserProcessor {
     queryRunner?: QueryRunner,
   ) {
     if (!winner) return;
-    this.logger.log(`Handling RaffleFinalized for ${raffleId} winner ${winner}`);
+    this.logger.log(`Handling RaffleFinalized for raffle ${raffleId}, winner ${winner}`);
+
+    // Synthetic idempotency key — one finalization per raffle
+    const txHash = `finalized:${raffleId}`;
+
     const runner = queryRunner ?? this.dataSource.createQueryRunner();
-    const startedTx = !queryRunner;
-    if (!queryRunner) {
+    const ownTx = !queryRunner;
+    if (ownTx) {
       await runner.connect();
       await runner.startTransaction();
     }
     try {
+      // 1. Ensure the winner row exists
       await runner.manager
         .createQueryBuilder()
         .insert()
@@ -121,47 +144,52 @@ export class UserProcessor {
         .values({
           address: winner,
           firstSeenLedger: 0,
+          lastTxHash: null,
         })
         .orIgnore()
         .execute();
 
-      const raw = await runner.query(
-        `SELECT COUNT(*)::int AS wins, COALESCE(SUM(prize_amount::numeric), 0)::text AS total_prize
-         FROM raffles
-         WHERE winner = $1`,
-        [winner],
-      );
-      const wins = Number(raw?.[0]?.wins ?? 0);
-      const totalPrize = String(raw?.[0]?.total_prize ?? '0');
+      // 2. Idempotency check
+      const existing = await runner.manager.findOne(UserEntity, {
+        where: { address: winner },
+        select: ['lastTxHash'],
+      });
+      if (existing?.lastTxHash === txHash) {
+        this.logger.debug(`RaffleFinalized ${raffleId} already applied for ${winner}, skipping`);
+        if (ownTx) await runner.commitTransaction();
+        return;
+      }
 
+      // 3. Atomic increments — add prize using PostgreSQL numeric arithmetic
+      const safePrize = BigInt(prizeAmount || '0').toString(); // guard against non-numeric input
       await runner.manager
         .createQueryBuilder()
         .update(UserEntity)
         .set({
-          totalRafflesWon: wins,
-          totalPrizeXlm: totalPrize,
+          totalRafflesWon: () => `total_raffles_won + 1`,
+          totalPrizeXlm: () => `(total_prize_xlm::numeric + ${safePrize})::text`,
+          lastTxHash: txHash,
         })
         .where('address = :winner', { winner })
         .execute();
 
-      if (startedTx) {
-        await runner.commitTransaction();
-      }
+      if (ownTx) await runner.commitTransaction();
 
       await this.cacheService.invalidateUserProfile(winner);
       await this.cacheService.invalidateLeaderboard();
     } catch (e) {
-      if (startedTx) {
-        await runner.rollbackTransaction();
-      }
+      if (ownTx) await runner.rollbackTransaction();
       throw e;
     } finally {
-      if (startedTx) {
-        await runner.release();
-      }
+      if (ownTx) await runner.release();
     }
   }
 
+  /**
+   * Called when a RaffleCreated event is indexed.
+   * Ensures the creator has a user row and updates first_seen_ledger.
+   * No stats to increment — creation is tracked on the raffles table.
+   */
   async handleRaffleCreated(
     creator: string,
     createdLedger: number,
@@ -169,8 +197,8 @@ export class UserProcessor {
   ) {
     this.logger.log(`Handling RaffleCreated by ${creator}`);
     const runner = queryRunner ?? this.dataSource.createQueryRunner();
-    const startedTx = !queryRunner;
-    if (!queryRunner) {
+    const ownTx = !queryRunner;
+    if (ownTx) {
       await runner.connect();
       await runner.startTransaction();
     }
@@ -182,6 +210,7 @@ export class UserProcessor {
         .values({
           address: creator,
           firstSeenLedger: createdLedger,
+          lastTxHash: null,
         })
         .orIgnore()
         .execute();
@@ -195,18 +224,12 @@ export class UserProcessor {
         .where('address = :creator', { creator })
         .execute();
 
-      if (startedTx) {
-        await runner.commitTransaction();
-      }
+      if (ownTx) await runner.commitTransaction();
     } catch (e) {
-      if (startedTx) {
-        await runner.rollbackTransaction();
-      }
+      if (ownTx) await runner.rollbackTransaction();
       throw e;
     } finally {
-      if (startedTx) {
-        await runner.release();
-      }
+      if (ownTx) await runner.release();
     }
   }
 }


### PR DESCRIPTION
Rewrites user.processor.ts to handle TicketPurchased, RaffleFinalized, and RaffleCreated events with the following guarantees:

Idempotency
- last_tx_hash column added to users table (migration 1720000000001)
- handleTicketPurchased: skips re-apply if last_tx_hash matches txHash
- handleRaffleFinalized: keyed by synthetic 'finalized:<raffleId>' — one application per raffle regardless of replay

Atomic increments (no race conditions)
- total_tickets_bought incremented by ticketCount via SQL expression
- total_raffles_entered incremented by 1 only on first ticket in that raffle, determined within the same transaction via a tickets table check
- total_raffles_won incremented by 1 via SQL expression
- total_prize_xlm accumulated via PostgreSQL numeric cast to handle bigint safely

Shared transactions
- All handlers accept an optional QueryRunner; when provided they join the caller's transaction (ticket.processor / raffle.processor) for consistency
- Own transaction only opened when no QueryRunner is passed

Other changes
- user.entity.ts: add lastTxHash column (VARCHAR 64, nullable)
- ticket.processor.ts: pass ticketIds.length as ticketCount to updated signature
- migration 1720000000001-AddUserLastTxHash: ALTER TABLE users ADD COLUMN IF NOT EXISTS last_tx_hash
closes #132