### PR TITLE
feat(oracle): implement VRF raffleId encoding for high-stakes randomn…

### DIFF
--- a/oracle/src/queue/randomness.worker.ts
+++ b/oracle/src/queue/randomness.worker.ts
@@ -78,7 +78,7 @@ export class RandomnessWorker {
       const method = this.determineMethod(finalPrizeAmount);
       this.logger.log(`Raffle ${raffleId}: prize=${finalPrizeAmount} XLM, method=${method}`);
 
-      const randomness = await this.computeRandomness(method, requestId);
+      const randomness = await this.computeRandomness(method, requestId, raffleId);
       const result = await this.txSubmitter.submitRandomness(raffleId, randomness);
 
       if (!result.success) {
@@ -136,7 +136,7 @@ export class RandomnessWorker {
       }
 
       const method = this.determineMethod(finalPrizeAmount);
-      const randomness = await this.computeRandomness(method, requestId);
+      const randomness = await this.computeRandomness(method, requestId, raffleId);
 
       const localOracle = this.oracleRegistry.getLocalOracle();
       if (!localOracle) {
@@ -212,11 +212,11 @@ export class RandomnessWorker {
       : RandomnessMethod.PRNG;
   }
 
-  private async computeRandomness(method: RandomnessMethod, requestId: string) {
+  private async computeRandomness(method: RandomnessMethod, requestId: string, raffleId?: number) {
     if (method === RandomnessMethod.VRF) {
-      return await this.vrfService.compute(requestId);
+      return await this.vrfService.compute(requestId, raffleId);
     } else {
-      return await this.prngService.compute(requestId);
+      return await this.prngService.compute(requestId, raffleId);
     }
   }
 }

--- a/oracle/src/randomness/ed25519-sha256.vrf-provider.ts
+++ b/oracle/src/randomness/ed25519-sha256.vrf-provider.ts
@@ -8,8 +8,11 @@ import * as crypto from 'crypto';
 /**
  * Ed25519-SHA-256 VRF provider.
  *
- * Proof  = Ed25519 deterministic signature over the requestId (RFC 8032).
+ * Proof  = Ed25519 deterministic signature over encoded input (RFC 8032).
  * Output = SHA-256(proof) — uniformly distributed 32-byte seed.
+ *
+ * Input encoding: requestId_bytes [|| raffleId_u32_BE]
+ * Mirrors the PRNG service encoding so both paths are consistent.
  *
  * Adding a new algorithm
  * ----------------------
@@ -24,25 +27,22 @@ export class Ed25519Sha256VrfProvider implements IVrfProvider {
 
   constructor(private readonly keyService: KeyService) {}
 
-  async compute(requestId: string): Promise<RandomnessResult> {
-    const msg = Buffer.from(requestId, 'utf-8');
-    
-    // Use KeyService.sign() for HSM compatibility
+  async compute(requestId: string, raffleId?: number): Promise<RandomnessResult> {
+    const msg = this.encodeInput(requestId, raffleId);
     const proof = await this.keyService.sign(msg);
     const seed = crypto.createHash('sha256').update(proof).digest();
-    
     return {
       seed: Buffer.from(seed).toString('hex'),
       proof: Buffer.from(proof).toString('hex'),
     };
   }
 
-  verify(publicKey: string | Buffer, requestId: string, proof: string, seed: string): boolean {
+  verify(publicKey: string | Buffer, requestId: string, proof: string, seed: string, raffleId?: number): boolean {
     try {
       const pubKeyBuf = typeof publicKey === 'string' ? Buffer.from(publicKey, 'hex') : publicKey;
       const proofBuf = Buffer.from(proof, 'hex');
       const seedBuf = Buffer.from(seed, 'hex');
-      const msgBuf = Buffer.from(requestId, 'utf-8');
+      const msgBuf = this.encodeInput(requestId, raffleId);
 
       if (!ed25519.verify(proofBuf, msgBuf, pubKeyBuf)) return false;
       const expectedSeed = crypto.createHash('sha256').update(proofBuf).digest();
@@ -51,5 +51,14 @@ export class Ed25519Sha256VrfProvider implements IVrfProvider {
       this.logger.error(`VRF verification failed: ${error.message}`);
       return false;
     }
+  }
+
+  /** Encodes VRF input: requestId_bytes [|| raffleId_u32_BE] */
+  private encodeInput(requestId: string, raffleId?: number): Buffer {
+    const reqBuf = Buffer.from(requestId, 'utf-8');
+    if (raffleId === undefined) return reqBuf;
+    const idBuf = Buffer.allocUnsafe(4);
+    idBuf.writeUInt32BE(raffleId >>> 0, 0);
+    return Buffer.concat([reqBuf, idBuf]);
   }
 }

--- a/oracle/src/randomness/vrf.interface.ts
+++ b/oracle/src/randomness/vrf.interface.ts
@@ -6,6 +6,6 @@ export enum VrfAlgorithm {
 
 export interface IVrfProvider {
   readonly algorithm: VrfAlgorithm;
-  compute(requestId: string): Promise<RandomnessResult>;
-  verify(publicKey: string | Buffer, requestId: string, proof: string, seed: string): boolean;
+  compute(requestId: string, raffleId?: number): Promise<RandomnessResult>;
+  verify(publicKey: string | Buffer, requestId: string, proof: string, seed: string, raffleId?: number): boolean;
 }

--- a/oracle/src/randomness/vrf.service.ts
+++ b/oracle/src/randomness/vrf.service.ts
@@ -11,7 +11,8 @@ import { Ed25519Sha256VrfProvider } from './ed25519-sha256.vrf-provider';
  * VrfService — Verifiable Random Function computation for high-stakes raffles.
  *
  * When prize >= 500 XLM, uses Ed25519 VRF for cryptographic security:
- *   proof = ed25519.sign(requestId, oraclePrivateKey)
+ *   input = requestId_bytes [|| raffleId_u32_BE]
+ *   proof = ed25519.sign(input, oraclePrivateKey)
  *   seed  = SHA-256(proof)
  *
  * The contract verifies the proof using the oracle's public key, ensuring
@@ -33,11 +34,13 @@ export class VrfService {
 
   /**
    * Compute VRF output using the oracle's private key.
-   * Used in single-oracle mode.
+   *
+   * @param requestId  Unique request identifier from the RandomnessRequested event.
+   * @param raffleId   Optional raffle ID — mixed into the input so two raffles
+   *                   with the same requestId still produce distinct seeds.
    */
-  async compute(requestId: string): Promise<RandomnessResult> {
-    // Delegate to the Ed25519 provider which now uses KeyService.sign()
-    return this.ed25519Provider.compute(requestId);
+  async compute(requestId: string, raffleId?: number): Promise<RandomnessResult> {
+    return this.ed25519Provider.compute(requestId, raffleId);
   }
 
   /**
@@ -45,7 +48,7 @@ export class VrfService {
    * Core VRF computation:
    *   proof = ed25519.sign(requestId, privateKey)
    *   seed  = SHA-256(proof)
-   * 
+   *
    * @deprecated This method exposes raw private keys. Use compute() instead.
    */
   computeWithKey(requestId: string, privateKey: Buffer): RandomnessResult {
@@ -63,16 +66,15 @@ export class VrfService {
 
   /**
    * Compute VRF output for a specific oracle in multi-oracle mode.
-   * Retrieves the oracle's keypair and uses its private key.
    */
-  async computeForOracle(requestId: string, oracleId: string): Promise<RandomnessResult> {
+  async computeForOracle(requestId: string, oracleId: string, raffleId?: number): Promise<RandomnessResult> {
     const oracle = this.oracleRegistry.getOracle(oracleId);
     if (!oracle) {
       throw new Error(`Oracle not found: ${oracleId}`);
     }
 
     if (oracleId === this.oracleRegistry.getLocalOracleId()) {
-      return this.compute(requestId);
+      return this.compute(requestId, raffleId);
     }
 
     throw new Error('computeForOracle only supported for local oracle in multi-oracle mode currently');
@@ -81,6 +83,7 @@ export class VrfService {
   /**
    * Verify VRF output using the oracle's public key.
    * Anyone can verify the output is authentic and unmanipulated.
+   *
    * @returns true if proof is valid and seed is correct; false otherwise
    */
   verify(
@@ -88,25 +91,8 @@ export class VrfService {
     requestId: string,
     proof: string,
     seed: string,
+    raffleId?: number,
   ): boolean {
-    try {
-      const pubKeyBuf = typeof publicKey === 'string' ? Buffer.from(publicKey, 'hex') : publicKey;
-      const proofBuf = Buffer.from(proof, 'hex');
-      const seedBuf = Buffer.from(seed, 'hex');
-      const msgBuf = Buffer.from(requestId, 'utf-8');
-
-      // Verify the proof is a valid Ed25519 signature
-      const isSignatureValid = ed25519.verify(proofBuf, msgBuf, pubKeyBuf);
-      if (!isSignatureValid) {
-        return false;
-      }
-
-      // Verify the seed is SHA-256(proof)
-      const expectedSeed = crypto.createHash('sha256').update(proofBuf).digest();
-      return Buffer.compare(expectedSeed, seedBuf) === 0;
-    } catch (error) {
-      this.logger.error(`VRF verification failed: ${error.message}`);
-      return false;
-    }
+    return this.ed25519Provider.verify(publicKey, requestId, proof, seed, raffleId);
   }
 }

--- a/oracle/test/vrf.service.spec.ts
+++ b/oracle/test/vrf.service.spec.ts
@@ -68,6 +68,32 @@ describe('VrfService', () => {
       const { proof } = await service.compute('test-req');
       expect(proof).toMatch(/^[0-9a-f]{128}$/);
     });
+
+    it('should produce different seed when raffleId is included', async () => {
+      const requestId = 'raffle-id-test';
+      const withoutRaffleId = await service.compute(requestId);
+      const withRaffleId = await service.compute(requestId, 42);
+
+      expect(withoutRaffleId.seed).not.toBe(withRaffleId.seed);
+      expect(withoutRaffleId.proof).not.toBe(withRaffleId.proof);
+    });
+
+    it('should produce different seeds for different raffleIds with same requestId', async () => {
+      const requestId = 'shared-request';
+      const raffle1 = await service.compute(requestId, 1);
+      const raffle2 = await service.compute(requestId, 2);
+
+      expect(raffle1.seed).not.toBe(raffle2.seed);
+    });
+
+    it('should be deterministic with same requestId and raffleId', async () => {
+      const requestId = 'deterministic-raffle';
+      const result1 = await service.compute(requestId, 99);
+      const result2 = await service.compute(requestId, 99);
+
+      expect(result1.seed).toBe(result2.seed);
+      expect(result1.proof).toBe(result2.proof);
+    });
   });
 
   describe('VRF verification', () => {
@@ -122,6 +148,24 @@ describe('VrfService', () => {
 
       const isValid = service.verify(invalidPublicKey, requestId, proof, seed);
       expect(isValid).toBe(false);
+    });
+
+    it('should verify proof computed with raffleId', async () => {
+      const requestId = 'raffle-verify-test';
+      const raffleId = 42;
+      const { seed, proof } = await service.compute(requestId, raffleId);
+      const publicKey = (await keyService.getPublicKeyBuffer()).toString('hex');
+
+      expect(service.verify(publicKey, requestId, proof, seed, raffleId)).toBe(true);
+    });
+
+    it('should reject verify when raffleId mismatch', async () => {
+      const requestId = 'raffle-mismatch-test';
+      const { seed, proof } = await service.compute(requestId, 1);
+      const publicKey = (await keyService.getPublicKeyBuffer()).toString('hex');
+
+      // Proof was computed with raffleId=1, verify with raffleId=2 must fail
+      expect(service.verify(publicKey, requestId, proof, seed, 2)).toBe(false);
     });
   });
 


### PR DESCRIPTION
closes #138 

Add an optional raffleId parameter to VRF input encoding so two raffles sharing the same requestId produce distinct seeds. Input is encoded as requestId_bytes [|| raffleId_u32_BE], mirroring the PRNG service. Wire raffleId through VrfService.compute/verify, computeForOracle, and RandomnessWorker so both single- and multi-oracle paths pass it along. Add 5 new test cases covering determinism, isolation, and verify mismatch.