### PR TITLE
feat: strengthen raffle DTO validation boundaries

### DIFF
--- a/backend/pnpm-lock.yaml
+++ b/backend/pnpm-lock.yaml
@@ -33,14 +33,14 @@ importers:
         specifier: ^11.1.17
         version: 11.1.19(@fastify/static@9.0.0)(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))
       '@nestjs/swagger':
-        specifier: ^11.4.1
-        version: 11.4.1(@fastify/static@9.0.0)(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)
+        specifier: ^11.4.2
+        version: 11.4.4(@fastify/static@9.0.0)(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)
       '@nestjs/throttler':
         specifier: ^6.4.0
         version: 6.5.0(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)
       '@nestjs/typeorm':
         specifier: ^11.0.0
-        version: 11.0.0(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)(typeorm@0.3.28(pg@8.20.0)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))
+        version: 11.0.0(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)(typeorm@0.3.28(ioredis@5.11.0)(pg@8.20.0)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))
       '@sentry/node':
         specifier: 8.55.1
         version: 8.55.1
@@ -62,6 +62,9 @@ importers:
       firebase-admin:
         specifier: ^13.8.0
         version: 13.8.0
+      ioredis:
+        specifier: ^5.6.1
+        version: 5.11.0
       nestjs-pino:
         specifier: ^4.4.1
         version: 4.6.1(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(pino-http@11.0.0)(pino@9.14.0)(rxjs@7.8.2)
@@ -91,7 +94,7 @@ importers:
         version: 0.33.5
       typeorm:
         specifier: ^0.3.28
-        version: 0.3.28(pg@8.20.0)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+        version: 0.3.28(ioredis@5.11.0)(pg@8.20.0)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
       zod:
         specifier: ^3.23.0
         version: 3.25.76
@@ -472,67 +475,79 @@ packages:
     resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.0.5':
     resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.0.4':
     resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.0.4':
     resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
     resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.0.4':
     resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.33.5':
     resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.33.5':
     resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.33.5':
     resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.33.5':
     resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.33.5':
     resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.33.5':
     resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.33.5':
     resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
@@ -693,6 +708,9 @@ packages:
     peerDependenciesMeta:
       '@types/node':
         optional: true
+
+  '@ioredis/commands@1.10.0':
+    resolution: {integrity: sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q==}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -903,8 +921,8 @@ packages:
       prettier:
         optional: true
 
-  '@nestjs/swagger@11.4.1':
-    resolution: {integrity: sha512-GuGzs8F1Cb3n+eEarmOqB4nt2ai+x4XGOYUXNYplOtDeB59DaFY5E16bsHsBWXiWgD1ywbyKQ5OVv02bQtB1Dw==}
+  '@nestjs/swagger@11.4.4':
+    resolution: {integrity: sha512-VaIo1ruV2G7b+f2zPzkBSUNy9a/WQ9sg8TLKhWlrTfg4O6U10M/PA7Xi6XMXadOVhwOqoesijba8jH3i/3adrA==}
     peerDependencies:
       '@fastify/static': ^8.0.0 || ^9.0.0
       '@nestjs/common': ^11.0.1
@@ -1843,6 +1861,10 @@ packages:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
     engines: {node: '>=0.8'}
 
+  cluster-key-slot@1.1.1:
+    resolution: {integrity: sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw==}
+    engines: {node: '>=0.10.0'}
+
   co@4.6.0:
     resolution: {integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==}
     engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
@@ -1975,6 +1997,10 @@ packages:
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
+
+  denque@2.1.0:
+    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
+    engines: {node: '>=0.10'}
 
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
@@ -2459,6 +2485,10 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
+  ioredis@5.11.0:
+    resolution: {integrity: sha512-EZBErytyVovD8f6pDfG3Kb37N6Y3lmDA9NNj+4+IP13CzzHGeX+OyeRM2Um13khRzoBSzzL+5lVnCX8V2RLeMg==}
+    engines: {node: '>=12.22.0'}
+
   ipaddr.js@2.3.0:
     resolution: {integrity: sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg==}
     engines: {node: '>= 10'}
@@ -2809,9 +2839,6 @@ packages:
 
   lodash.once@4.1.1:
     resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
-
-  lodash@4.17.23:
-    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
 
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
@@ -3242,6 +3269,14 @@ packages:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
     engines: {node: '>= 12.13.0'}
 
+  redis-errors@1.2.0:
+    resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
+    engines: {node: '>=4'}
+
+  redis-parser@3.0.0:
+    resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
+    engines: {node: '>=4'}
+
   reflect-metadata@0.2.2:
     resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
 
@@ -3436,6 +3471,9 @@ packages:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
 
+  standard-as-callback@2.1.0:
+    resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
@@ -3519,8 +3557,8 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  swagger-ui-dist@5.32.4:
-    resolution: {integrity: sha512-0AADFFQNJzExEN49SrD/34Nn9cxNxVLiydYl2MBwSZFPVXNkVwC/EFAjoezGGqE8oDegiDC+p47t8lKObCinMQ==}
+  swagger-ui-dist@5.32.6:
+    resolution: {integrity: sha512-75ttZNaYCLoFPnozPZcTUU6mS3wKT8l7WLjU5zJSHFeJa23i5vtnze6IiCl4jDMPeQTXVXIgovq4M11NNfQvSA==}
 
   symbol-observable@4.0.0:
     resolution: {integrity: sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==}
@@ -4549,6 +4587,8 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.15
 
+  '@ioredis/commands@1.10.0': {}
+
   '@isaacs/cliui@8.0.2':
     dependencies:
       string-width: 5.1.2
@@ -4879,7 +4919,7 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@nestjs/swagger@11.4.1(@fastify/static@9.0.0)(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)':
+  '@nestjs/swagger@11.4.4(@fastify/static@9.0.0)(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)':
     dependencies:
       '@microsoft/tsdoc': 0.16.0
       '@nestjs/common': 10.4.22(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -4889,7 +4929,7 @@ snapshots:
       lodash: 4.18.1
       path-to-regexp: 8.4.2
       reflect-metadata: 0.2.2
-      swagger-ui-dist: 5.32.4
+      swagger-ui-dist: 5.32.6
     optionalDependencies:
       '@fastify/static': 9.0.0
       class-transformer: 0.5.1
@@ -4907,13 +4947,13 @@ snapshots:
       '@nestjs/core': 10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)
       reflect-metadata: 0.2.2
 
-  '@nestjs/typeorm@11.0.0(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)(typeorm@0.3.28(pg@8.20.0)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))':
+  '@nestjs/typeorm@11.0.0(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)(typeorm@0.3.28(ioredis@5.11.0)(pg@8.20.0)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))':
     dependencies:
       '@nestjs/common': 10.4.22(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core': 10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)
       reflect-metadata: 0.2.2
       rxjs: 7.8.2
-      typeorm: 0.3.28(pg@8.20.0)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+      typeorm: 0.3.28(ioredis@5.11.0)(pg@8.20.0)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
 
   '@noble/curves@1.9.7':
     dependencies:
@@ -6025,6 +6065,8 @@ snapshots:
 
   clone@1.0.4: {}
 
+  cluster-key-slot@1.1.1: {}
+
   co@4.6.0: {}
 
   collect-v8-coverage@1.0.3: {}
@@ -6136,6 +6178,8 @@ snapshots:
       gopd: 1.2.0
 
   delayed-stream@1.0.0: {}
+
+  denque@2.1.0: {}
 
   depd@2.0.0:
     optional: true
@@ -6736,6 +6780,18 @@ snapshots:
 
   inherits@2.0.4: {}
 
+  ioredis@5.11.0:
+    dependencies:
+      '@ioredis/commands': 1.10.0
+      cluster-key-slot: 1.1.1
+      debug: 4.4.3
+      denque: 2.1.0
+      redis-errors: 1.2.0
+      redis-parser: 3.0.0
+      standard-as-callback: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   ipaddr.js@2.3.0: {}
 
   is-arrayish@0.2.1: {}
@@ -7276,8 +7332,6 @@ snapshots:
 
   lodash.once@4.1.1: {}
 
-  lodash@4.17.23: {}
-
   lodash@4.18.1: {}
 
   log-symbols@4.1.0:
@@ -7386,7 +7440,7 @@ snapshots:
 
   node-emoji@1.11.0:
     dependencies:
-      lodash: 4.17.23
+      lodash: 4.18.1
 
   node-fetch@2.7.0:
     dependencies:
@@ -7697,6 +7751,12 @@ snapshots:
 
   real-require@0.2.0: {}
 
+  redis-errors@1.2.0: {}
+
+  redis-parser@3.0.0:
+    dependencies:
+      redis-errors: 1.2.0
+
   reflect-metadata@0.2.2: {}
 
   require-directory@2.1.1: {}
@@ -7910,6 +7970,8 @@ snapshots:
     dependencies:
       escape-string-regexp: 2.0.0
 
+  standard-as-callback@2.1.0: {}
+
   statuses@2.0.2:
     optional: true
 
@@ -8002,7 +8064,7 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  swagger-ui-dist@5.32.4:
+  swagger-ui-dist@5.32.6:
     dependencies:
       '@scarf/scarf': 1.4.0
 
@@ -8143,7 +8205,7 @@ snapshots:
       es-errors: 1.3.0
       is-typed-array: 1.1.15
 
-  typeorm@0.3.28(pg@8.20.0)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)):
+  typeorm@0.3.28(ioredis@5.11.0)(pg@8.20.0)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)):
     dependencies:
       '@sqltools/formatter': 1.2.5
       ansis: 4.2.0
