### PR TITLE
fix(client): persist user theme preference and prevent FOUC

### DIFF
--- a/client/src/components/ThemeToggle.tsx
+++ b/client/src/components/ThemeToggle.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react";
 
 export default function ThemeToggle() {
     const [theme, setTheme] = useState<"light" | "dark" | "system">(
-        (localStorage.getItem("theme") as "light" | "dark") || "system"
+        (localStorage.getItem("tikka-theme") as "light" | "dark") || "system"
     );
 
     useEffect(() => {
@@ -11,13 +11,13 @@ export default function ThemeToggle() {
 
         if (theme === "dark") {
             root.classList.add("dark");
-            localStorage.theme = "dark";
+            localStorage.setItem("tikka-theme", "dark");
         } else if (theme === "light") {
             root.classList.remove("dark");
-            localStorage.theme = "light";
+            localStorage.setItem("tikka-theme", "light");
         } else {
             // Respect OS preference (remove explicit choice)
-            localStorage.removeItem("theme");
+            localStorage.removeItem("tikka-theme");
             root.classList.toggle(
                 "dark",
                 window.matchMedia("(prefers-color-scheme: dark)").matches

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -11,6 +11,17 @@ import ErrorBoundary from './components/ui/ErrorBoundary.tsx'
 import { HelmetProvider } from 'react-helmet-async'
 import './i18n'
 
+// Initialize theme before rendering to prevent FOUC
+const savedTheme = localStorage.getItem("tikka-theme");
+if (
+  savedTheme === "dark" ||
+  (!savedTheme && window.matchMedia("(prefers-color-scheme: dark)").matches)
+) {
+  document.documentElement.classList.add("dark");
+} else {
+  document.documentElement.classList.remove("dark");
+}
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <HelmetProvider>


### PR DESCRIPTION
closes #419 
## 🎯 Summary
Implements persistence for the user's theme preference across sessions and prevents the Flash of Unstyled Content (FOUC) on initial load.

## 📋 Problem
When a user toggled their theme in the `ThemeToggle` component, the choice was not being properly stored and read. Consequently, upon refreshing the page or opening a new tab, the user's selected theme was lost and reverted to the default, creating a frustrating user experience.

## ✨ Solution
- **Storage Strategy**: Updated the `ThemeToggle` component to properly save and retrieve the user's chosen theme ("dark" or "light") to `localStorage` under the key `tikka-theme`. 
- **FOUC Prevention**: Added a synchronous inline script in `main.tsx` right before React's `createRoot` execution. This reads the stored theme preference (or falls back to the OS `prefers-color-scheme`) and applies it directly to the `document.documentElement` class list before the React app hydrates.
- **OS Fallbacks**: Ensuring `localStorage` items are properly removed if a user selects "system", so it gracefully falls back to the OS preference.

## 📦 Files Changed
- `client/src/components/ThemeToggle.tsx`
- `client/src/main.tsx`

## ✅ Acceptance Criteria Met
- [x] Theme persists across hard refreshes.
- [x] Theme persists across new tabs in the same browser.
- [x] OS preference is used as default when no stored preference exists.
- [x] No flash of wrong theme on load.


