### PR TITLE
feat(indexer): implement RaffleProcessor for RaffleCreated, RaffleFin…

### DIFF
--- a/indexer/src/database/entities/raffle.entity.ts
+++ b/indexer/src/database/entities/raffle.entity.ts
@@ -70,6 +70,10 @@ export class RaffleEntity {
   @Column({ type: "varchar", length: 56, nullable: true, name: "winner" })
   winner!: string | null;
 
+  /** Winning ticket ID — null until raffle is FINALIZED. */
+  @Column({ type: "integer", nullable: true, name: "winning_ticket_id" })
+  winningTicketId!: number | null;
+
   /** Prize amount as a string — null until finalized. */
   @Column({
     type: "varchar",

--- a/indexer/src/database/migrations/1720000000002-AddWinningTicketId.ts
+++ b/indexer/src/database/migrations/1720000000002-AddWinningTicketId.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner, TableColumn } from "typeorm";
+
+export class AddWinningTicketId1720000000002 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.addColumn(
+      "raffles",
+      new TableColumn({
+        name: "winning_ticket_id",
+        type: "integer",
+        isNullable: true,
+        comment: "Contract-assigned ticket ID of the winner — null until FINALIZED",
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropColumn("raffles", "winning_ticket_id");
+  }
+}

--- a/indexer/src/ingestor/ingestion-dispatcher.service.ts
+++ b/indexer/src/ingestor/ingestion-dispatcher.service.ts
@@ -46,6 +46,8 @@ export class IngestionDispatcherService {
             event.raffle_id,
             event.creator,
             ledger,
+            txHash,
+            event.params,
           );
 
         case "TicketPurchased":
@@ -62,7 +64,10 @@ export class IngestionDispatcherService {
           return await this.raffleProcessor.handleRaffleFinalized(
             event.raffle_id,
             event.winner,
+            event.winning_ticket_id,
             event.prize_amount,
+            ledger,
+            txHash,
           );
 
         case "RaffleCancelled":

--- a/indexer/src/processors/raffle.processor.ts
+++ b/indexer/src/processors/raffle.processor.ts
@@ -4,7 +4,7 @@ import { DataSource, QueryRunner } from "typeorm";
 import { UserProcessor } from "./user.processor";
 import { RaffleEventEntity } from "../database/entities/raffle-event.entity";
 import { RaffleEntity, RaffleStatus } from "../database/entities/raffle.entity";
-import { WebhookService, WebhookPayload } from "../webhooks/webhook.service";
+import { WebhookService } from "../webhooks/webhook.service";
 
 @Injectable()
 export class RaffleProcessor {
@@ -19,111 +19,202 @@ export class RaffleProcessor {
 
   /**
    * Called when a RaffleCreated event is indexed.
-   * Invalidates active raffles list cache.
+   *
+   * Upserts the raffle row with all params and status OPEN.
+   * Idempotent: the insert uses orIgnore() keyed on raffle_id, so replaying
+   * the same event is a no-op. The raffle_events audit row is keyed on txHash.
    */
   async handleRaffleCreated(
     raffleId: number,
-    creator?: string,
-    ledger?: number,
+    creator: string,
+    ledger: number,
+    txHash: string,
+    params: {
+      ticket_price: string;
+      max_tickets: number;
+      end_time: number;
+      asset: string;
+      metadata_cid: string;
+      allow_multiple: boolean;
+    },
   ): Promise<QueryRunner> {
-    this.logger.log(`Handling RaffleCreated for ${raffleId}`);
+    this.logger.log(`Handling RaffleCreated for raffle ${raffleId} (tx ${txHash})`);
     const runner = this.dataSource.createQueryRunner();
     await runner.connect();
     await runner.startTransaction();
 
     try {
-      if (creator && typeof ledger === "number") {
-        await this.userProcessor.handleRaffleCreated(creator, ledger, runner);
-      }
+      // 1. Upsert raffle row — idempotent via orIgnore on PK
+      await runner.manager
+        .createQueryBuilder()
+        .insert()
+        .into(RaffleEntity)
+        .values({
+          id: raffleId,
+          creator,
+          status: RaffleStatus.OPEN,
+          ticketPrice: params.ticket_price,
+          asset: params.asset,
+          maxTickets: params.max_tickets,
+          endTime: params.end_time.toString(),
+          metadataCid: params.metadata_cid || null,
+          createdLedger: ledger,
+          winner: null,
+          winningTicketId: null,
+          prizeAmount: null,
+          finalizedLedger: null,
+        })
+        .orIgnore()
+        .execute();
 
-      // Invalidate caches
-      await this.cacheService.invalidateActiveRaffles();
-
-      // Dispatch webhook after successful DB write
-      if (creator && typeof ledger === "number") {
-        await this.webhookService.dispatchEvent({
-          eventType: "RaffleCreated",
+      // 2. Audit event — idempotent via unique constraint on txHash
+      await runner.manager
+        .createQueryBuilder()
+        .insert()
+        .into(RaffleEventEntity)
+        .values({
           raffleId,
-          timestamp: new Date(),
-          data: { creator, ledger },
-        });
-      }
+          eventType: "RaffleCreated",
+          ledger,
+          txHash,
+          payloadJson: { raffle_id: raffleId, creator, params },
+        })
+        .orIgnore()
+        .execute();
+
+      // 3. Ensure creator has a user row
+      await this.userProcessor.handleRaffleCreated(creator, ledger, runner);
+
+      await this.cacheService.invalidateActiveRaffles();
+      await this.cacheService.invalidatePlatformStats();
+
+      await this.webhookService.dispatchEvent({
+        eventType: "RaffleCreated",
+        raffleId,
+        timestamp: new Date(),
+        data: { creator, ledger },
+      });
 
       return runner;
     } catch (e) {
       await runner.rollbackTransaction();
       await runner.release();
+      this.logger.error(`Error processing RaffleCreated for raffle ${raffleId} (tx ${txHash})`, e as any);
       throw e;
     }
-    // Invalidate caches
-    await this.cacheService.invalidateActiveRaffles();
-    await this.cacheService.invalidatePlatformStats();
   }
 
   /**
    * Called when a RaffleFinalized event is indexed.
-   * Invalidates raffle detail and leaderboard.
+   *
+   * Updates the raffle row: winner, winning_ticket_id, prize_amount, status → FINALIZED.
+   * Idempotent: the raffle_events audit row is keyed on txHash; the raffle UPDATE is
+   * conditional on the row not already being FINALIZED.
    */
   async handleRaffleFinalized(
     raffleId: number,
-    winner?: string,
-    prizeAmount?: string,
+    winner: string,
+    winningTicketId: number,
+    prizeAmount: string,
+    ledger: number,
+    txHash: string,
   ): Promise<QueryRunner> {
-    this.logger.log(`Handling RaffleFinalized for ${raffleId}`);
+    this.logger.log(`Handling RaffleFinalized for raffle ${raffleId}, winner ${winner} (tx ${txHash})`);
     const runner = this.dataSource.createQueryRunner();
     await runner.connect();
     await runner.startTransaction();
 
     try {
-      if (winner) {
-        await this.userProcessor.handleRaffleFinalized(
-          raffleId,
+      // 1. Update raffle row — conditional so replays are no-ops
+      await runner.manager
+        .createQueryBuilder()
+        .update(RaffleEntity)
+        .set({
+          status: RaffleStatus.FINALIZED,
           winner,
-          prizeAmount ?? "0",
-          runner,
-        );
-      }
+          winningTicketId,
+          prizeAmount,
+          finalizedLedger: ledger,
+        })
+        .where("id = :raffleId AND status != :finalized", {
+          raffleId,
+          finalized: RaffleStatus.FINALIZED,
+        })
+        .execute();
 
-      // Invalidate caches
+      // 2. Audit event — idempotent via unique constraint on txHash
+      await runner.manager
+        .createQueryBuilder()
+        .insert()
+        .into(RaffleEventEntity)
+        .values({
+          raffleId,
+          eventType: "RaffleFinalized",
+          ledger,
+          txHash,
+          payloadJson: { raffle_id: raffleId, winner, winning_ticket_id: winningTicketId, prize_amount: prizeAmount },
+        })
+        .orIgnore()
+        .execute();
+
+      // 3. Update winner stats
+      await this.userProcessor.handleRaffleFinalized(raffleId, winner, prizeAmount, runner);
+
       await this.cacheService.invalidateRaffleDetail(raffleId.toString());
       await this.cacheService.invalidateLeaderboard();
+      await this.cacheService.invalidatePlatformStats();
 
-      // Dispatch webhook after successful DB write
-      if (winner) {
-        await this.webhookService.dispatchEvent({
-          eventType: "RaffleFinalized",
-          raffleId,
-          timestamp: new Date(),
-          data: { winner, prizeAmount },
-        });
-      }
+      await this.webhookService.dispatchEvent({
+        eventType: "RaffleFinalized",
+        raffleId,
+        timestamp: new Date(),
+        data: { winner, winningTicketId, prizeAmount },
+      });
 
       return runner;
     } catch (e) {
       await runner.rollbackTransaction();
       await runner.release();
+      this.logger.error(`Error processing RaffleFinalized for raffle ${raffleId} (tx ${txHash})`, e as any);
       throw e;
     }
-    // Invalidate caches
-    await this.cacheService.invalidateRaffleDetail(raffleId.toString());
-    await this.cacheService.invalidateLeaderboard();
-    await this.cacheService.invalidatePlatformStats();
   }
 
+  /**
+   * Called when a RaffleCancelled event is indexed.
+   *
+   * Updates raffle status to CANCELLED.
+   * Idempotent: the raffle_events audit row is keyed on txHash; the raffle UPDATE
+   * is conditional on the row not already being CANCELLED.
+   */
   async handleRaffleCancelled(
     raffleId: number,
     reason: string,
     ledger: number,
     txHash: string,
   ): Promise<QueryRunner> {
-    this.logger.log(`Handling RaffleCancelled for ${raffleId}`);
-    const queryRunner = this.dataSource.createQueryRunner();
-
-    await queryRunner.connect();
-    await queryRunner.startTransaction();
+    this.logger.log(`Handling RaffleCancelled for raffle ${raffleId} (tx ${txHash})`);
+    const runner = this.dataSource.createQueryRunner();
+    await runner.connect();
+    await runner.startTransaction();
 
     try {
-      await queryRunner.manager
+      // 1. Update raffle row — conditional so replays are no-ops
+      await runner.manager
+        .createQueryBuilder()
+        .update(RaffleEntity)
+        .set({
+          status: RaffleStatus.CANCELLED,
+          finalizedLedger: ledger,
+        })
+        .where("id = :raffleId AND status != :cancelled", {
+          raffleId,
+          cancelled: RaffleStatus.CANCELLED,
+        })
+        .execute();
+
+      // 2. Audit event — idempotent via unique constraint on txHash
+      await runner.manager
         .createQueryBuilder()
         .insert()
         .into(RaffleEventEntity)
@@ -132,36 +223,20 @@ export class RaffleProcessor {
           eventType: "RaffleCancelled",
           ledger,
           txHash,
-          payloadJson: {
-            raffle_id: raffleId,
-            reason,
-          },
+          payloadJson: { raffle_id: raffleId, reason },
         })
         .orIgnore()
-        .execute();
-
-      await queryRunner.manager
-        .createQueryBuilder()
-        .update(RaffleEntity)
-        .set({
-          status: RaffleStatus.CANCELLED,
-          finalizedLedger: ledger,
-        })
-        .where("id = :raffleId", { raffleId })
         .execute();
 
       await this.cacheService.invalidateRaffleDetail(raffleId.toString());
       await this.cacheService.invalidateActiveRaffles();
 
-      return queryRunner;
-    } catch (error) {
-      await queryRunner.rollbackTransaction();
-      await queryRunner.release();
-      this.logger.error(
-        `Error processing RaffleCancelled for txHash ${txHash}`,
-        error as any,
-      );
-      throw error;
+      return runner;
+    } catch (e) {
+      await runner.rollbackTransaction();
+      await runner.release();
+      this.logger.error(`Error processing RaffleCancelled for raffle ${raffleId} (tx ${txHash})`, e as any);
+      throw e;
     }
   }
 }


### PR DESCRIPTION
Closes #130 

- handleRaffleCreated: inserts raffle row with all params (ticket_price, max_tickets, end_time, asset, metadata_cid) and status OPEN using orIgnore() on PK for idempotency; writes audit row to raffle_events
- handleRaffleFinalized: updates raffle with winner, winning_ticket_id, prize_amount, status FINALIZED, finalized_ledger; conditional on status != FINALIZED so replays are no-ops; updates winner stats via UserProcessor within the same transaction
- handleRaffleCancelled: conditional update to CANCELLED + audit row; removed dead unreachable code from prior implementation
- Add winningTicketId nullable field to RaffleEntity and corresponding migration (1720000000002-AddWinningTicketId)
- Update IngestionDispatcherService to pass txHash + params to handleRaffleCreated and winning_ticket_id + ledger + txHash to handleRaffleFinalized