### PR TITLE
feat(backend): add maintenance mode toggle and 503 guard

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -20,6 +20,7 @@ ADMIN_IP_ALLOWLIST=
 
 # Server
 PORT=3001
+MAINTENANCE_MODE=false
 
 # Stellar — testnet (default) or mainnet; drives Horizon / contract defaults and indexer URL if INDEXER_URL is unset
 STELLAR_NETWORK=testnet

--- a/backend/src/api/rest/monitor/monitor.controller.ts
+++ b/backend/src/api/rest/monitor/monitor.controller.ts
@@ -1,4 +1,12 @@
-import { Controller, Get, Query, UseGuards, UsePipes } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Put,
+  Query,
+  UseGuards,
+  UsePipes,
+} from '@nestjs/common';
 import { SkipThrottle } from '../../../middleware/throttle.decorator';
 import { Public } from '../../../auth/decorators/public.decorator';
 import { AdminGuard } from './admin.guard';
@@ -16,13 +24,25 @@ import {
   type ErrorsQueryDto,
 } from './dto/errors-query.dto';
 import { createZodPipe } from '../raffles/pipes/zod-validation.pipe';
+import { z } from 'zod';
+import { MaintenanceModeService } from '../../../maintenance/maintenance-mode.service';
+import { SkipMaintenance } from '../../../maintenance/skip-maintenance.decorator';
+
+const SetMaintenanceModeSchema = z.object({
+  enabled: z.coerce.boolean(),
+});
+
+type SetMaintenanceModeDto = z.infer<typeof SetMaintenanceModeSchema>;
 
 @Controller('monitor')
 @UseGuards(AdminGuard)
 @Public()
 @SkipThrottle()
 export class MonitorController {
-  constructor(private readonly monitorService: MonitorService) {}
+  constructor(
+    private readonly monitorService: MonitorService,
+    private readonly maintenanceModeService: MaintenanceModeService,
+  ) {}
 
   @Get('jobs')
   @UsePipes(new (createZodPipe(JobsQuerySchema))())
@@ -45,5 +65,23 @@ export class MonitorController {
   @UsePipes(new (createZodPipe(ErrorsQuerySchema))())
   async getErrors(@Query() query: ErrorsQueryDto) {
     return this.monitorService.getErrors(query);
+  }
+
+  @Get('maintenance')
+  @SkipMaintenance()
+  getMaintenanceMode() {
+    return {
+      maintenanceMode: this.maintenanceModeService.isEnabled(),
+    };
+  }
+
+  @Put('maintenance')
+  @SkipMaintenance()
+  @UsePipes(new (createZodPipe(SetMaintenanceModeSchema))())
+  setMaintenanceMode(@Body() body: SetMaintenanceModeDto) {
+    this.maintenanceModeService.setEnabled(body.enabled);
+    return {
+      maintenanceMode: this.maintenanceModeService.isEnabled(),
+    };
   }
 }

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -20,6 +20,8 @@ import { GeoMiddleware } from "./middleware/geo.middleware";
 import { TikkaThrottlerGuard } from "./middleware/throttler.guard";
 import { validate } from "./config/env.schema";
 import { IndexerBackfillModule } from "./services/indexer-backfill.module";
+import { MaintenanceModeGuard } from "./maintenance/maintenance-mode.guard";
+import { MaintenanceModeModule } from "./maintenance/maintenance-mode.module";
 
 @Module({
   imports: [
@@ -80,11 +82,14 @@ import { IndexerBackfillModule } from "./services/indexer-backfill.module";
     HealthModule,
     MonitorModule,
     IndexerBackfillModule,
+    MaintenanceModeModule,
   ],
   providers: [
-    // 1. JWT guard first — authenticates the request (sets req.user)
+    // 1. Maintenance guard first — blocks requests when MAINTENANCE_MODE is enabled
+    { provide: APP_GUARD, useClass: MaintenanceModeGuard },
+    // 2. JWT guard second — authenticates the request (sets req.user)
     { provide: APP_GUARD, useClass: JwtAuthGuard },
-    // 2. Throttler guard second — rate limits by IP across all named tiers
+    // 3. Throttler guard third — rate limits by IP across all named tiers
     { provide: APP_GUARD, useClass: TikkaThrottlerGuard },
   ],
 })

--- a/backend/src/config/env.schema.spec.ts
+++ b/backend/src/config/env.schema.spec.ts
@@ -34,6 +34,7 @@ describe('env.schema validate()', () => {
     };
     const result = validate(minimal);
     expect(result.PORT).toBe(3001);
+    expect(result.MAINTENANCE_MODE).toBe(false);
     expect(result.INDEXER_URL).toBe('http://localhost:3002');
     expect(result.INDEXER_TIMEOUT_MS).toBe(5000);
     expect(result.JWT_EXPIRES_IN).toBe('7d');
@@ -71,6 +72,11 @@ describe('env.schema validate()', () => {
   it('coerces PORT from string to number', () => {
     const result = validate({ ...validEnv, PORT: '4000' });
     expect(result.PORT).toBe(4000);
+  });
+
+  it('coerces MAINTENANCE_MODE from string to boolean', () => {
+    const result = validate({ ...validEnv, MAINTENANCE_MODE: 'true' });
+    expect(result.MAINTENANCE_MODE).toBe(true);
   });
 
   it('passes through unknown system env vars', () => {

--- a/backend/src/config/env.schema.ts
+++ b/backend/src/config/env.schema.ts
@@ -56,6 +56,7 @@ const envSchemaInner = z
   .object({
     // Server
     PORT: z.coerce.number().int().positive().default(3001),
+    MAINTENANCE_MODE: z.coerce.boolean().default(false),
 
     // Supabase — required for metadata and storage
     SUPABASE_URL: z.string().url(),

--- a/backend/src/maintenance/maintenance-mode.guard.spec.ts
+++ b/backend/src/maintenance/maintenance-mode.guard.spec.ts
@@ -1,0 +1,47 @@
+import { ExecutionContext, ServiceUnavailableException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { MaintenanceModeGuard } from './maintenance-mode.guard';
+import { MaintenanceModeService } from './maintenance-mode.service';
+
+describe('MaintenanceModeGuard', () => {
+  const reflector = {
+    getAllAndOverride: jest.fn(),
+  } as unknown as Reflector;
+
+  const maintenanceModeService = {
+    isEnabled: jest.fn(),
+  } as unknown as MaintenanceModeService;
+
+  const context = {} as ExecutionContext;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('allows request when maintenance mode is disabled', () => {
+    reflector.getAllAndOverride = jest.fn().mockReturnValue(false);
+    maintenanceModeService.isEnabled = jest.fn().mockReturnValue(false);
+
+    const guard = new MaintenanceModeGuard(reflector, maintenanceModeService);
+
+    expect(guard.canActivate(context)).toBe(true);
+  });
+
+  it('allows request when endpoint is marked with SkipMaintenance', () => {
+    reflector.getAllAndOverride = jest.fn().mockReturnValue(true);
+    maintenanceModeService.isEnabled = jest.fn().mockReturnValue(true);
+
+    const guard = new MaintenanceModeGuard(reflector, maintenanceModeService);
+
+    expect(guard.canActivate(context)).toBe(true);
+  });
+
+  it('throws 503 when maintenance mode is enabled', () => {
+    reflector.getAllAndOverride = jest.fn().mockReturnValue(false);
+    maintenanceModeService.isEnabled = jest.fn().mockReturnValue(true);
+
+    const guard = new MaintenanceModeGuard(reflector, maintenanceModeService);
+
+    expect(() => guard.canActivate(context)).toThrow(ServiceUnavailableException);
+  });
+});

--- a/backend/src/maintenance/maintenance-mode.guard.ts
+++ b/backend/src/maintenance/maintenance-mode.guard.ts
@@ -1,0 +1,38 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  ServiceUnavailableException,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import {
+  SKIP_MAINTENANCE_KEY,
+} from './skip-maintenance.decorator';
+import { MaintenanceModeService } from './maintenance-mode.service';
+
+@Injectable()
+export class MaintenanceModeGuard implements CanActivate {
+  constructor(
+    private readonly reflector: Reflector,
+    private readonly maintenanceMode: MaintenanceModeService,
+  ) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const shouldSkip = this.reflector.getAllAndOverride<boolean>(
+      SKIP_MAINTENANCE_KEY,
+      [context.getHandler(), context.getClass()],
+    );
+
+    if (shouldSkip) {
+      return true;
+    }
+
+    if (!this.maintenanceMode.isEnabled()) {
+      return true;
+    }
+
+    throw new ServiceUnavailableException(
+      'Service temporarily unavailable due to maintenance mode',
+    );
+  }
+}

--- a/backend/src/maintenance/maintenance-mode.module.ts
+++ b/backend/src/maintenance/maintenance-mode.module.ts
@@ -1,0 +1,9 @@
+import { Global, Module } from '@nestjs/common';
+import { MaintenanceModeService } from './maintenance-mode.service';
+
+@Global()
+@Module({
+  providers: [MaintenanceModeService],
+  exports: [MaintenanceModeService],
+})
+export class MaintenanceModeModule {}

--- a/backend/src/maintenance/maintenance-mode.service.ts
+++ b/backend/src/maintenance/maintenance-mode.service.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+@Injectable()
+export class MaintenanceModeService {
+  private enabled: boolean;
+
+  constructor(private readonly config: ConfigService) {
+    this.enabled = this.config.get<boolean>('MAINTENANCE_MODE', false);
+  }
+
+  isEnabled(): boolean {
+    return this.enabled;
+  }
+
+  setEnabled(enabled: boolean): void {
+    this.enabled = enabled;
+  }
+}

--- a/backend/src/maintenance/skip-maintenance.decorator.ts
+++ b/backend/src/maintenance/skip-maintenance.decorator.ts
@@ -1,0 +1,5 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const SKIP_MAINTENANCE_KEY = 'skipMaintenance';
+
+export const SkipMaintenance = () => SetMetadata(SKIP_MAINTENANCE_KEY, true);


### PR DESCRIPTION
This PR closes #170

## Summary
- add MAINTENANCE_MODE env flag with schema validation and example env entry
- add a global maintenance guard that returns HTTP 503 for non-exempt routes
- add admin monitor endpoints to read/update maintenance mode at runtime
- add guard tests for enabled/disabled/skip behavior

## Notes
- error response shape follows existing global exception filter
- monitor maintenance endpoints are marked to bypass maintenance checks so mode can be switched off