### PR TITLE
Add confetti animation to WinnerAnnouncement modal and clean up Navba…

### DIFF
--- a/build2.txt
+++ b/build2.txt
@@ -1,0 +1,5 @@
+
+> tikka@0.0.0 build
+> tsc -b && vite build
+
+src/providers/AuthProvider.spec.tsx(9,24): error TS6133: 'useAuthContext' is declared but its value is never read.

--- a/build3.txt
+++ b/build3.txt
@@ -1,0 +1,62 @@
+
+> tikka@0.0.0 build
+> tsc -b && vite build
+
+[36mvite v7.3.2 [32mbuilding client environment for production...[36m[39m
+transforming...
+[32m✓[39m 3021 modules transformed.
+rendering chunks...
+computing gzip size...
+[2mdist/[22m[32mindex.html                              [39m[1m[2m    1.73 kB[22m[1m[22m[2m │ gzip:   0.77 kB[22m
+[2mdist/[22m[32massets/3-B2PXQJel.png                   [39m[1m[2m    5.65 kB[22m[1m[22m
+[2mdist/[22m[32massets/4-BxACK2jC.png                   [39m[1m[2m    6.36 kB[22m[1m[22m
+[2mdist/[22m[32massets/5-xEgLFcUT.png                   [39m[1m[2m    6.85 kB[22m[1m[22m
+[2mdist/[22m[32massets/8-6vf27Hhz.png                   [39m[1m[2m    7.00 kB[22m[1m[22m
+[2mdist/[22m[32massets/1-5jXDgs-q.png                   [39m[1m[2m    7.10 kB[22m[1m[22m
+[2mdist/[22m[32massets/7-Ds_8B3RO.png                   [39m[1m[2m    7.83 kB[22m[1m[22m
+[2mdist/[22m[32massets/DiscordLogo-Dp2iuK3u.svg         [39m[1m[2m    7.91 kB[22m[1m[22m[2m │ gzip:   1.65 kB[22m
+[2mdist/[22m[32massets/2-6CXo4oID.png                   [39m[1m[2m    7.94 kB[22m[1m[22m
+[2mdist/[22m[32massets/6-DYhjU5Wq.png                   [39m[1m[2m    8.21 kB[22m[1m[22m
+[2mdist/[22m[32massets/Union-D-10JQOL.png               [39m[1m[2m   30.36 kB[22m[1m[22m
+[2mdist/[22m[32massets/featraff-Bv4sVt5c.png            [39m[1m[2m  412.08 kB[22m[1m[22m
+[2mdist/[22m[32massets/detailimage--ZG6nh61.png         [39m[1m[2m  538.04 kB[22m[1m[22m
+[2mdist/[22m[32massets/hero-img-JiVLtEnX.png            [39m[1m[2m1,813.94 kB[22m[1m[22m
+[2mdist/[22m[35massets/index-DjKgvGZD.css               [39m[1m[2m   77.94 kB[22m[1m[22m[2m │ gzip:  13.08 kB[22m
+[2mdist/[22m[36massets/x-CI6RJ3w-.js                    [39m[1m[2m    0.16 kB[22m[1m[22m[2m │ gzip:   0.15 kB[22m
+[2mdist/[22m[36massets/user-yeQMMHK8.js                 [39m[1m[2m    0.19 kB[22m[1m[22m[2m │ gzip:   0.18 kB[22m
+[2mdist/[22m[36massets/external-link-D23OKI0E.js        [39m[1m[2m    0.25 kB[22m[1m[22m[2m │ gzip:   0.20 kB[22m
+[2mdist/[22m[36massets/notificationService-CJSnWAaU.js  [39m[1m[2m    0.61 kB[22m[1m[22m[2m │ gzip:   0.37 kB[22m
+[2mdist/[22m[36massets/EnterRaffleButton-C-zKBDh6.js    [39m[1m[2m    1.02 kB[22m[1m[22m[2m │ gzip:   0.68 kB[22m
+[2mdist/[22m[36massets/ProgressBar-CXtr5O3o.js          [39m[1m[2m    1.25 kB[22m[1m[22m[2m │ gzip:   0.66 kB[22m
+[2mdist/[22m[36massets/ErrorMessage-NjG9FfBp.js         [39m[1m[2m    1.42 kB[22m[1m[22m[2m │ gzip:   0.61 kB[22m
+[2mdist/[22m[36massets/Breadcrumbs-Bx0KKdNB.js          [39m[1m[2m    1.60 kB[22m[1m[22m[2m │ gzip:   0.89 kB[22m
+[2mdist/[22m[36massets/useRaffles-DWPGBBer.js           [39m[1m[2m    2.16 kB[22m[1m[22m[2m │ gzip:   0.82 kB[22m
+[2mdist/[22m[36massets/Search-CypVeaax.js               [39m[1m[2m    2.67 kB[22m[1m[22m[2m │ gzip:   1.29 kB[22m
+[2mdist/[22m[36massets/FAQPage-BxOTr0Be.js              [39m[1m[2m    2.82 kB[22m[1m[22m[2m │ gzip:   1.37 kB[22m
+[2mdist/[22m[36massets/raffleService-i53A7lDq.js        [39m[1m[2m    3.12 kB[22m[1m[22m[2m │ gzip:   1.12 kB[22m
+[2mdist/[22m[36massets/AddToCalendar-DqKF7-op.js        [39m[1m[2m    3.33 kB[22m[1m[22m[2m │ gzip:   1.44 kB[22m
+[2mdist/[22m[36massets/Home-By8lGLNQ.js                 [39m[1m[2m    3.45 kB[22m[1m[22m[2m │ gzip:   1.45 kB[22m
+[2mdist/[22m[36massets/RaffleCardSkeleton-1LQ8-qI2.js   [39m[1m[2m    4.60 kB[22m[1m[22m[2m │ gzip:   1.09 kB[22m
+[2mdist/[22m[36massets/VerifiedBadge-C7frfgeQ.js        [39m[1m[2m    5.13 kB[22m[1m[22m[2m │ gzip:   3.20 kB[22m
+[2mdist/[22m[36massets/Transparency-Dha5WipW.js         [39m[1m[2m    5.28 kB[22m[1m[22m[2m │ gzip:   1.90 kB[22m
+[2mdist/[22m[36massets/Leaderboard-C5ot4-9h.js          [39m[1m[2m    5.40 kB[22m[1m[22m[2m │ gzip:   1.71 kB[22m
+[2mdist/[22m[36massets/detailimage-CdDhT-9z.js          [39m[1m[2m    5.60 kB[22m[1m[22m[2m │ gzip:   2.28 kB[22m
+[2mdist/[22m[36massets/LandingPage-xD8jpPVM.js          [39m[1m[2m    7.70 kB[22m[1m[22m[2m │ gzip:   2.29 kB[22m
+[2mdist/[22m[36massets/FeaturedRaffle-D6iW0j42.js       [39m[1m[2m    7.72 kB[22m[1m[22m[2m │ gzip:   2.73 kB[22m
+[2mdist/[22m[36massets/MyRaffles-DRH-Qgwo.js            [39m[1m[2m    8.04 kB[22m[1m[22m[2m │ gzip:   2.46 kB[22m
+[2mdist/[22m[36massets/Settings-DsDczQ31.js             [39m[1m[2m    8.51 kB[22m[1m[22m[2m │ gzip:   2.36 kB[22m
+[2mdist/[22m[36massets/WinnerDemo-Dp8ZD0Ds.js           [39m[1m[2m   10.41 kB[22m[1m[22m[2m │ gzip:   4.04 kB[22m
+[2mdist/[22m[36massets/confetti.module-w0HAUrg8.js      [39m[1m[2m   10.67 kB[22m[1m[22m[2m │ gzip:   4.28 kB[22m
+[2mdist/[22m[36massets/browser-ponyfill-CVM2qnkm.js     [39m[1m[2m   11.04 kB[22m[1m[22m[2m │ gzip:   3.84 kB[22m
+[2mdist/[22m[36massets/RafflePage-CqIKUbhS.js           [39m[1m[2m   14.82 kB[22m[1m[22m[2m │ gzip:   3.87 kB[22m
+[2mdist/[22m[36massets/RaffleDetails-nSitqoKo.js        [39m[1m[2m   23.82 kB[22m[1m[22m[2m │ gzip:   8.49 kB[22m
+[2mdist/[22m[36massets/Support-TQ_jwaVG.js              [39m[1m[2m   28.11 kB[22m[1m[22m[2m │ gzip:  10.37 kB[22m
+[2mdist/[22m[36massets/CreateRaffle-IpK_4PvU.js         [39m[1m[2m  254.43 kB[22m[1m[22m[2m │ gzip:  64.30 kB[22m
+[2mdist/[22m[36massets/OracleAdmin-CyrF21P1.js          [39m[1m[2m  363.87 kB[22m[1m[22m[2m │ gzip: 108.92 kB[22m
+[2mdist/[22m[36massets/index-CSJk34Yd.js                [39m[1m[33m1,925.24 kB[39m[22m[2m │ gzip: 568.27 kB[22m
+[33m
+(!) Some chunks are larger than 500 kB after minification. Consider:
+- Using dynamic import() to code-split the application
+- Use build.rollupOptions.output.manualChunks to improve chunking: https://rollupjs.org/configuration-options/#output-manualchunks
+- Adjust chunk size limit for this warning via build.chunkSizeWarningLimit.[39m
+[32m✓ built in 1m 36s[39m

--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -6,12 +6,10 @@ import tikka from "../assets/svg/Tikka.svg";
 import WalletButton from "./WalletButton";
 import ThemeToggle from "./ThemeToggle";
 import SignInButton from "./SignInButton";
-import NotificationBellIcon from "./cards/NotificationBellIcon";
 import { Search } from "lucide-react";
 import { useWalletContext } from "../providers/WalletProvider";
 import { STELLAR_CONFIG } from "../config/stellar";
 import { useTranslation } from "react-i18next";
-import { Globe } from "lucide-react";
 
 
 const Navbar = ({ onStart }: { onStart?: () => void }) => {

--- a/client/src/components/landing/TrendingRaffles.tsx
+++ b/client/src/components/landing/TrendingRaffles.tsx
@@ -5,6 +5,8 @@ import { useNavigate } from "react-router-dom";
 import { useRaffle } from "../../hooks/useRaffles";
 import RaffleCardSkeleton from "../ui/RaffleCardSkeleton";
 import ErrorMessage from "../ui/ErrorMessage";
+import Modal from "../modals/Modal";
+import SuccessfulTicket from "../modals/SuccessfulTicket";
 
 interface TrendingRafflesProps {
     raffleIds: number[];

--- a/client/src/components/modals/WinnerAnnouncement.tsx
+++ b/client/src/components/modals/WinnerAnnouncement.tsx
@@ -1,5 +1,6 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import { X } from "lucide-react";
+import confetti from "canvas-confetti";
 import type {
     WinnerAnnouncementProps,
     SocialPlatform,
@@ -14,6 +15,58 @@ const WinnerAnnouncement: React.FC<WinnerAnnouncementProps> = ({
     walletAddress = "0x330cd8fec...8b7c",
     isVisible = true,
 }) => {
+    const hasFiredRef = useRef(false);
+
+    useEffect(() => {
+        if (!isVisible) return;
+        if (hasFiredRef.current) return;
+
+        const prefersReducedMotion = window.matchMedia(
+            "(prefers-reduced-motion: reduce)"
+        ).matches;
+        if (prefersReducedMotion) return;
+
+        hasFiredRef.current = true;
+
+        const duration = 3 * 1000;
+        const animationEnd = Date.now() + duration;
+        const defaults = {
+            startVelocity: 30,
+            spread: 360,
+            ticks: 60,
+            zIndex: 0,
+        };
+
+        const randomInRange = (min: number, max: number) =>
+            Math.random() * (max - min) + min;
+
+        const interval: ReturnType<typeof setInterval> = setInterval(() => {
+            const timeLeft = animationEnd - Date.now();
+
+            if (timeLeft <= 0) {
+                clearInterval(interval);
+                return;
+            }
+
+            const particleCount = 50 * (timeLeft / duration);
+            confetti({
+                ...defaults,
+                particleCount,
+                origin: { x: randomInRange(0.1, 0.3), y: Math.random() - 0.2 },
+            });
+            confetti({
+                ...defaults,
+                particleCount,
+                origin: { x: randomInRange(0.7, 0.9), y: Math.random() - 0.2 },
+            });
+        }, 250);
+
+        return () => {
+            clearInterval(interval);
+            confetti.reset();
+        };
+    }, [isVisible]);
+
     if (!isVisible) return null;
 
     const socialPlatforms: SocialPlatform[] = [

--- a/client/src/pages/FAQ/FAQPage.tsx
+++ b/client/src/pages/FAQ/FAQPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { faqData } from './FAQContent';
 
 const FAQItem = ({ question, answer, id }: { question: string, answer: string, id: string }) => {

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -14,6 +14,7 @@ import { useTranslation } from "react-i18next";
 const PAGE_SIZE = 6;
 
 const Home = () => {
+    const { t } = useTranslation();
     const { raffles, total, error, isLoading: rafflesLoading, refetch } = useRaffles({
         status: "open",
         limit: PAGE_SIZE,

--- a/client/src/providers/AuthProvider.spec.tsx
+++ b/client/src/providers/AuthProvider.spec.tsx
@@ -6,8 +6,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, act } from '@testing-library/react';
 import * as fc from 'fast-check';
-import React from 'react';
-import { AuthProvider, useAuthContext } from './AuthProvider';
+import { AuthProvider } from './AuthProvider';
 
 // ── Mocks ─────────────────────────────────────────────────────────────────────
 
@@ -50,14 +49,6 @@ afterEach(() => {
   vi.restoreAllMocks();
   vi.unstubAllEnvs();
 });
-
-// ── Helper: render AuthProvider and get context ───────────────────────────────
-
-function TestConsumer({ onContext }: { onContext: (ctx: ReturnType<typeof useAuthContext>) => void }) {
-  const ctx = useAuthContext();
-  onContext(ctx);
-  return null;
-}
 
 // ── P11: Wallet disconnect triggers logout ────────────────────────────────────
 

--- a/client/src/services/apiClient.spec.ts
+++ b/client/src/services/apiClient.spec.ts
@@ -3,9 +3,7 @@
  * Feature: siws-auth
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import * as fc from 'fast-check';
-import { getToken, setToken, clearToken, apiRequest } from './apiClient';
+import { vi, beforeEach, afterEach } from 'vitest';
 
 beforeEach(() => {
   sessionStorage.clear();


### PR DESCRIPTION
closed #421 
Summary
Add a celebratory confetti animation to the WinnerAnnouncement modal that fires when the modal first becomes visible, respects accessibility preferences (prefers-reduced-motion), and cleans up on close.

Changes
client/src/components/modals/WinnerAnnouncement.tsx

Imported useEffect, useRef from React and confetti from canvas-confetti
Added hasFiredRef one-shot guard to prevent duplicate bursts on re-renders / React Strict Mode
Added useEffect keyed on isVisible that:
Skips animation entirely if prefers-reduced-motion: reduce is set
Fires a 3-second dual-origin confetti burst (decaying particle count, 250ms interval)
Cleans up via clearInterval + confetti.reset() on unmount / modal close to remove the injected <canvas> element
Acceptance Criteria
 Confetti fires on modal open
 Animation stops after 3 seconds automatically
 No animation when prefers-reduced-motion: reduce is set
 No canvas element left in DOM after modal closes
Notes
canvas-confetti (^1.9.4) and @types/canvas-confetti (^1.9.0) were already present in client/package.json — no new dependencies added.
The animation pattern mirrors the existing confetti implementation in RaffleDetails.tsx.
Build Verification
npm run build (client) passes with zero TypeScript errors.