@@ -8161,6 +8223,7 @@ snapshots:
       uuid: 11.1.0
       yargs: 17.7.2
     optionalDependencies:
+      ioredis: 5.11.0
       pg: 8.20.0
       ts-node: 10.9.2(@types/node@22.19.15)(typescript@5.9.3)
     transitivePeerDependencies:

--- a/backend/src/api/rest/raffles/dto/batch-metadata-query.dto.ts
+++ b/backend/src/api/rest/raffles/dto/batch-metadata-query.dto.ts
@@ -1,28 +1,46 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { z } from 'zod';
 
+export const MAX_BATCH_IDS = 50;
+
 /** Query params for GET /raffles/metadata?ids=1,2,3 */
 export const BatchMetadataQuerySchema = z.object({
   ids: z
     .string()
-    .min(1)
-    .transform((val) =>
-      val
+    .min(1, 'ids must not be empty')
+    .transform((val, ctx) => {
+      const items = val
         .split(',')
         .map((s) => s.trim())
-        .filter(Boolean)
-        .map((s) => {
-          const n = parseInt(s, 10);
-          if (isNaN(n) || n <= 0) throw new Error(`Invalid raffle id: "${s}"`);
-          return n;
-        }),
-    )
-    .refine((ids) => ids.length <= 100, {
-      message: 'Cannot request more than 100 IDs at once',
+        .filter(Boolean);
+
+      const result: number[] = [];
+      for (const s of items) {
+        const n = Number(s);
+        if (!Number.isInteger(n) || n <= 0) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `Invalid raffle ID "${s}": must be a positive integer`,
+          });
+          return z.NEVER;
+        }
+        result.push(n);
+      }
+      return result;
+    })
+    .refine((ids) => ids.length > 0, {
+      message: 'At least one valid ID is required',
+    })
+    .refine((ids) => ids.length <= MAX_BATCH_IDS, {
+      message: `Cannot request more than ${MAX_BATCH_IDS} IDs at once`,
     }),
 });
 
 export class BatchMetadataQueryDto {
-  @ApiProperty({ type: 'string', description: 'Comma-separated list of raffle IDs (max 100)' })
+  @ApiProperty({
+    type: 'string',
+    description: `Comma-separated list of raffle IDs (max ${MAX_BATCH_IDS})`,
+    example: '1,2,3',
+  })
   ids: number[];
 }

