### PR TITLE
feat(auth): add JWT auth guard and strategy with tests

### DIFF
--- a/backend/src/auth/guards/jwt-auth.guard.spec.ts
+++ b/backend/src/auth/guards/jwt-auth.guard.spec.ts
@@ -1,0 +1,58 @@
+import { ExecutionContext, UnauthorizedException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { JwtAuthGuard } from './jwt-auth.guard';
+
+const mockExecutionContext = (handler = {}, klass = {}) =>
+  ({
+    getHandler: () => handler,
+    getClass: () => klass,
+    switchToHttp: () => ({ getRequest: () => ({}) }),
+  }) as unknown as ExecutionContext;
+
+describe('JwtAuthGuard', () => {
+  let reflector: Reflector;
+
+  beforeEach(() => {
+    reflector = { getAllAndOverride: jest.fn() } as unknown as Reflector;
+  });
+
+  describe('canActivate', () => {
+    it('returns true without calling super when route is @Public()', () => {
+      (reflector.getAllAndOverride as jest.Mock).mockReturnValue(true);
+      const guard = new JwtAuthGuard(reflector);
+      const ctx = mockExecutionContext();
+
+      expect(guard.canActivate(ctx)).toBe(true);
+    });
+
+    it('delegates to passport when route is not @Public()', () => {
+      (reflector.getAllAndOverride as jest.Mock).mockReturnValue(false);
+      const guard = new JwtAuthGuard(reflector);
+      // Stub AuthGuard's canActivate so we don't need a real Passport setup
+      jest.spyOn(Object.getPrototypeOf(Object.getPrototypeOf(guard)), 'canActivate')
+        .mockReturnValue(true);
+
+      const ctx = mockExecutionContext();
+      expect(guard.canActivate(ctx)).toBe(true);
+    });
+  });
+
+  describe('handleRequest', () => {
+    it('returns the user when present and no error', () => {
+      const guard = new JwtAuthGuard(reflector);
+      const user = { address: 'GXYZ', iat: 1, exp: 9999999999 };
+      expect(guard.handleRequest(null, user)).toBe(user);
+    });
+
+    it('throws UnauthorizedException when user is falsy', () => {
+      const guard = new JwtAuthGuard(reflector);
+      expect(() => guard.handleRequest(null, null)).toThrow(UnauthorizedException);
+    });
+
+    it('re-throws the original error when one is provided', () => {
+      const guard = new JwtAuthGuard(reflector);
+      const err = new UnauthorizedException('token expired');
+      expect(() => guard.handleRequest(err, null)).toThrow(err);
+    });
+  });
+});

--- a/backend/src/auth/jwt.strategy.spec.ts
+++ b/backend/src/auth/jwt.strategy.spec.ts
@@ -1,0 +1,33 @@
+import { JwtPayload, JwtStrategy } from './jwt.strategy';
+
+// Prevent the strategy constructor from reading process.env / env.config
+jest.mock('../config/env.config', () => ({
+  env: { jwt: { secret: 'test-secret' } },
+}));
+
+describe('JwtStrategy', () => {
+  let strategy: JwtStrategy;
+
+  beforeEach(() => {
+    strategy = new JwtStrategy();
+  });
+
+  describe('validate', () => {
+    it('returns the expected payload shape', () => {
+      const payload: JwtPayload = {
+        address: 'GABCDE1234567890',
+        iat: 1700000000,
+        exp: 1700003600,
+      };
+      expect(strategy.validate(payload)).toEqual(payload);
+    });
+
+    it('omits undefined iat/exp gracefully', () => {
+      const payload: JwtPayload = { address: 'GABCDE1234567890' };
+      const result = strategy.validate(payload);
+      expect(result.address).toBe('GABCDE1234567890');
+      expect(result.iat).toBeUndefined();
+      expect(result.exp).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
Closes #107 

Implements NestJS JWT authentication via passport-jwt:
- JwtStrategy validates Bearer tokens and returns { address, iat, exp }
- JwtAuthGuard is registered globally; routes marked @Public() bypass auth
- /auth/nonce, /auth/verify, /auth/refresh remain public via @Public() on AuthController
- Adds unit tests for guard (public bypass, 401 on missing/invalid token) and strategy (validate shape)