### PR TITLE
feat(backend): implement Supabase metadata service CRUD and raffle merge auth

### DIFF
--- a/backend/src/api/rest/raffles/raffles.controller.ts
+++ b/backend/src/api/rest/raffles/raffles.controller.ts
@@ -93,10 +93,11 @@ export class RafflesController {
   @ApiParam({ name: "raffleId", description: "Internal raffle ID" })
   async upsertMetadata(
     @Param("raffleId", ParseIntPipe) raffleId: number,
+    @CurrentUser("address") address: string,
     @Body(new (createZodPipe(UpsertMetadataSchema))())
     payload: UpsertMetadataDto,
   ) {
-    return this.rafflesService.upsertMetadata(raffleId, payload);
+    return this.rafflesService.upsertMetadata(raffleId, payload, address);
   }
 
   /**

--- a/backend/src/api/rest/raffles/raffles.service.spec.ts
+++ b/backend/src/api/rest/raffles/raffles.service.spec.ts
@@ -1,4 +1,4 @@
-import { NotFoundException } from '@nestjs/common';
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
 import { RafflesService } from './raffles.service';
 import { IndexerService, IndexerRaffleData } from '../../../services/indexer.service';
 import { MetadataService, RaffleMetadata } from '../../../services/metadata.service';
@@ -25,6 +25,7 @@ const mockMetadata: RaffleMetadata = {
   title: 'Test Raffle',
   description: 'A test raffle',
   image_url: 'https://example.com/img.png',
+  image_urls: ['https://example.com/img.png'],
   category: 'art',
   metadata_cid: 'ipfs://abc',
   created_at: '2026-01-01T00:00:00Z',
@@ -154,11 +155,28 @@ describe('RafflesService', () => {
   describe('upsertMetadata', () => {
     it('delegates to metadataService.upsertMetadata', async () => {
       const payload = { title: 'New Title' };
+      indexerService.getRaffle.mockResolvedValue(mockRaffle);
       metadataService.upsertMetadata.mockResolvedValue({ ...mockMetadata, title: 'New Title' });
 
-      await service.upsertMetadata(1, payload);
+      await service.upsertMetadata(1, payload, 'GABC123');
 
       expect(metadataService.upsertMetadata).toHaveBeenCalledWith(1, payload);
+    });
+
+    it('throws NotFoundException when raffle is missing in indexer', async () => {
+      indexerService.getRaffle.mockResolvedValue(null);
+
+      await expect(
+        service.upsertMetadata(99, { title: 'Nope' }, 'GABC123'),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws ForbiddenException when requester is not raffle creator', async () => {
+      indexerService.getRaffle.mockResolvedValue(mockRaffle);
+
+      await expect(
+        service.upsertMetadata(1, { title: 'Nope' }, 'GOTHER999'),
+      ).rejects.toThrow(ForbiddenException);
     });
   });
 });

--- a/backend/src/api/rest/raffles/raffles.service.ts
+++ b/backend/src/api/rest/raffles/raffles.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
 import {
   MetadataService,
   RaffleMetadata,
@@ -32,6 +32,7 @@ export interface RaffleDetailResponse {
   title?: string;
   description?: string;
   image_url?: string | null;
+  image_urls?: string[] | null;
   category?: string | null;
 }
 
@@ -61,7 +62,22 @@ export class RafflesService {
   /**
    * Create or update raffle metadata (title, description, image_url, category, metadata_cid).
    */
-  async upsertMetadata(raffleId: number, payload: UpsertMetadataPayload) {
+  async upsertMetadata(
+    raffleId: number,
+    payload: UpsertMetadataPayload,
+    requesterAddress: string,
+  ) {
+    const raffle = await this.indexerService.getRaffle(raffleId);
+    if (!raffle) {
+      throw new NotFoundException(`Raffle ${raffleId} not found`);
+    }
+
+    if (raffle.creator.toLowerCase() !== requesterAddress.toLowerCase()) {
+      throw new ForbiddenException(
+        `Only raffle creator ${raffle.creator} can update metadata for raffle ${raffleId}`,
+      );
+    }
+
     return this.metadataService.upsertMetadata(raffleId, payload);
   }
 
@@ -108,6 +124,7 @@ export class RafflesService {
       response.title = metadata.title;
       response.description = metadata.description;
       response.image_url = metadata.image_url;
+      response.image_urls = metadata.image_urls;
       response.category = metadata.category;
       // Prefer metadata_cid from metadata if contract doesn't have it
       if (!response.metadata_cid && metadata.metadata_cid) {

--- a/backend/src/services/metadata.service.spec.ts
+++ b/backend/src/services/metadata.service.spec.ts
@@ -4,7 +4,7 @@ describe('MetadataService', () => {
   let service: MetadataService;
   let queryBuilder: {
     select: jest.Mock;
-    or: jest.Mock;
+    textSearch: jest.Mock;
     range: jest.Mock;
     eq: jest.Mock;
     maybeSingle: jest.Mock;
@@ -16,7 +16,7 @@ describe('MetadataService', () => {
   beforeEach(() => {
     queryBuilder = {
       select: jest.fn().mockReturnThis(),
-      or: jest.fn().mockReturnThis(),
+      textSearch: jest.fn().mockReturnThis(),
       range: jest.fn().mockResolvedValue({ data: [], error: null, count: 0 }),
       eq: jest.fn().mockReturnThis(),
       maybeSingle: jest.fn().mockResolvedValue({ data: null, error: null }),
@@ -31,11 +31,16 @@ describe('MetadataService', () => {
     service = new MetadataService(client as any);
   });
 
-  it('searches metadata with ilike pattern', async () => {
+  it('searches metadata using full-text search vector', async () => {
     await service.searchMetadata('raffle');
 
-    expect(queryBuilder.or).toHaveBeenCalledWith(
-      expect.stringContaining('%raffle%'),
+    expect(queryBuilder.textSearch).toHaveBeenCalledWith(
+      'search_vector',
+      'raffle',
+      expect.objectContaining({
+        config: 'english',
+        type: 'websearch',
+      }),
     );
   });
 
@@ -54,6 +59,27 @@ describe('MetadataService', () => {
 
     expect(queryBuilder.upsert).toHaveBeenCalledWith(
       expect.objectContaining({ category: 'Art' }),
+      expect.any(Object),
+    );
+  });
+
+  it('normalizes image_urls before upserting metadata', async () => {
+    const selectBuilder = {
+      single: jest.fn().mockResolvedValue({
+        data: { raffle_id: 1, image_urls: ['https://a.com/x.png'] },
+        error: null,
+      }),
+    };
+    queryBuilder.upsert.mockReturnValue({
+      select: jest.fn().mockReturnValue(selectBuilder),
+    });
+
+    await service.upsertMetadata(1, {
+      image_urls: [' https://a.com/x.png ', '   ', ''],
+    });
+
+    expect(queryBuilder.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({ image_urls: ['https://a.com/x.png'] }),
       expect.any(Object),
     );
   });

--- a/backend/src/services/metadata.service.ts
+++ b/backend/src/services/metadata.service.ts
@@ -8,6 +8,7 @@ export interface RaffleMetadata {
   title: string;
   description: string;
   image_url: string | null;
+  image_urls: string[] | null;
   category: string | null;
   metadata_cid: string | null;
   created_at: string;
@@ -24,6 +25,7 @@ export interface UpsertMetadataPayload {
   title?: string;
   description?: string;
   image_url?: string | null;
+  image_urls?: string[] | null;
   category?: string | null;
   metadata_cid?: string | null;
 }
@@ -123,9 +125,17 @@ export class MetadataService {
     raffleId: number,
     payload: UpsertMetadataPayload,
   ): Promise<RaffleMetadata> {
+    const normalizedImageUrls = payload.image_urls
+      ?.map((url) => url?.trim())
+      .filter((url): url is string => Boolean(url));
+
     const row = {
       raffle_id: raffleId,
       ...payload,
+      image_urls:
+        normalizedImageUrls && normalizedImageUrls.length > 0
+          ? normalizedImageUrls
+          : null,
       category: payload.category?.trim() || null,
       updated_at: new Date().toISOString(),
     };


### PR DESCRIPTION
Pr closes  #110 

## Summary
- added creator authorization for raffle metadata updates in POST /raffles/:raffleId/metadata
- validated raffle existence and ownership via indexer before allowing metadata upsert
- threaded authenticated wallet address from controller to raffles service
- preserved merged raffle detail response (on-chain indexer data + off-chain Supabase metadata)

## Testing
- npm test -- raffles.service.spec.ts metadata.service.spec.ts