### PR TITLE
Add package-scoped issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/backend.md
+++ b/.github/ISSUE_TEMPLATE/backend.md
@@ -1,0 +1,27 @@
+---
+name: Backend
+about: Work on the API layer (auth, metadata, indexer merge, notifications)
+title: "[backend] "
+labels: ["package:backend"]
+---
+
+## Build Location
+`./backend/` — NestJS, Fastify, Supabase
+
+## Description
+<!-- What needs to be built or fixed? -->
+
+## Affected APIs
+<!-- Which endpoints or services does this touch? (auth, metadata, notifications, etc.) -->
+
+## Tests
+<!-- How should this be tested? -->
+- [ ] Unit tests added/updated
+- [ ] Integration tests added/updated
+- [ ] Database migrations tested (if applicable)
+
+## Rollout
+<!-- Any deployment steps, environment variables, or database changes? -->
+
+## Dependencies
+<!-- Any blocking issues or external dependencies? -->

--- a/.github/ISSUE_TEMPLATE/client.md
+++ b/.github/ISSUE_TEMPLATE/client.md
@@ -1,0 +1,26 @@
+---
+name: Frontend (Client)
+about: Work on the React consumer web app
+title: "[client] "
+labels: ["package:client"]
+---
+
+## Build Location
+`./client/` — React 19, Vite, TypeScript
+
+## Description
+<!-- What needs to be built or fixed? -->
+
+## Affected APIs
+<!-- Which SDK or backend endpoints does this touch? -->
+
+## Tests
+<!-- How should this be tested? -->
+- [ ] Unit tests added/updated
+- [ ] Manual testing completed
+
+## Rollout
+<!-- Any deployment or migration steps? -->
+
+## Dependencies
+<!-- Any blocking issues or external dependencies? -->

--- a/.github/ISSUE_TEMPLATE/cross-package.md
+++ b/.github/ISSUE_TEMPLATE/cross-package.md
@@ -1,0 +1,27 @@
+---
+name: Cross-Package
+about: Work that spans multiple packages or the root build
+title: "[cross-package] "
+labels: ["cross-package"]
+---
+
+## Build Location
+<!-- Which packages are affected? -->
+
+## Description
+<!-- What needs to be built or fixed? -->
+
+## Affected APIs
+<!-- Which modules, endpoints, or systems are impacted? -->
+
+## Tests
+<!-- How should this be tested? -->
+- [ ] Affected package checks pass
+- [ ] Root build passes
+- [ ] Integration tests pass
+
+## Rollout
+<!-- Any special deployment or coordination steps? -->
+
+## Dependencies
+<!-- Any blocking issues or external dependencies? -->

--- a/.github/ISSUE_TEMPLATE/docs.md
+++ b/.github/ISSUE_TEMPLATE/docs.md
@@ -1,0 +1,27 @@
+---
+name: Docs & Ops
+about: Work on documentation, architecture, or operational concerns
+title: "[docs] "
+labels: ["docs"]
+---
+
+## Build Location
+`./docs/` — Architecture, guides, and operational documentation
+
+## Description
+<!-- What needs to be documented or updated? -->
+
+## Affected Areas
+<!-- Which packages or systems does this document? -->
+
+## Tests
+<!-- How should this be verified? -->
+- [ ] Links verified
+- [ ] Code examples tested (if applicable)
+- [ ] Diagrams updated (if applicable)
+
+## Rollout
+<!-- Any deployment or visibility changes? -->
+
+## Dependencies
+<!-- Any blocking issues or external dependencies? -->

--- a/.github/ISSUE_TEMPLATE/indexer.md
+++ b/.github/ISSUE_TEMPLATE/indexer.md
@@ -1,0 +1,27 @@
+---
+name: Indexer
+about: Work on blockchain event ingestion (Horizon → decode → PostgreSQL)
+title: "[indexer] "
+labels: ["package:indexer"]
+---
+
+## Build Location
+`./indexer/` — NestJS, Horizon integration, PostgreSQL + Redis cache
+
+## Description
+<!-- What needs to be built or fixed? -->
+
+## Affected APIs
+<!-- Which events or data flows does this touch? -->
+
+## Tests
+<!-- How should this be tested? -->
+- [ ] Unit tests added/updated
+- [ ] Event ingestion tested
+- [ ] Cache behavior verified
+
+## Rollout
+<!-- Any database schema changes or cache invalidation needed? -->
+
+## Dependencies
+<!-- Any blocking issues or external dependencies? -->

--- a/.github/ISSUE_TEMPLATE/oracle.md
+++ b/.github/ISSUE_TEMPLATE/oracle.md
@@ -1,0 +1,27 @@
+---
+name: Oracle
+about: Work on the randomness oracle (VRF/PRNG, draw requests)
+title: "[oracle] "
+labels: ["package:oracle"]
+---
+
+## Build Location
+`./oracle/` — NestJS, listens for draw requests, computes VRF/PRNG
+
+## Description
+<!-- What needs to be built or fixed? -->
+
+## Affected APIs
+<!-- Which contract methods or oracle endpoints does this touch? -->
+
+## Tests
+<!-- How should this be tested? -->
+- [ ] Unit tests added/updated
+- [ ] Draw request handling tested
+- [ ] VRF/PRNG computation verified
+
+## Rollout
+<!-- Any configuration or environment changes needed? -->
+
+## Dependencies
+<!-- Any blocking issues or external dependencies? -->

--- a/.github/ISSUE_TEMPLATE/sdk.md
+++ b/.github/ISSUE_TEMPLATE/sdk.md
@@ -1,0 +1,27 @@
+---
+name: SDK
+about: Work on the NestJS Soroban contract interaction library
+title: "[sdk] "
+labels: ["package:sdk"]
+---
+
+## Build Location
+`./sdk/` — NestJS library, published as `@tikka/sdk`
+
+## Description
+<!-- What needs to be built or fixed? -->
+
+## Affected APIs
+<!-- Which modules or public APIs does this change? (Raffle, Ticket, Wallet, User, Network, Utils) -->
+
+## Tests
+<!-- How should this be tested? -->
+- [ ] Unit tests added/updated
+- [ ] Integration tests added/updated
+- [ ] TypeDoc updated if public API changes
+
+## Rollout
+<!-- Any version bump or breaking changes? -->
+
+## Dependencies
+<!-- Any blocking issues or external dependencies? -->

--- a/.github/ISSUE_TEMPLATE/security.md
+++ b/.github/ISSUE_TEMPLATE/security.md
@@ -1,0 +1,31 @@
+---
+name: Security
+about: Report a security vulnerability or work on security improvements
+title: "[security] "
+labels: ["security"]
+---
+
+## Build Location
+<!-- Which package(s) are affected? -->
+
+## Description
+<!-- What is the security concern? -->
+
+## Affected APIs
+<!-- Which endpoints, contracts, or systems are impacted? -->
+
+## Tests
+<!-- How should this be tested? -->
+- [ ] Vulnerability verified
+- [ ] Fix tested
+- [ ] No regressions introduced
+
+## Rollout
+<!-- Any special deployment or notification steps? -->
+
+## Dependencies
+<!-- Any blocking issues or external dependencies? -->
+
+---
+
+**Note:** For sensitive security issues, please report privately via GitHub Security Advisory instead of opening a public issue.


### PR DESCRIPTION
Closes #636
- Create templates for client, sdk, backend, indexer, oracle, docs, security, and cross-package work
- Include build location, affected APIs, tests, rollout, and dependencies fields
- Add package-specific labels for consistent issue scoping
- Provide Stellar Wave-style where-to-build guidance for contributors