--- a/backend/src/api/rest/raffles/dto/list-raffles-query.dto.ts
+++ b/backend/src/api/rest/raffles/dto/list-raffles-query.dto.ts
@@ -1,33 +1,72 @@
 import { z } from 'zod';
 import { ApiPropertyOptional } from '@nestjs/swagger';
 
+export const MAX_PAGE_LIMIT = 50;
+
+const STELLAR_ADDRESS_RE = /^G[A-Z2-7]{55}$/;
+const ASSET_CODE_RE = /^[A-Za-z0-9]+$/;
+
 /** Query params for GET /raffles */
 export const ListRafflesQuerySchema = z.object({
-  status: z.string().optional(),
-  category: z.string().optional(),
-  creator: z.string().optional(),
-  asset: z.string().optional(),
-  limit: z.coerce.number().int().min(1).max(100).default(20).optional(),
-  offset: z.coerce.number().int().min(0).default(0).optional(),
+  status: z
+    .string()
+    .max(50, 'status must be at most 50 characters')
+    .optional(),
+  category: z
+    .string()
+    .max(100, 'category must be at most 100 characters')
+    .optional(),
+  creator: z
+    .string()
+    .regex(
+      STELLAR_ADDRESS_RE,
+      'creator must be a valid Stellar public key (G followed by 55 base-32 characters)',
+    )
+    .optional(),
+  asset: z
+    .string()
+    .min(1, 'asset code must be at least 1 character')
+    .max(12, 'asset code must be at most 12 characters')
+    .regex(ASSET_CODE_RE, 'asset code must contain only alphanumeric characters')
+    .optional(),
+  limit: z.coerce
+    .number({ invalid_type_error: 'limit must be a number' })
+    .int('limit must be an integer')
+    .min(1, 'limit must be at least 1')
+    .max(MAX_PAGE_LIMIT, `limit must not exceed ${MAX_PAGE_LIMIT}`)
+    .default(20),
+  offset: z.coerce
+    .number({ invalid_type_error: 'offset must be a number' })
+    .int('offset must be an integer')
+    .min(0, 'offset must be at least 0')
+    .default(0),
 });
 
 export class ListRafflesQueryDto {
-  @ApiPropertyOptional({ description: 'Filter by raffle status' })
+  @ApiPropertyOptional({ description: 'Filter by raffle status', maxLength: 50 })
   status?: string;
 
-  @ApiPropertyOptional({ description: 'Filter by raffle category' })
+  @ApiPropertyOptional({ description: 'Filter by raffle category', maxLength: 100 })
   category?: string;
 
-  @ApiPropertyOptional({ description: 'Filter by raffle creator' })
+  @ApiPropertyOptional({
+    description: 'Filter by raffle creator — must be a valid Stellar public key',
+    pattern: '^G[A-Z2-7]{55}$',
+  })
   creator?: string;
 
-  @ApiPropertyOptional({ description: 'Filter by asset code' })
+  @ApiPropertyOptional({
+    description: 'Filter by asset code (1–12 alphanumeric characters)',
+    minLength: 1,
+    maxLength: 12,
+    pattern: '^[A-Za-z0-9]+$',
+  })
   asset?: string;
 
   @ApiPropertyOptional({
     description: 'Number of records to return',
     minimum: 1,
-    maximum: 100,
+    maximum: MAX_PAGE_LIMIT,
     default: 20,
   })
   limit?: number;

--- a/backend/src/api/rest/raffles/dto/purchase-ticket.dto.ts
+++ b/backend/src/api/rest/raffles/dto/purchase-ticket.dto.ts
@@ -1,12 +1,22 @@
 import { z } from 'zod';
 import { ApiProperty } from '@nestjs/swagger';
 
+export const MAX_TICKET_QUANTITY = 100;
+
 export const PurchaseTicketSchema = z.object({
-  quantity: z.coerce.number().int().min(1).max(100),
+  quantity: z.coerce
+    .number({ invalid_type_error: 'quantity must be a number' })
+    .int('quantity must be an integer')
+    .min(1, 'quantity must be at least 1')
+    .max(MAX_TICKET_QUANTITY, `quantity must not exceed ${MAX_TICKET_QUANTITY}`),
 });
 
 export class PurchaseTicketDto {
-  @ApiProperty({ description: 'Number of tickets to purchase', minimum: 1, maximum: 100 })
+  @ApiProperty({
+    description: 'Number of tickets to purchase',
+    minimum: 1,
+    maximum: MAX_TICKET_QUANTITY,
+  })
   quantity!: number;
 }
 

--- a/backend/src/api/rest/raffles/dto/raffle-dto-validation.spec.ts
+++ b/backend/src/api/rest/raffles/dto/raffle-dto-validation.spec.ts
@@ -1,0 +1,351 @@
+import { ListRafflesQuerySchema, MAX_PAGE_LIMIT } from './list-raffles-query.dto';
+import { PurchaseTicketSchema, MAX_TICKET_QUANTITY } from './purchase-ticket.dto';
+import { BatchMetadataQuerySchema, MAX_BATCH_IDS } from './batch-metadata-query.dto';
+import {
+  UpsertMetadataSchema,
+  METADATA_TITLE_MAX,
+  METADATA_DESCRIPTION_MAX,
+  METADATA_CATEGORY_MAX,
+  METADATA_IMAGE_URLS_MAX_COUNT,
+} from '../metadata.schema';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const ok = <T>(result: { success: boolean; data?: T }) => {
+  expect(result.success).toBe(true);
+  return (result as { success: true; data: T }).data;
+};
+
+const err = (result: { success: boolean; error?: { errors: { message: string }[] } }) => {
+  expect(result.success).toBe(false);
+  return (result as { success: false; error: { errors: { message: string }[] } }).error.errors;
+};
+
+const messages = (result: { success: boolean; error?: { errors: { message: string }[] } }) =>
+  err(result).map((e) => e.message);
+
+// ---------------------------------------------------------------------------
+// ListRafflesQuerySchema — pagination & filter validation
+// ---------------------------------------------------------------------------
+
+describe('ListRafflesQuerySchema', () => {
+  describe('limit', () => {
+    it('accepts limit at the maximum allowed value', () => {
+      const data = ok(ListRafflesQuerySchema.safeParse({ limit: MAX_PAGE_LIMIT }));
+      expect(data.limit).toBe(MAX_PAGE_LIMIT);
+    });
+
+    it('rejects limit above the maximum', () => {
+      const msgs = messages(ListRafflesQuerySchema.safeParse({ limit: MAX_PAGE_LIMIT + 1 }));
+      expect(msgs.some((m) => m.includes(`must not exceed ${MAX_PAGE_LIMIT}`))).toBe(true);
+    });
+
+    it('rejects limit of zero', () => {
+      const msgs = messages(ListRafflesQuerySchema.safeParse({ limit: 0 }));
+      expect(msgs.some((m) => m.includes('at least 1'))).toBe(true);
+    });
+
+    it('rejects negative limit', () => {
+      const msgs = messages(ListRafflesQuerySchema.safeParse({ limit: -5 }));
+      expect(msgs.some((m) => m.includes('at least 1'))).toBe(true);
+    });
+
+    it('coerces string numbers', () => {
+      const data = ok(ListRafflesQuerySchema.safeParse({ limit: '10' }));
+      expect(data.limit).toBe(10);
+    });
+
+    it('rejects non-numeric limit string', () => {
+      const msgs = messages(ListRafflesQuerySchema.safeParse({ limit: 'abc' }));
+      expect(msgs.some((m) => /number|integer/i.test(m))).toBe(true);
+    });
+
+    it('defaults to 20 when omitted', () => {
+      const data = ok(ListRafflesQuerySchema.safeParse({}));
+      expect(data.limit).toBe(20);
+    });
+  });
+
+  describe('offset', () => {
+    it('accepts zero', () => {
+      const data = ok(ListRafflesQuerySchema.safeParse({ offset: 0 }));
+      expect(data.offset).toBe(0);
+    });
+
+    it('rejects negative offset', () => {
+      const msgs = messages(ListRafflesQuerySchema.safeParse({ offset: -1 }));
+      expect(msgs.some((m) => m.includes('at least 0'))).toBe(true);
+    });
+  });
+
+  describe('creator', () => {
+    it('accepts a valid Stellar G-address', () => {
+      const validAddress = 'G' + 'A'.repeat(55);
+      const data = ok(ListRafflesQuerySchema.safeParse({ creator: validAddress }));
+      expect(data.creator).toBe(validAddress);
+    });
+
+    it('rejects an address that is too short', () => {
+      const msgs = messages(ListRafflesQuerySchema.safeParse({ creator: 'GABC123' }));
+      expect(msgs.some((m) => /stellar|public key/i.test(m))).toBe(true);
+    });
+
+    it('rejects an address that does not start with G', () => {
+      const msgs = messages(ListRafflesQuerySchema.safeParse({ creator: 'S' + 'A'.repeat(55) }));
+      expect(msgs.some((m) => /stellar|public key/i.test(m))).toBe(true);
+    });
+
+    it('rejects arbitrary strings', () => {
+      const msgs = messages(ListRafflesQuerySchema.safeParse({ creator: 'not-an-address' }));
+      expect(msgs.some((m) => /stellar|public key/i.test(m))).toBe(true);
+    });
+
+    it('is optional — omitting it is valid', () => {
+      expect(ListRafflesQuerySchema.safeParse({}).success).toBe(true);
+    });
+  });
+
+  describe('asset', () => {
+    it('accepts valid alphanumeric asset codes', () => {
+      expect(ListRafflesQuerySchema.safeParse({ asset: 'XLM' }).success).toBe(true);
+      expect(ListRafflesQuerySchema.safeParse({ asset: 'USDC' }).success).toBe(true);
+    });
+
+    it('rejects asset codes with special characters', () => {
+      const msgs = messages(ListRafflesQuerySchema.safeParse({ asset: 'US-DC' }));
+      expect(msgs.some((m) => /alphanumeric/i.test(m))).toBe(true);
+    });
+
+    it('rejects asset codes longer than 12 characters', () => {
+      const msgs = messages(ListRafflesQuerySchema.safeParse({ asset: 'A'.repeat(13) }));
+      expect(msgs.some((m) => /12/i.test(m))).toBe(true);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PurchaseTicketSchema — quantity validation
+// ---------------------------------------------------------------------------
+
+describe('PurchaseTicketSchema', () => {
+  it('accepts a valid positive integer quantity', () => {
+    const data = ok(PurchaseTicketSchema.safeParse({ quantity: 5 }));
+    expect(data.quantity).toBe(5);
+  });
+
+  it('accepts the maximum allowed quantity', () => {
+    const data = ok(PurchaseTicketSchema.safeParse({ quantity: MAX_TICKET_QUANTITY }));
+    expect(data.quantity).toBe(MAX_TICKET_QUANTITY);
+  });
+
+  it('rejects zero', () => {
+    const msgs = messages(PurchaseTicketSchema.safeParse({ quantity: 0 }));
+    expect(msgs.some((m) => m.includes('at least 1'))).toBe(true);
+  });
+
+  it('rejects negative quantities', () => {
+    const msgs = messages(PurchaseTicketSchema.safeParse({ quantity: -1 }));
+    expect(msgs.some((m) => m.includes('at least 1'))).toBe(true);
+  });
+
+  it('rejects quantities above the maximum', () => {
+    const msgs = messages(PurchaseTicketSchema.safeParse({ quantity: MAX_TICKET_QUANTITY + 1 }));
+    expect(msgs.some((m) => m.includes(`must not exceed ${MAX_TICKET_QUANTITY}`))).toBe(true);
+  });
+
+  it('rejects non-integer float', () => {
+    const msgs = messages(PurchaseTicketSchema.safeParse({ quantity: 1.5 }));
+    expect(msgs.some((m) => /integer/i.test(m))).toBe(true);
+  });
+
+  it('coerces numeric strings', () => {
+    const data = ok(PurchaseTicketSchema.safeParse({ quantity: '3' }));
+    expect(data.quantity).toBe(3);
+  });
+
+  it('rejects non-numeric strings', () => {
+    const msgs = messages(PurchaseTicketSchema.safeParse({ quantity: 'abc' }));
+    expect(msgs.some((m) => /number/i.test(m))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// BatchMetadataQuerySchema — ID list validation
+// ---------------------------------------------------------------------------
+
+describe('BatchMetadataQuerySchema', () => {
+  it('parses a valid comma-separated list of IDs', () => {
+    const data = ok(BatchMetadataQuerySchema.safeParse({ ids: '1,2,3' }));
+    expect(data.ids).toEqual([1, 2, 3]);
+  });
+
+  it('trims whitespace around IDs', () => {
+    const data = ok(BatchMetadataQuerySchema.safeParse({ ids: ' 1 , 2 , 3 ' }));
+    expect(data.ids).toEqual([1, 2, 3]);
+  });
+
+  it('rejects alphabetic IDs', () => {
+    const result = BatchMetadataQuerySchema.safeParse({ ids: 'abc,def' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects negative IDs', () => {
+    const result = BatchMetadataQuerySchema.safeParse({ ids: '-1,2' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects zero as an ID', () => {
+    const result = BatchMetadataQuerySchema.safeParse({ ids: '0,1' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects mixed valid and invalid IDs — e.g. "123abc"', () => {
+    const result = BatchMetadataQuerySchema.safeParse({ ids: '1,123abc' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects empty ids string', () => {
+    const result = BatchMetadataQuerySchema.safeParse({ ids: '' });
+    expect(result.success).toBe(false);
+  });
+
+  it(`rejects more than ${MAX_BATCH_IDS} IDs`, () => {
+    const ids = Array.from({ length: MAX_BATCH_IDS + 1 }, (_, i) => i + 1).join(',');
+    const msgs = messages(BatchMetadataQuerySchema.safeParse({ ids }));
+    expect(msgs.some((m) => m.includes(`${MAX_BATCH_IDS}`))).toBe(true);
+  });
+
+  it(`accepts exactly ${MAX_BATCH_IDS} IDs`, () => {
+    const ids = Array.from({ length: MAX_BATCH_IDS }, (_, i) => i + 1).join(',');
+    const data = ok(BatchMetadataQuerySchema.safeParse({ ids }));
+    expect(data.ids).toHaveLength(MAX_BATCH_IDS);
+  });
+
+  it('rejects float IDs', () => {
+    const result = BatchMetadataQuerySchema.safeParse({ ids: '1.5,2' });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// UpsertMetadataSchema — metadata payload validation
+// ---------------------------------------------------------------------------
+
+describe('UpsertMetadataSchema', () => {
+  it('accepts a fully valid payload', () => {
+    const result = UpsertMetadataSchema.safeParse({
+      title: 'My Raffle',
+      description: 'A great raffle',
+      image_url: 'https://example.com/image.png',
+      image_urls: ['https://example.com/a.png', 'https://example.com/b.png'],
+      category: 'art',
+      metadata_cid: 'QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  describe('title', () => {
+    it(`rejects titles longer than ${METADATA_TITLE_MAX} characters`, () => {
+      const msgs = messages(UpsertMetadataSchema.safeParse({ title: 'x'.repeat(METADATA_TITLE_MAX + 1) }));
+      expect(msgs.some((m) => m.includes(`${METADATA_TITLE_MAX}`))).toBe(true);
+    });
+
+    it(`accepts titles up to ${METADATA_TITLE_MAX} characters`, () => {
+      expect(UpsertMetadataSchema.safeParse({ title: 'x'.repeat(METADATA_TITLE_MAX) }).success).toBe(true);
+    });
+
+    it('is optional', () => {
+      expect(UpsertMetadataSchema.safeParse({}).success).toBe(true);
+    });
+  });
+
+  describe('description', () => {
+    it(`rejects descriptions longer than ${METADATA_DESCRIPTION_MAX} characters`, () => {
+      const msgs = messages(UpsertMetadataSchema.safeParse({ description: 'x'.repeat(METADATA_DESCRIPTION_MAX + 1) }));
+      expect(msgs.some((m) => m.includes(`${METADATA_DESCRIPTION_MAX}`))).toBe(true);
+    });
+
+    it(`accepts descriptions up to ${METADATA_DESCRIPTION_MAX} characters`, () => {
+      expect(
+        UpsertMetadataSchema.safeParse({ description: 'x'.repeat(METADATA_DESCRIPTION_MAX) }).success,
+      ).toBe(true);
+    });
+  });
+
+  describe('image_url', () => {
+    it('accepts a valid https URL', () => {
+      expect(
+        UpsertMetadataSchema.safeParse({ image_url: 'https://cdn.example.com/photo.jpg' }).success,
+      ).toBe(true);
+    });
+
+    it('accepts a valid http URL', () => {
+      expect(
+        UpsertMetadataSchema.safeParse({ image_url: 'http://cdn.example.com/photo.jpg' }).success,
+      ).toBe(true);
+    });
+
+    it('rejects javascript: URLs', () => {
+      const msgs = messages(UpsertMetadataSchema.safeParse({ image_url: 'javascript:alert(1)' }));
+      expect(msgs.some((m) => /http|https|valid/i.test(m))).toBe(true);
+    });
+
+    it('rejects data: URLs', () => {
+      const msgs = messages(UpsertMetadataSchema.safeParse({ image_url: 'data:text/html,<h1>xss</h1>' }));
+      expect(msgs.some((m) => /http|https|valid/i.test(m))).toBe(true);
+    });
+
+    it('rejects plain strings that are not URLs', () => {
+      const msgs = messages(UpsertMetadataSchema.safeParse({ image_url: 'not-a-url' }));
+      expect(msgs.some((m) => /http|https|valid/i.test(m))).toBe(true);
+    });
+
+    it('accepts null (to clear the image)', () => {
+      expect(UpsertMetadataSchema.safeParse({ image_url: null }).success).toBe(true);
+    });
+  });
+
+  describe('image_urls', () => {
+    it(`rejects arrays with more than ${METADATA_IMAGE_URLS_MAX_COUNT} entries`, () => {
+      const urls = Array.from(
+        { length: METADATA_IMAGE_URLS_MAX_COUNT + 1 },
+        (_, i) => `https://example.com/${i}.png`,
+      );
+      const msgs = messages(UpsertMetadataSchema.safeParse({ image_urls: urls }));
+      expect(msgs.some((m) => m.includes(`${METADATA_IMAGE_URLS_MAX_COUNT}`))).toBe(true);
+    });
+
+    it('rejects any invalid URL within the array', () => {
+      const urls = ['https://example.com/ok.png', 'javascript:alert(1)'];
+      const result = UpsertMetadataSchema.safeParse({ image_urls: urls });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects data: URLs within the array', () => {
+      const urls = ['https://example.com/ok.png', 'data:image/png;base64,abc'];
+      const result = UpsertMetadataSchema.safeParse({ image_urls: urls });
+      expect(result.success).toBe(false);
+    });
+
+    it('accepts an empty array', () => {
+      expect(UpsertMetadataSchema.safeParse({ image_urls: [] }).success).toBe(true);
+    });
+
+    it('accepts null', () => {
+      expect(UpsertMetadataSchema.safeParse({ image_urls: null }).success).toBe(true);
+    });
+  });
+
+  describe('category', () => {
+    it(`rejects categories longer than ${METADATA_CATEGORY_MAX} characters`, () => {
+      const msgs = messages(UpsertMetadataSchema.safeParse({ category: 'x'.repeat(METADATA_CATEGORY_MAX + 1) }));
+      expect(msgs.some((m) => m.includes(`${METADATA_CATEGORY_MAX}`))).toBe(true);
+    });
+
+    it('accepts null', () => {
+      expect(UpsertMetadataSchema.safeParse({ category: null }).success).toBe(true);
+    });
+  });
+});

--- a/backend/src/api/rest/raffles/metadata.schema.ts
+++ b/backend/src/api/rest/raffles/metadata.schema.ts
@@ -2,6 +2,29 @@ import { z } from "zod";
 import { ApiPropertyOptional } from "@nestjs/swagger";
 import { isAllowedTicketAsset, resolveAllowedTicketAssets } from "../../../config/stellar.constants";
 
+export const METADATA_TITLE_MAX = 200;
+export const METADATA_DESCRIPTION_MAX = 2000;
+export const METADATA_CATEGORY_MAX = 100;
+export const METADATA_CID_MAX = 128;
+export const METADATA_IMAGE_URL_MAX = 2048;
+export const METADATA_IMAGE_URLS_MAX_COUNT = 10;
+
+/** Validates that a string is a safe http/https URL (rejects javascript:, data:, etc.). */
+const SafeHttpUrlSchema = z
+  .string()
+  .max(METADATA_IMAGE_URL_MAX, `URL must not exceed ${METADATA_IMAGE_URL_MAX} characters`)
+  .refine(
+    (url) => {
+      try {
+        const { protocol } = new URL(url);
+        return protocol === "http:" || protocol === "https:";
+      } catch {
+        return false;
+      }
+    },
+    "Must be a valid http or https URL",
+  );
+
 /** Structured asset descriptor for ticket pricing. */
 export const AssetSchema = z.object({
   /** Asset code, e.g. "XLM", "USDC", "yXLM" */
@@ -22,33 +45,71 @@ export const AssetSchema = z.object({
 export type AssetDto = z.infer<typeof AssetSchema>;
 
 export const UpsertMetadataSchema = z.object({
-  title: z.string().optional(),
-  description: z.string().optional(),
-  image_url: z.string().nullable().optional(),
-  image_urls: z.array(z.string()).nullable().optional(),
-  category: z.string().nullable().optional(),
-  metadata_cid: z.string().nullable().optional(),
+  title: z
+    .string()
+    .max(METADATA_TITLE_MAX, `title must not exceed ${METADATA_TITLE_MAX} characters`)
+    .optional(),
+  description: z
+    .string()
+    .max(METADATA_DESCRIPTION_MAX, `description must not exceed ${METADATA_DESCRIPTION_MAX} characters`)
+    .optional(),
+  image_url: SafeHttpUrlSchema.nullable().optional(),
+  image_urls: z
+    .array(SafeHttpUrlSchema)
+    .max(METADATA_IMAGE_URLS_MAX_COUNT, `image_urls must not contain more than ${METADATA_IMAGE_URLS_MAX_COUNT} entries`)
+    .nullable()
+    .optional(),
+  category: z
+    .string()
+    .max(METADATA_CATEGORY_MAX, `category must not exceed ${METADATA_CATEGORY_MAX} characters`)
+    .nullable()
+    .optional(),
+  metadata_cid: z
+    .string()
+    .max(METADATA_CID_MAX, `metadata_cid must not exceed ${METADATA_CID_MAX} characters`)
+    .nullable()
+    .optional(),
   /** Asset used for ticket pricing. When provided, code must be on the whitelist. */
   asset: AssetSchema.optional(),
 });
 
 export class UpsertMetadataDto {
-  @ApiPropertyOptional({ description: "Title of the raffle" })
+  @ApiPropertyOptional({
+    description: "Title of the raffle",
+    maxLength: METADATA_TITLE_MAX,
+  })
   title?: string;
 
-  @ApiPropertyOptional({ description: "Description text" })
+  @ApiPropertyOptional({
+    description: "Description text",
+    maxLength: METADATA_DESCRIPTION_MAX,
+  })
   description?: string;
 
-  @ApiPropertyOptional({ description: "Primary image URL" })
+  @ApiPropertyOptional({
+    description: "Primary image URL (http or https only)",
+    maxLength: METADATA_IMAGE_URL_MAX,
+    format: "uri",
+  })
   image_url?: string;
 
-  @ApiPropertyOptional({ description: "Additional image URLs", type: [String] })
+  @ApiPropertyOptional({
+    description: `Additional image URLs (http or https only, max ${METADATA_IMAGE_URLS_MAX_COUNT})`,
+    type: [String],
+    maxItems: METADATA_IMAGE_URLS_MAX_COUNT,
+  })
   image_urls?: string[];
 
-  @ApiPropertyOptional({ description: "Category name" })
+  @ApiPropertyOptional({
+    description: "Category name",
+    maxLength: METADATA_CATEGORY_MAX,
+  })
   category?: string;
 
-  @ApiPropertyOptional({ description: "IPFS CID for metadata" })
+  @ApiPropertyOptional({
+    description: "IPFS CID for metadata",
+    maxLength: METADATA_CID_MAX,
+  })
   metadata_cid?: string;
 
   @ApiPropertyOptional({


### PR DESCRIPTION
## Description
Strengthened the DTO validation boundaries for the raffle REST API to reject ambiguous or unsafe input at the edge.

## Key Changes
- **Pagination & Quantities**: Added strict Zod caps for pagination limits and blocked negative/zero quantity values.
- **Data Integrity**: Enforced strict ID formatting and safe image URL structures.
- **Payload Protection**: Implemented metadata size constraints to prevent payload bloating and resource exhaustion.
- **Testing**: Added `raffle-dto-validation.spec.ts` to ensure invalid IDs, oversized metadata, and bad quantities are properly rejected with consistent API error responses.

Closes #533 