### PR TITLE
feat(oracle): expose public VRF proof verification and oracle key endpoints

### DIFF
--- a/oracle/docs/VRF_VERIFICATION.md
+++ b/oracle/docs/VRF_VERIFICATION.md
@@ -1,0 +1,90 @@
+# VRF Proof Verification
+
+This oracle uses an Ed25519-SHA256 VRF for high-stakes raffles:
+
+- `proof = Ed25519Sign(requestId, oraclePrivateKey)`
+- `seed = SHA-256(proof)`
+
+Any third party can verify proofs using the public API or fully offline.
+
+## Public Endpoints
+
+### `GET /oracle/public-key`
+
+Returns the current oracle Ed25519 public key in two encodings:
+
+```json
+{
+  "hex": "8f...32-byte-hex...",
+  "base64": "j/...=="
+}
+```
+
+### `POST /oracle/verify`
+
+Request:
+
+```json
+{
+  "requestId": "raffle-123-request-456",
+  "proof": "aabbcc... (64-byte signature in hex)",
+  "publicKey": "8f... (32-byte public key in hex)"
+}
+```
+
+Response when valid:
+
+```json
+{
+  "valid": true,
+  "seed": "d4f8... (32-byte SHA-256 seed in hex)"
+}
+```
+
+Response when invalid/tampered:
+
+```json
+{
+  "valid": false
+}
+```
+
+## Offline Verification (No Oracle API Needed)
+
+1. Convert values:
+   - `requestId` as UTF-8 bytes
+   - `proof` from hex to bytes
+   - `publicKey` from hex to bytes
+2. Verify signature:
+   - `Ed25519.verify(proof, requestIdBytes, publicKeyBytes)` must be `true`
+3. Derive seed:
+   - `seed = SHA-256(proofBytes)` (hex output)
+4. If step 2 fails, the proof is invalid and must be rejected.
+
+## Example (Node.js / @noble/curves)
+
+```ts
+import { ed25519 } from '@noble/curves/ed25519';
+import * as crypto from 'crypto';
+
+function verifyVrfProof(input: {
+  requestId: string;
+  proofHex: string;
+  publicKeyHex: string;
+}): { valid: boolean; seed?: string } {
+  try {
+    const msg = Buffer.from(input.requestId, 'utf-8');
+    const proof = Buffer.from(input.proofHex, 'hex');
+    const publicKey = Buffer.from(input.publicKeyHex, 'hex');
+
+    const valid = ed25519.verify(proof, msg, publicKey);
+    if (!valid) return { valid: false };
+
+    const seed = crypto.createHash('sha256').update(proof).digest('hex');
+    return { valid: true, seed };
+  } catch {
+    return { valid: false };
+  }
+}
+```
+

--- a/oracle/src/randomness/ed25519-sha256.vrf-provider.ts
+++ b/oracle/src/randomness/ed25519-sha256.vrf-provider.ts
@@ -37,15 +37,35 @@ export class Ed25519Sha256VrfProvider implements IVrfProvider {
     };
   }
 
