### PR TITLE
feat: Add webhook notifications for raffle state changes

### DIFF
--- a/backend/database/migrations/008_webhooks.sql
+++ b/backend/database/migrations/008_webhooks.sql
@@ -1,0 +1,60 @@
+-- Migration 008: Add Webhooks table
+CREATE TABLE IF NOT EXISTS public.webhooks (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    owner_address TEXT NOT NULL,
+    target_url TEXT NOT NULL,
+    events TEXT[] NOT NULL DEFAULT '{}',
+    secret TEXT NOT NULL,
+    is_active BOOLEAN NOT NULL DEFAULT true,
+    failure_count INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Indexes for fast querying
+CREATE INDEX IF NOT EXISTS idx_webhooks_owner_address ON public.webhooks(owner_address);
+CREATE INDEX IF NOT EXISTS idx_webhooks_is_active ON public.webhooks(is_active);
+
+-- Prevent duplicate active webhooks for the same user and target URL
+CREATE UNIQUE INDEX IF NOT EXISTS idx_webhooks_unique_subscription 
+ON public.webhooks(owner_address, target_url) 
+WHERE is_active = true;
+
+-- Enable Row Level Security
+ALTER TABLE public.webhooks ENABLE ROW LEVEL SECURITY;
+
+-- Create policy for users to manage their own webhooks
+CREATE POLICY "Users can manage their own webhooks"
+    ON public.webhooks
+    FOR ALL
+    USING (owner_address = current_setting('request.jwt.claims')::json->>'address');
+
+-- Create a table for delivery logs (optional but helpful for the requirement "Delivery log is queryable by the webhook owner")
+CREATE TABLE IF NOT EXISTS public.webhook_deliveries (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    webhook_id UUID NOT NULL REFERENCES public.webhooks(id) ON DELETE CASCADE,
+    event_type TEXT NOT NULL,
+    payload JSONB NOT NULL,
+    status_code INTEGER,
+    response_body TEXT,
+    error_message TEXT,
+    success BOOLEAN NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_webhook_id ON public.webhook_deliveries(webhook_id);
+CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_created_at ON public.webhook_deliveries(created_at);
+
+-- RLS for deliveries
+ALTER TABLE public.webhook_deliveries ENABLE ROW LEVEL SECURITY;
+
+-- Users can only read their own deliveries
+CREATE POLICY "Users can view deliveries for their webhooks"
+    ON public.webhook_deliveries
+    FOR SELECT
+    USING (
+        EXISTS (
+            SELECT 1 FROM public.webhooks w 
+            WHERE w.id = webhook_deliveries.webhook_id 
+            AND w.owner_address = current_setting('request.jwt.claims')::json->>'address'
+        )
+    );

--- a/backend/src/Proccessors/ticket.proccesor.ts
+++ b/backend/src/Proccessors/ticket.proccesor.ts
@@ -1,5 +1,6 @@
-import { Logger } from '@nestjs/common';
+import { Logger, Injectable } from '@nestjs/common';
 import { captureIngestionError } from '../sentry/sentry';
+import { WebhookService } from '../services/webhook.service';
 
 export interface TicketEvent {
   ledger?: number;
@@ -8,8 +9,11 @@ export interface TicketEvent {
   [key: string]: unknown;
 }
 
+@Injectable()
 export class TicketProcessor {
   private readonly logger = new Logger(TicketProcessor.name);
+
+  constructor(private readonly webhookService: WebhookService) {}
 
   /**
    * Process a ticket-related blockchain event.
@@ -20,6 +24,14 @@ export class TicketProcessor {
       this.logger.log(
         `Processing event: type=${event.eventType ?? 'unknown'}, ledger=${event.ledger ?? 'unknown'}`,
       );
+
+      // Trigger webhook notifications on state change
+      if (event.eventType && event.raffleId) {
+        await this.webhookService.triggerWebhooks(event.eventType, {
+          raffleId: event.raffleId,
+          ...event,
+        });
+      }
 
       // TODO: implement ticket event processing logic here
     } catch (error: unknown) {

--- a/backend/src/api/rest/webhooks/webhooks.controller.ts
+++ b/backend/src/api/rest/webhooks/webhooks.controller.ts
@@ -1,0 +1,90 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Post,
+  Put,
+  UsePipes,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger';
+import { CurrentUser } from '../../../auth/decorators/current-user.decorator';
+import { WebhookService } from '../../../services/webhook.service';
+import { createZodPipe } from '../raffles/pipes/zod-validation.pipe';
+import {
+  CreateWebhookDto,
+  CreateWebhookSchema,
+  UpdateWebhookDto,
+  UpdateWebhookSchema,
+} from './webhooks.schema';
+
+@ApiTags('Webhooks')
+@ApiBearerAuth()
+@Controller('webhooks')
+export class WebhooksController {
+  constructor(private readonly webhookService: WebhookService) {}
+
+  @Post()
+  @ApiOperation({ summary: 'Create a new webhook subscription' })
+  @UsePipes(new (createZodPipe(CreateWebhookSchema))())
+  async createWebhook(
+    @CurrentUser('address') address: string,
+    @Body() payload: CreateWebhookDto,
+  ) {
+    return this.webhookService.createWebhook({
+      ownerAddress: address,
+      targetUrl: payload.targetUrl,
+      events: payload.events,
+    });
+  }
+
+  @Get()
+  @ApiOperation({ summary: 'List webhooks for the current user' })
+  async getWebhooks(@CurrentUser('address') address: string) {
+    return this.webhookService.getWebhooksByOwner(address);
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get a specific webhook by ID' })
+  @ApiParam({ name: 'id', description: 'Webhook UUID' })
+  async getWebhook(
+    @CurrentUser('address') address: string,
+    @Param('id') id: string,
+  ) {
+    return this.webhookService.getWebhook(id, address);
+  }
+
+  @Put(':id')
+  @ApiOperation({ summary: 'Update a webhook' })
+  @ApiParam({ name: 'id', description: 'Webhook UUID' })
+  @UsePipes(new (createZodPipe(UpdateWebhookSchema))())
+  async updateWebhook(
+    @CurrentUser('address') address: string,
+    @Param('id') id: string,
+    @Body() payload: UpdateWebhookDto,
+  ) {
+    return this.webhookService.updateWebhook(id, address, payload);
+  }
+
+  @Delete(':id')
+  @ApiOperation({ summary: 'Delete a webhook' })
+  @ApiParam({ name: 'id', description: 'Webhook UUID' })
+  async deleteWebhook(
+    @CurrentUser('address') address: string,
+    @Param('id') id: string,
+  ) {
+    await this.webhookService.deleteWebhook(id, address);
+    return { success: true };
+  }
+
+  @Get(':id/deliveries')
+  @ApiOperation({ summary: 'Get recent delivery logs for a webhook' })
+  @ApiParam({ name: 'id', description: 'Webhook UUID' })
+  async getDeliveries(
+    @CurrentUser('address') address: string,
+    @Param('id') id: string,
+  ) {
+    return this.webhookService.getDeliveries(id, address);
+  }
+}

--- a/backend/src/api/rest/webhooks/webhooks.module.ts
+++ b/backend/src/api/rest/webhooks/webhooks.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { WebhooksController } from './webhooks.controller';
+import { WebhookService } from '../../../services/webhook.service';
+
+@Module({
+  controllers: [WebhooksController],
+  providers: [WebhookService],
+  exports: [WebhookService],
+})
+export class WebhooksModule {}

--- a/backend/src/api/rest/webhooks/webhooks.schema.ts
+++ b/backend/src/api/rest/webhooks/webhooks.schema.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod';
+
+export const CreateWebhookSchema = z.object({
+  targetUrl: z.string().url('Must be a valid URL'),
+  events: z.array(z.string()).min(1, 'At least one event must be specified'),
+});
+
+export type CreateWebhookDto = z.infer<typeof CreateWebhookSchema>;
+
+export const UpdateWebhookSchema = z.object({
+  targetUrl: z.string().url('Must be a valid URL').optional(),
+  events: z.array(z.string()).min(1).optional(),
+  isActive: z.boolean().optional(),
+});
+
+export type UpdateWebhookDto = z.infer<typeof UpdateWebhookSchema>;

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -23,6 +23,7 @@ import { validate } from "./config/env.schema";
 import { IndexerBackfillModule } from "./services/indexer-backfill.module";
 import { MaintenanceModeGuard } from "./maintenance/maintenance-mode.guard";
 import { MaintenanceModeModule } from "./maintenance/maintenance-mode.module";
+import { WebhooksModule } from "./api/rest/webhooks/webhooks.module";
 
 @Module({
   imports: [
@@ -112,6 +113,7 @@ import { MaintenanceModeModule } from "./maintenance/maintenance-mode.module";
     MonitorModule,
     IndexerBackfillModule,
     MaintenanceModeModule,
+    WebhooksModule,
   ],
   providers: [
     // 1. Maintenance guard first — blocks requests when MAINTENANCE_MODE is enabled

--- a/backend/src/services/webhook.service.ts
+++ b/backend/src/services/webhook.service.ts
@@ -1,0 +1,315 @@
+import { Inject, Injectable, Logger, ConflictException, NotFoundException } from '@nestjs/common';
+import { SupabaseClient } from '@supabase/supabase-js';
+import { SUPABASE_CLIENT } from './supabase.provider';
+import * as crypto from 'crypto';
+
+export interface Webhook {
+  id: string;
+  owner_address: string;
+  target_url: string;
+  events: string[];
+  secret: string;
+  is_active: boolean;
+  failure_count: number;
+  created_at: string;
+}
+
+export interface WebhookDelivery {
+  id: string;
+  webhook_id: string;
+  event_type: string;
+  payload: any;
+  status_code: number | null;
+  response_body: string | null;
+  error_message: string | null;
+  success: boolean;
+  created_at: string;
+}
+
+export interface CreateWebhookPayload {
+  ownerAddress: string;
+  targetUrl: string;
+  events: string[];
+}
+
+export interface UpdateWebhookPayload {
+  targetUrl?: string;
+  events?: string[];
+  isActive?: boolean;
+}
+
+const TABLE = 'webhooks';
+const DELIVERIES_TABLE = 'webhook_deliveries';
+const MAX_FAILURES = 5;
+const MAX_RETRIES = 3;
+
+@Injectable()
+export class WebhookService {
+  private readonly logger = new Logger(WebhookService.name);
+
+  constructor(
+    @Inject(SUPABASE_CLIENT) private readonly client: SupabaseClient,
+  ) {}
+
+  /**
+   * Create a new webhook subscription
+   */
+  async createWebhook(payload: CreateWebhookPayload): Promise<Webhook> {
+    const secret = crypto.randomBytes(32).toString('hex');
+    
+    const row = {
+      owner_address: payload.ownerAddress,
+      target_url: payload.targetUrl,
+      events: payload.events,
+      secret,
+    };
+
+    const { data, error } = await this.client
+      .from(TABLE)
+      .insert(row)
+      .select()
+      .single();
+
+    if (error) {
+      if (error.code === '23505') {
+        throw new ConflictException('Webhook already exists for this URL');
+      }
+      throw new Error(`Failed to create webhook: ${error.message}`);
+    }
+
+    return data as Webhook;
+  }
+
+  /**
+   * Get all webhooks for an owner
+   */
+  async getWebhooksByOwner(ownerAddress: string): Promise<Webhook[]> {
+    const { data, error } = await this.client
+      .from(TABLE)
+      .select('*')
+      .eq('owner_address', ownerAddress)
+      .order('created_at', { ascending: false });
+
+    if (error) {
+      throw new Error(`Failed to fetch webhooks: ${error.message}`);
+    }
+
+    return (data as Webhook[]) || [];
+  }
+
+  /**
+   * Get a single webhook
+   */
+  async getWebhook(id: string, ownerAddress: string): Promise<Webhook> {
+    const { data, error } = await this.client
+      .from(TABLE)
+      .select('*')
+      .eq('id', id)
+      .eq('owner_address', ownerAddress)
+      .maybeSingle();
+
+    if (error || !data) {
+      throw new NotFoundException('Webhook not found');
+    }
+
+    return data as Webhook;
+  }
+
+  /**
+   * Update a webhook
+   */
+  async updateWebhook(id: string, ownerAddress: string, payload: UpdateWebhookPayload): Promise<Webhook> {
+    // Verify ownership
+    await this.getWebhook(id, ownerAddress);
+
+    const updateData: any = {};
+    if (payload.targetUrl !== undefined) updateData.target_url = payload.targetUrl;
+    if (payload.events !== undefined) updateData.events = payload.events;
+    if (payload.isActive !== undefined) updateData.is_active = payload.isActive;
+
+    const { data, error } = await this.client
+      .from(TABLE)
+      .update(updateData)
+      .eq('id', id)
+      .select()
+      .single();
+
+    if (error) {
+      throw new Error(`Failed to update webhook: ${error.message}`);
+    }
+
+    return data as Webhook;
+  }
+
+  /**
+   * Delete a webhook
+   */
+  async deleteWebhook(id: string, ownerAddress: string): Promise<void> {
+    const { error } = await this.client
+      .from(TABLE)
+      .delete()
+      .eq('id', id)
+      .eq('owner_address', ownerAddress);
+
+    if (error) {
+      throw new Error(`Failed to delete webhook: ${error.message}`);
+    }
+  }
+
+  /**
+   * Get delivery logs for a webhook
+   */
+  async getDeliveries(webhookId: string, ownerAddress: string): Promise<WebhookDelivery[]> {
+    // Verify ownership
+    await this.getWebhook(webhookId, ownerAddress);
+
+    const { data, error } = await this.client
+      .from(DELIVERIES_TABLE)
+      .select('*')
+      .eq('webhook_id', webhookId)
+      .order('created_at', { ascending: false })
+      .limit(50);
+
+    if (error) {
+      throw new Error(`Failed to fetch webhook deliveries: ${error.message}`);
+    }
+
+    return (data as WebhookDelivery[]) || [];
+  }
+
+  /**
+   * Main entry point to trigger webhooks for a specific event
+   */
+  async triggerWebhooks(eventType: string, payloadData: any): Promise<void> {
+    // Find all active webhooks that subscribe to this event
+    const { data, error } = await this.client
+      .from(TABLE)
+      .select('*')
+      .eq('is_active', true)
+      .contains('events', [eventType]);
+
+    if (error) {
+      this.logger.error(`Failed to query webhooks for event ${eventType}`, error);
+      return;
+    }
+
+    const webhooks = (data as Webhook[]) || [];
+    if (webhooks.length === 0) {
+      return; // No webhooks to trigger
+    }
+
+    const payloadObj = {
+      event: eventType,
+      timestamp: new Date().toISOString(),
+      data: payloadData,
+    };
+    
+    const payloadString = JSON.stringify(payloadObj);
+
+    // Process all webhooks concurrently
+    await Promise.allSettled(
+      webhooks.map((webhook) => this.deliverWebhookWithRetries(webhook, eventType, payloadString))
+    );
+  }
+
+  /**
+   * Delivers a webhook with exponential backoff retries
+   */
+  private async deliverWebhookWithRetries(webhook: Webhook, eventType: string, payloadString: string): Promise<void> {
+    const signature = crypto
+      .createHmac('sha256', webhook.secret)
+      .update(payloadString)
+      .digest('hex');
+
+    let attempt = 0;
+    let success = false;
+    let statusCode: number | null = null;
+    let responseBody: string | null = null;
+    let errorMessage: string | null = null;
+
+    while (attempt <= MAX_RETRIES && !success) {
+      if (attempt > 0) {
+        // Exponential backoff: 2s, 4s, 8s
+        const delayMs = Math.pow(2, attempt) * 1000;
+        await new Promise((res) => setTimeout(res, delayMs));
+      }
+
+      try {
+        const response = await fetch(webhook.target_url, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Tikka-Signature': signature,
+            'User-Agent': 'Tikka-Webhook-Dispatcher/1.0',
+          },
+          body: payloadString,
+          // Set a reasonable timeout (fetch doesn't have native timeout, assuming standard node usage)
+          signal: AbortSignal.timeout(10000)
+        });
+
+        statusCode = response.status;
+        const text = await response.text();
+        responseBody = text ? text.substring(0, 1000) : null; // Limit response body size
+
+        if (response.ok) {
+          success = true;
+        } else {
+          errorMessage = `HTTP ${statusCode}`;
+        }
+      } catch (err: any) {
+        errorMessage = err.message || 'Network error';
+        if (err.name === 'TimeoutError') {
+          errorMessage = 'Request timed out';
+        }
+      }
+
+      attempt++;
+    }
+
+    // Log the delivery attempt in Supabase
+    await this.logDelivery(webhook.id, eventType, JSON.parse(payloadString), statusCode, responseBody, errorMessage, success);
+
+    if (success) {
+      // If previously failing, reset failure count
+      if (webhook.failure_count > 0) {
+        await this.client.from(TABLE).update({ failure_count: 0 }).eq('id', webhook.id);
+      }
+    } else {
+      // Increment failure count
+      const newFailureCount = webhook.failure_count + 1;
+      const updates: any = { failure_count: newFailureCount };
+      
+      // Disable webhook if it consistently fails
+      if (newFailureCount >= MAX_FAILURES) {
+        updates.is_active = false;
+        this.logger.warn(`Disabled webhook ${webhook.id} due to ${newFailureCount} consecutive failures.`);
+      }
+      
+      await this.client.from(TABLE).update(updates).eq('id', webhook.id);
+    }
+  }
+
+  private async logDelivery(
+    webhookId: string, 
+    eventType: string, 
+    payload: any, 
+    statusCode: number | null, 
+    responseBody: string | null, 
+    errorMessage: string | null, 
+    success: boolean
+  ) {
+    try {
+      await this.client.from(DELIVERIES_TABLE).insert({
+        webhook_id: webhookId,
+        event_type: eventType,
+        payload,
+        status_code: statusCode,
+        response_body: responseBody,
+        error_message: errorMessage,
+        success,
+      });
+    } catch (err) {
+      this.logger.error(`Failed to log delivery for webhook ${webhookId}`, err);
+    }
+  }
+}


### PR DESCRIPTION
closes #412 

##  Summary
Implements webhook notifications for third-party integrations (bots, dashboards, analytics tools) to receive real-time updates when raffles transition state, eliminating the need to poll the API repeatedly.

## ✨ Solution
Added a robust webhook delivery system using Supabase for storage and a new `WebhookService` for payload signing and delivery, complete with an exponential back-off retry mechanism.

## Features
- **Database Support:** Added `webhooks` and `webhook_deliveries` tables with Row Level Security (RLS) in Supabase.
-  **Secure Payloads:** `WebhookService` securely signs all payloads with `HMAC-SHA256` using an auto-generated secret for each webhook.
- **API Endpoints:** Exposed full CRUD endpoints under `/webhooks` protected by JWT auth, ensuring they are owner-scoped.
-  **Smart Delivery & Retries:** Implemented exponential back-off retry (3 attempts) and automatic disabling of webhooks that consistently fail (5 consecutive failures).
-  **Event Triggering:** Integrated webhook dispatch directly into the `TicketProcessor` so blockchain state changes instantly trigger deliveries.
- **Delivery Logs:** Webhook owners can query their webhook's delivery history via `/webhooks/:id/deliveries`.

##  Checklist
- [x] Code implemented and tested
- [x] TypeScript compilation successful (0 errors)
- [x] Database migrations added
- [x] API endpoints functional
