### PR TITLE
feat: integrate @sentry/nestjs for centralized error tracking (#156)

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -13,7 +13,8 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
-    "@sentry/node": "8.55.1",
+    "@sentry/nestjs": "8.55.1",
+    "@sentry/profiling-node": "8.55.1",
     "@fastify/helmet": "^13.0.2",
     "@fastify/multipart": "^9.0.0",
     "@nestjs/common": "^10.4.0",

--- a/backend/src/common/filters/base-exception.filter.ts
+++ b/backend/src/common/filters/base-exception.filter.ts
@@ -6,6 +6,7 @@ import {
   HttpStatus,
   Logger,
 } from '@nestjs/common';
+import * as Sentry from '@sentry/nestjs';
 import { FastifyReply, FastifyRequest } from 'fastify';
 
 export interface ErrorResponse {
@@ -65,6 +66,7 @@ export class BaseExceptionFilter implements ExceptionFilter {
       'Unhandled exception',
       exception instanceof Error ? exception.stack : String(exception),
     );
+    Sentry.captureException(exception);
 
     return {
       statusCode: HttpStatus.INTERNAL_SERVER_ERROR,

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -10,6 +10,7 @@ import { AppModule } from "./app.module";
 import { configureSecurity } from "./bootstrap";
 import { MAX_UPLOAD_BYTES } from "./config/upload.config";
 import { RequestLoggingInterceptor } from "./middleware/request-logging.interceptor";
+import { SentryInterceptor } from "./sentry/sentry.interceptor";
 import { BaseExceptionFilter } from "./common/filters/base-exception.filter";
 import { initSentry } from "./sentry/sentry";
 import { Logger as PinoLogger } from "nestjs-pino";
@@ -45,7 +46,7 @@ async function bootstrap() {
     },
   });
 
-  app.useGlobalInterceptors(new RequestLoggingInterceptor());
+  app.useGlobalInterceptors(new SentryInterceptor(), new RequestLoggingInterceptor());
   app.useGlobalFilters(new BaseExceptionFilter());
 
   await app.listen(process.env.PORT ?? 3001, "0.0.0.0");

--- a/backend/src/sentry/sentry.interceptor.ts
+++ b/backend/src/sentry/sentry.interceptor.ts
@@ -1,0 +1,16 @@
+import { Injectable, NestInterceptor, ExecutionContext, CallHandler } from '@nestjs/common';
+import { Observable, throwError } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+import * as Sentry from '@sentry/nestjs';
+
+@Injectable()
+export class SentryInterceptor implements NestInterceptor {
+  intercept(_context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    return next.handle().pipe(
+      catchError((error) => {
+        Sentry.captureException(error);
+        return throwError(() => error);
+      }),
+    );
+  }
+}

--- a/backend/src/sentry/sentry.spec.ts
+++ b/backend/src/sentry/sentry.spec.ts
@@ -1,5 +1,5 @@
 import * as fc from 'fast-check';
-import * as Sentry from '@sentry/node';
+import * as Sentry from '@sentry/nestjs';
 import { Logger } from '@nestjs/common';
 import {
   buildSentryOptions,

--- a/backend/src/sentry/sentry.ts
+++ b/backend/src/sentry/sentry.ts
@@ -1,4 +1,5 @@
-import * as Sentry from '@sentry/node';
+import * as Sentry from '@sentry/nestjs';
+import { nodeProfilingIntegration } from '@sentry/profiling-node';
 import { Logger } from '@nestjs/common';
 
 export interface IngestionErrorContext {
@@ -35,6 +36,8 @@ export function buildSentryOptions(env: {
     dsn,
     environment: env.NODE_ENV ?? 'development',
     tracesSampleRate,
+    integrations: [nodeProfilingIntegration()],
+    profilesSampleRate: 1.0,
   };
 }
 


### PR DESCRIPTION
closes #156 

- Replace @sentry/node with @sentry/nestjs + @sentry/profiling-node
- Add nodeProfilingIntegration to Sentry init options
- Create SentryInterceptor to capture all unhandled route exceptions
- Register SentryInterceptor globally in main.ts
- Capture 500-level errors in BaseExceptionFilter