-  verify(publicKey: string | Buffer, requestId: string, proof: string, seed: string): boolean {
+  verifyProof(
+    publicKey: string | Buffer,
+    requestId: string,
+    proof: string,
+  ): { valid: boolean; seed?: string } {
     try {
       const pubKeyBuf = typeof publicKey === 'string' ? Buffer.from(publicKey, 'hex') : publicKey;
       const proofBuf = Buffer.from(proof, 'hex');
-      const seedBuf = Buffer.from(seed, 'hex');
       const msgBuf = Buffer.from(requestId, 'utf-8');
 
-      if (!ed25519.verify(proofBuf, msgBuf, pubKeyBuf)) return false;
-      const expectedSeed = crypto.createHash('sha256').update(proofBuf).digest();
+      if (!ed25519.verify(proofBuf, msgBuf, pubKeyBuf)) {
+        return { valid: false };
+      }
+
+      const seed = crypto.createHash('sha256').update(proofBuf).digest('hex');
+      return { valid: true, seed };
+    } catch (error) {
+      this.logger.error(`VRF proof verification failed: ${error.message}`);
+      return { valid: false };
+    }
+  }
+
+  verify(publicKey: string | Buffer, requestId: string, proof: string, seed: string): boolean {
+    try {
+      const proofVerification = this.verifyProof(publicKey, requestId, proof);
+      if (!proofVerification.valid || !proofVerification.seed) return false;
+
+      const seedBuf = Buffer.from(seed, 'hex');
+      const expectedSeed = Buffer.from(proofVerification.seed, 'hex');
       return Buffer.compare(expectedSeed, seedBuf) === 0;
     } catch (error) {
       this.logger.error(`VRF verification failed: ${error.message}`);

--- a/oracle/src/randomness/vrf.interface.ts
+++ b/oracle/src/randomness/vrf.interface.ts
@@ -7,5 +7,10 @@ export enum VrfAlgorithm {
 export interface IVrfProvider {
   readonly algorithm: VrfAlgorithm;
   compute(requestId: string): Promise<RandomnessResult>;
+  verifyProof(
+    publicKey: string | Buffer,
+    requestId: string,
+    proof: string,
+  ): { valid: boolean; seed?: string };
   verify(publicKey: string | Buffer, requestId: string, proof: string, seed: string): boolean;
 }

--- a/oracle/src/randomness/vrf.service.ts
+++ b/oracle/src/randomness/vrf.service.ts
@@ -89,24 +89,45 @@ export class VrfService {
     proof: string,
     seed: string,
   ): boolean {
+    const verifiedProof = this.verifyProof({
+      publicKey,
+      requestId,
+      proof,
+    });
+    if (!verifiedProof.valid || !verifiedProof.seed) return false;
+
     try {
-      const pubKeyBuf = typeof publicKey === 'string' ? Buffer.from(publicKey, 'hex') : publicKey;
-      const proofBuf = Buffer.from(proof, 'hex');
-      const seedBuf = Buffer.from(seed, 'hex');
-      const msgBuf = Buffer.from(requestId, 'utf-8');
-
-      // Verify the proof is a valid Ed25519 signature
-      const isSignatureValid = ed25519.verify(proofBuf, msgBuf, pubKeyBuf);
-      if (!isSignatureValid) {
-        return false;
-      }
-
-      // Verify the seed is SHA-256(proof)
-      const expectedSeed = crypto.createHash('sha256').update(proofBuf).digest();
-      return Buffer.compare(expectedSeed, seedBuf) === 0;
-    } catch (error) {
-      this.logger.error(`VRF verification failed: ${error.message}`);
+      const expectedSeed = Buffer.from(verifiedProof.seed, 'hex');
+      const providedSeed = Buffer.from(seed, 'hex');
+      return Buffer.compare(expectedSeed, providedSeed) === 0;
+    } catch {
       return false;
     }
+  }
+
+  /**
+   * Verify a VRF proof and derive the seed when valid.
+   */
+  verifyProof(input: {
+    requestId: string;
+    proof: string;
+    publicKey: string | Buffer;
+  }): { valid: boolean; seed?: string } {
+    return this.ed25519Provider.verifyProof(
+      input.publicKey,
+      input.requestId,
+      input.proof,
+    );
+  }
+
+  /**
+   * Return the local oracle's public key in common encodings.
+   */
+  async getPublicKey(): Promise<{ hex: string; base64: string }> {
+    const keyBuffer = await this.keyService.getPublicKeyBuffer();
+    return {
+      hex: keyBuffer.toString('hex'),
+      base64: keyBuffer.toString('base64'),
+    };
   }
 }

--- a/oracle/src/rescue/rescue.controller.ts
+++ b/oracle/src/rescue/rescue.controller.ts
@@ -1,15 +1,19 @@
 import { Controller, Post, Get, Body, Param, Query, HttpCode, HttpStatus } from '@nestjs/common';
 import { RescueService } from './rescue.service';
+import { VrfService } from '../randomness/vrf.service';
 
-@Controller('rescue')
+@Controller()
 export class RescueController {
-  constructor(private readonly rescueService: RescueService) {}
+  constructor(
+    private readonly rescueService: RescueService,
+    private readonly vrfService: VrfService,
+  ) {}
 
   /**
    * Re-enqueue a failed job
    * POST /rescue/re-enqueue
    */
-  @Post('re-enqueue')
+  @Post('rescue/re-enqueue')
   @HttpCode(HttpStatus.OK)
   async reEnqueueJob(
     @Body('jobId') jobId: string,
@@ -23,7 +27,7 @@ export class RescueController {
    * Force submit randomness for a raffle
    * POST /rescue/force-submit
    */
-  @Post('force-submit')
+  @Post('rescue/force-submit')
   @HttpCode(HttpStatus.OK)
   async forceSubmit(
     @Body('raffleId') raffleId: number,
@@ -39,7 +43,7 @@ export class RescueController {
    * Force fail a job (mark as invalid/malicious)
    * POST /rescue/force-fail
    */
-  @Post('force-fail')
+  @Post('rescue/force-fail')
   @HttpCode(HttpStatus.OK)
   async forceFail(
     @Body('jobId') jobId: string,
@@ -53,7 +57,7 @@ export class RescueController {
    * Get failed jobs
    * GET /rescue/failed-jobs
    */
-  @Get('failed-jobs')
+  @Get('rescue/failed-jobs')
   async getFailedJobs() {
     return this.rescueService.getFailedJobs();
   }
@@ -62,7 +66,7 @@ export class RescueController {
    * Get all jobs by state
    * GET /rescue/jobs
    */
-  @Get('jobs')
+  @Get('rescue/jobs')
   async getAllJobs() {
     return this.rescueService.getAllJobs();
   }
@@ -71,7 +75,7 @@ export class RescueController {
    * Get rescue audit logs
    * GET /rescue/logs
    */
-  @Get('logs')
+  @Get('rescue/logs')
   async getRescueLogs(@Query('limit') limit?: string) {
     const parsedLimit = limit ? parseInt(limit, 10) : 100;
     return this.rescueService.getRescueLogs(parsedLimit);
@@ -81,8 +85,39 @@ export class RescueController {
    * Get rescue logs for a specific raffle
    * GET /rescue/logs/:raffleId
    */
-  @Get('logs/:raffleId')
+  @Get('rescue/logs/:raffleId')
   async getRescueLogsByRaffle(@Param('raffleId') raffleId: string) {
     return this.rescueService.getRescueLogsByRaffle(parseInt(raffleId, 10));
+  }
+
+  /**
+   * Verify an Ed25519-SHA256 VRF proof and derive the seed.
+   * POST /oracle/verify
+   */
+  @Post('oracle/verify')
+  @HttpCode(HttpStatus.OK)
+  verifyOracleProof(
+    @Body('requestId') requestId: string,
+    @Body('proof') proof: string,
+    @Body('publicKey') publicKey: string,
+  ): { valid: boolean; seed?: string } {
+    if (!requestId || !proof || !publicKey) {
+      return { valid: false };
+    }
+
+    return this.vrfService.verifyProof({
+      requestId,
+      proof,
+      publicKey,
+    });
+  }
+
+  /**
+   * Return this oracle's Ed25519 public key.
+   * GET /oracle/public-key
+   */
+  @Get('oracle/public-key')
+  async getOraclePublicKey() {
+    return this.vrfService.getPublicKey();
   }
 }


### PR DESCRIPTION
Add unauthenticated /oracle/verify and /oracle/public-key APIs so third parties can independently validate requestId proofs against the oracle key. Also add offline verification documentation and wire provider/service methods to return derived seed on valid proofs.

Closes #430 