### PR TITLE
SDK: add runnable end-to-end examples

### DIFF
--- a/sdk/README.md
+++ b/sdk/README.md
@@ -40,6 +40,116 @@ The docs are organized by module: **Raffle** · **Ticket** · **Wallet** · **Us
 
 Full ecosystem spec: [../docs/ARCHITECTURE.md](../docs/ARCHITECTURE.md) (section 2 — tikka-sdk).
 
+## Examples
+
+All runnable examples live in [`examples/`](./examples/). They use `MockWalletAdapter` so they compile and run without a browser wallet — swap it for `FreighterAdapter` or another adapter when you need real signing.
+
+**Setup:**
+```bash
+cp examples/.env.example examples/.env
+# fill in TIKKA_PUBLIC_KEY and any other vars you need
+```
+
+**Type-check all examples (no network required):**
+```bash
+npm run examples:check
+```
+
+### [quickstart.ts](./examples/quickstart.ts)
+
+End-to-end walkthrough: bootstrap → create raffle → buy tickets → read state.
+
+| Env var | Required | Default | Description |
+|---|---|---|---|
+| `TIKKA_NETWORK` | no | `testnet` | `testnet` \| `mainnet` \| `standalone` |
+| `TIKKA_PUBLIC_KEY` | no | mock key | Stellar G… address |
+
+```bash
+TIKKA_NETWORK=testnet npx ts-node examples/quickstart.ts
+```
+
+### [create-raffle.ts](./examples/create-raffle.ts)
+
+Create a new raffle on-chain with configurable price, asset, and duration.
+
+| Env var | Required | Default | Description |
+|---|---|---|---|
+| `TIKKA_NETWORK` | no | `testnet` | Network |
+| `TIKKA_PUBLIC_KEY` | **yes** | — | Signer address |
+| `TIKKA_TICKET_PRICE` | no | `1` | Amount per ticket |
+| `TIKKA_ASSET_CODE` | no | `XLM` | Asset code |
+| `TIKKA_ASSET_ISSUER` | no | `""` | Issuer for non-native assets |
+| `TIKKA_MAX_TICKETS` | no | `50` | Max tickets available |
+| `TIKKA_DURATION_HOURS` | no | `24` | Hours until raffle closes |
+| `TIKKA_METADATA_CID` | no | `""` | IPFS CID for metadata |
+
+```bash
+TIKKA_PUBLIC_KEY=G... npx ts-node examples/create-raffle.ts
+# USDC example:
+TIKKA_ASSET_CODE=USDC TIKKA_ASSET_ISSUER=GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN \
+  TIKKA_PUBLIC_KEY=G... npx ts-node examples/create-raffle.ts
+```
+
+### [buy-tickets.ts](./examples/buy-tickets.ts)
+
+Purchase tickets for an existing raffle, with pre-flight status checks.
+
+| Env var | Required | Default | Description |
+|---|---|---|---|
+| `TIKKA_NETWORK` | no | `testnet` | Network |
+| `TIKKA_PUBLIC_KEY` | **yes** | — | Buyer address |
+| `TIKKA_RAFFLE_ID` | **yes** | — | Numeric raffle ID |
+| `TIKKA_QUANTITY` | no | `1` | Number of tickets |
+
+```bash
+TIKKA_PUBLIC_KEY=G... TIKKA_RAFFLE_ID=1 npx ts-node examples/buy-tickets.ts
+```
+
+### [listen-events.ts](./examples/listen-events.ts)
+
+Poll Soroban contract events (`RaffleCreated`, `TicketPurchased`, `RaffleFinalized`) with optional raffle filter. Runs until Ctrl+C.
+
+> **Network required** — connects to the Soroban RPC to stream events.
+
+| Env var | Required | Default | Description |
+|---|---|---|---|
+| `TIKKA_NETWORK` | no | `testnet` | Network |
+| `TIKKA_RAFFLE_ID` | no | all | Filter events for one raffle |
+| `TIKKA_POLL_MS` | no | `5000` | Polling interval (ms) |
+| `TIKKA_CONTRACT_ID` | no | built-in | Override contract address |
+
+```bash
+TIKKA_NETWORK=testnet npx ts-node examples/listen-events.ts
+# filter to raffle #1:
+TIKKA_RAFFLE_ID=1 npx ts-node examples/listen-events.ts
+```
+
+### [offline-signing.ts](./examples/offline-signing.ts)
+
+Cold-wallet / air-gapped signing flow. Step 1 builds an unsigned XDR; Step 3 submits a pre-signed XDR. Useful for multisig and hardware wallets.
+
+> **Network required** — Step 1 calls `simulateTransaction`; Step 3 submits to the network.
+
+| Env var | Required | Default | Description |
+|---|---|---|---|
+| `TIKKA_NETWORK` | no | `testnet` | Network |
+| `TIKKA_PUBLIC_KEY` | **yes** | — | Source account address |
+| `TIKKA_SIGNED_XDR` | no | — | Provide to skip to Step 3 (submit) |
+
+```bash
+# Step 1 — build unsigned XDR:
+TIKKA_PUBLIC_KEY=G... npx ts-node examples/offline-signing.ts
+
+# Step 3 — submit after signing offline:
+TIKKA_PUBLIC_KEY=G... TIKKA_SIGNED_XDR=<xdr> npx ts-node examples/offline-signing.ts
+```
+
+### [albedo-wallet.ts](./examples/albedo-wallet.ts) · [rabet-wallet.ts](./examples/rabet-wallet.ts)
+
+Browser-wallet integration demos. These require a browser environment (Albedo opens a popup; Rabet needs the extension installed).
+
+> **Browser + wallet required** — not runnable via `ts-node` in a plain terminal.
+
 ## Wallet Adapters
 
 The SDK provides a unified interface for multiple Stellar wallets. All adapters implement the same `WalletAdapter` interface with `getPublicKey()` and `signTransaction(xdr)` methods.

--- a/sdk/examples/.env.example
+++ b/sdk/examples/.env.example
@@ -1,0 +1,58 @@
+# ─── Tikka SDK — Example Environment Variables ───────────────────────────────
+#
+# Copy this file to .env and fill in the values before running any example.
+# Network-required examples will fail gracefully when these are absent.
+#
+# Usage:
+#   cp examples/.env.example examples/.env
+#   # edit .env, then:
+#   npx ts-node examples/quickstart.ts
+
+# ── Network ───────────────────────────────────────────────────────────────────
+# Which Stellar network to target.
+# Values: testnet | mainnet | standalone
+# Default: testnet
+TIKKA_NETWORK=testnet
+
+# ── Account ───────────────────────────────────────────────────────────────────
+# Your Stellar public key (G... address, 56 chars).
+# Required by: quickstart, create-raffle, buy-tickets, buy-tickets-batch,
+#              offline-signing, estimate-fee
+TIKKA_PUBLIC_KEY=
+
+# ── Contract overrides (optional) ─────────────────────────────────────────────
+# Override the default raffle contract address for the chosen network.
+# Leave blank to use the built-in address from src/contract/constants.ts.
+TIKKA_CONTRACT_TESTNET=
+TIKKA_CONTRACT_MAINNET=
+TIKKA_CONTRACT_STANDALONE=
+
+# ── create-raffle ─────────────────────────────────────────────────────────────
+TIKKA_TICKET_PRICE=1          # Amount per ticket (default: 1)
+TIKKA_ASSET_CODE=XLM          # Asset code (default: XLM)
+TIKKA_ASSET_ISSUER=           # Issuer for non-native assets (leave blank for XLM)
+TIKKA_MAX_TICKETS=50          # Maximum tickets available (default: 50)
+TIKKA_DURATION_HOURS=24       # Hours until raffle closes (default: 24)
+TIKKA_METADATA_CID=           # IPFS CID for raffle metadata (optional)
+
+# ── buy-tickets ───────────────────────────────────────────────────────────────
+TIKKA_RAFFLE_ID=              # Numeric raffle ID to buy into (required)
+TIKKA_QUANTITY=1              # Number of tickets to buy (default: 1)
+
+# ── buy-tickets-batch ─────────────────────────────────────────────────────────
+TIKKA_RAFFLE_IDS=             # Comma-separated raffle IDs, e.g. "1,2,3"
+TIKKA_QUANTITIES=             # Comma-separated quantities per raffle, e.g. "5,3,2"
+
+# ── listen-events ─────────────────────────────────────────────────────────────
+# TIKKA_RAFFLE_ID              (reuses the variable above — filter by raffle)
+TIKKA_POLL_MS=5000            # Polling interval in milliseconds (default: 5000)
+TIKKA_CONTRACT_ID=            # Override contract address for event filtering
+
+# ── offline-signing ───────────────────────────────────────────────────────────
+# TIKKA_PUBLIC_KEY             (reuses the variable above — source account)
+TIKKA_SIGNED_XDR=             # Provide to skip Step 1 and submit a pre-signed XDR
+
+# ── estimate-fee ──────────────────────────────────────────────────────────────
+# TIKKA_PUBLIC_KEY             (reuses the variable above — tx source)
+# TIKKA_RAFFLE_ID              (reuses the variable above)
+# TIKKA_QUANTITY               (reuses the variable above)

--- a/sdk/examples/albedo-wallet.ts
+++ b/sdk/examples/albedo-wallet.ts
@@ -79,8 +79,15 @@ async function main() {
 
     // Step 2: Verify raffle is open
     console.log('📋 Step 2: Verifying raffle status...');
-    const raffle = await raffleService.get(raffleId);
+    const raffleRes = await raffleService.get(raffleId);
     
+    if (!raffleRes.success || !raffleRes.value) {
+      console.error(`❌ Failed to fetch raffle ${raffleId}: ${raffleRes.error}`);
+      await app.close();
+      process.exit(1);
+    }
+    const raffle = raffleRes.value;
+
     if (raffle.status !== RaffleStatus.Open) {
       console.error(`❌ Raffle ${raffleId} is not open (status=${raffle.status})`);
       await app.close();
@@ -105,20 +112,26 @@ async function main() {
     
     const result = await ticketService.buy({ raffleId, quantity });
 
+    if (!result.success) {
+      console.error(`\n❌ Purchase failed: ${result.error}`);
+      await app.close();
+      process.exit(1);
+    }
+
     console.log('\n✅ Tickets purchased successfully!');
-    console.log(`   Ticket IDs: ${result.ticketIds.join(', ')}`);
-    console.log(`   Transaction: ${result.txHash}`);
+    console.log(`   Ticket IDs: ${(result.value ?? []).join(', ')}`);
+    console.log(`   Transaction: ${result.transactionHash}`);
     console.log(`   Ledger: ${result.ledger}\n`);
 
     // Step 4: Verify tickets
     console.log('📋 Step 4: Verifying your tickets...');
-    const myTickets = await ticketService.getUserTickets({ 
+    const myTicketsRes = await ticketService.getUserTickets({ 
       raffleId, 
       userAddress: publicKey 
     });
     
     console.log(`✅ All your tickets for raffle ${raffleId}:`);
-    console.log(`   [${myTickets.join(', ')}]\n`);
+    console.log(`   [${(myTicketsRes.value ?? []).join(', ')}]\n`);
 
     // Optional: Demonstrate message signing
     console.log('📋 Bonus: Demonstrating message signing...');

--- a/sdk/examples/buy-tickets-batch.ts
+++ b/sdk/examples/buy-tickets-batch.ts
@@ -94,10 +94,18 @@ async function main() {
 
   console.log(`Purchasing tickets for ${purchases.length} raffle(s)...\n`);
 
-  const result = await ticketService.buyBatch({
+  const batchRes = await ticketService.buyBatch({
     purchases,
     memo: { type: 'text', value: 'Batch purchase' },
   });
+
+  if (!batchRes.success || !batchRes.value) {
+    console.error('Batch purchase failed:', batchRes.error);
+    await app.close();
+    process.exit(1);
+  }
+
+  const batchResults = batchRes.value;
 
   // Display results
   console.log('Batch purchase completed:\n');
@@ -105,7 +113,7 @@ async function main() {
   let successCount = 0;
   let failureCount = 0;
 
-  for (const purchaseResult of result.results) {
+  for (const purchaseResult of batchResults) {
     if (purchaseResult.success) {
       successCount++;
       console.log(`✅ Raffle ${purchaseResult.raffleId}:`);
@@ -120,20 +128,19 @@ async function main() {
   console.log(`\nSummary:`);
   console.log(`  Successful: ${successCount}`);
   console.log(`  Failed: ${failureCount}`);
-  console.log(`  Last txHash: ${result.txHash}`);
-  console.log(`  Last ledger: ${result.ledger}`);
-  console.log(`  Total fees: ${result.feePaid} stroops`);
+  console.log(`  Last txHash: ${batchRes.transactionHash}`);
+  console.log(`  Last ledger: ${batchRes.ledger}`);
 
   // Show all tickets for successful purchases
   if (successCount > 0) {
     console.log(`\nYour tickets:`);
-    for (const purchaseResult of result.results) {
+    for (const purchaseResult of batchResults) {
       if (purchaseResult.success) {
-        const myTickets = await ticketService.getUserTickets({
+        const myTicketsRes = await ticketService.getUserTickets({
           raffleId: purchaseResult.raffleId,
           userAddress: publicKey,
         });
-        console.log(`  Raffle ${purchaseResult.raffleId}: [${myTickets.join(', ')}]`);
+        console.log(`  Raffle ${purchaseResult.raffleId}: [${(myTicketsRes.value ?? []).join(', ')}]`);
       }
     }
   }

--- a/sdk/examples/buy-tickets.ts
+++ b/sdk/examples/buy-tickets.ts
@@ -50,7 +50,13 @@ async function main() {
   const ticketService = app.get(TicketService);
 
   // Verify raffle is open before buying
-  const raffle = await raffleService.get(raffleId);
+  const raffleRes = await raffleService.get(raffleId);
+  if (!raffleRes.success || !raffleRes.value) {
+    console.error(`Failed to fetch raffle ${raffleId}: ${raffleRes.error}`);
+    await app.close();
+    process.exit(1);
+  }
+  const raffle = raffleRes.value;
   if (raffle.status !== RaffleStatus.Open) {
     console.error(`Raffle ${raffleId} is not open (status=${raffle.status})`);
     await app.close();
@@ -69,14 +75,20 @@ async function main() {
   console.log(`Buying ${quantity} ticket(s)...`);
   const result = await ticketService.buy({ raffleId, quantity });
 
+  if (!result.success) {
+    console.error(`Purchase failed: ${result.error}`);
+    await app.close();
+    process.exit(1);
+  }
+
   console.log('\nTickets purchased successfully:');
-  console.log(`  ticketIds : ${result.ticketIds.join(', ')}`);
-  console.log(`  txHash    : ${result.txHash}`);
+  console.log(`  ticketIds : ${(result.value ?? []).join(', ')}`);
+  console.log(`  txHash    : ${result.transactionHash}`);
   console.log(`  ledger    : ${result.ledger}`);
 
   // Show updated ticket list for this user
-  const myTickets = await ticketService.getUserTickets({ raffleId, userAddress: publicKey });
-  console.log(`\nAll your tickets for raffle ${raffleId}: [${myTickets.join(', ')}]`);
+  const myTicketsRes = await ticketService.getUserTickets({ raffleId, userAddress: publicKey });
+  console.log(`\nAll your tickets for raffle ${raffleId}: [${(myTicketsRes.value ?? []).join(', ')}]`);
 
   await app.close();
 }

--- a/sdk/examples/create-raffle.ts
+++ b/sdk/examples/create-raffle.ts
@@ -70,9 +70,15 @@ async function main() {
     metadataCid,
   });
 
+  if (!result.success) {
+    console.error('Failed to create raffle:', result.error);
+    await app.close();
+    process.exit(1);
+  }
+
   console.log('\nRaffle created successfully:');
-  console.log(`  raffleId : ${result.raffleId}`);
-  console.log(`  txHash   : ${result.txHash}`);
+  console.log(`  raffleId : ${result.value}`);
+  console.log(`  txHash   : ${result.transactionHash}`);
   console.log(`  ledger   : ${result.ledger}`);
 
   await app.close();

--- a/sdk/examples/offline-signing.ts
+++ b/sdk/examples/offline-signing.ts
@@ -59,9 +59,9 @@ async function main() {
     const result = await contractService.submitSigned(signedXdr);
 
     console.log('\nTransaction confirmed:');
-    console.log(`  txHash : ${result.txHash}`);
+    console.log(`  txHash : ${result.transactionHash}`);
     console.log(`  ledger : ${result.ledger}`);
-    console.log(`  result :`, result.result);
+    console.log(`  result :`, result.value);
   } else {
     // ----------------------------------------------------------------
     // Step 1 — build an unsigned XDR for a sample create_raffle call

--- a/sdk/examples/quickstart.ts
+++ b/sdk/examples/quickstart.ts
@@ -38,7 +38,7 @@ async function main() {
 
   // 1. Create a raffle
   console.log('Creating raffle...');
-  const { raffleId, txHash } = await raffleService.create({
+  const createRes = await raffleService.create({
     ticketPrice: '1',           // 1 XLM
     maxTickets: 100,
     endTime: Date.now() + 24 * 60 * 60 * 1000, // 24 h from now
@@ -46,16 +46,27 @@ async function main() {
     asset: 'XLM',
     metadataCid: '',
   });
-  console.log(`Raffle created — id=${raffleId}  tx=${txHash}`);
+  if (!createRes.success) {
+    console.error('Failed to create raffle:', createRes.error);
+    await app.close();
+    process.exit(1);
+  }
+  const raffleId = createRes.value!;
+  console.log(`Raffle created — id=${raffleId}  tx=${createRes.transactionHash}`);
 
   // 2. Buy tickets
   console.log('Buying 2 tickets...');
-  const { ticketIds, txHash: buyTx } = await ticketService.buy({ raffleId, quantity: 2 });
-  console.log(`Tickets purchased — ids=${ticketIds.join(',')}  tx=${buyTx}`);
+  const buyRes = await ticketService.buy({ raffleId, quantity: 2 });
+  if (!buyRes.success) {
+    console.error('Failed to buy tickets:', buyRes.error);
+    await app.close();
+    process.exit(1);
+  }
+  console.log(`Tickets purchased — ids=${(buyRes.value ?? []).join(',')}  tx=${buyRes.transactionHash}`);
 
   // 3. Read raffle state
-  const raffle = await raffleService.get(raffleId);
-  console.log('Raffle state:', raffle);
+  const raffleRes = await raffleService.get(raffleId);
+  console.log('Raffle state:', raffleRes.value);
 
   await app.close();
 }

--- a/sdk/examples/rabet-wallet.ts
+++ b/sdk/examples/rabet-wallet.ts
@@ -79,8 +79,15 @@ async function main() {
 
     // Step 2: Verify raffle is open
     console.log('📋 Step 2: Verifying raffle status...');
-    const raffle = await raffleService.get(raffleId);
+    const raffleRes = await raffleService.get(raffleId);
     
+    if (!raffleRes.success || !raffleRes.value) {
+      console.error(`❌ Failed to fetch raffle ${raffleId}: ${raffleRes.error}`);
+      await app.close();
+      process.exit(1);
+    }
+    const raffle = raffleRes.value;
+
     if (raffle.status !== RaffleStatus.Open) {
       console.error(`❌ Raffle ${raffleId} is not open (status=${raffle.status})`);
       await app.close();
@@ -105,20 +112,26 @@ async function main() {
     
     const result = await ticketService.buy({ raffleId, quantity });
 
+    if (!result.success) {
+      console.error(`\n❌ Purchase failed: ${result.error}`);
+      await app.close();
+      process.exit(1);
+    }
+
     console.log('\n✅ Tickets purchased successfully!');
-    console.log(`   Ticket IDs: ${result.ticketIds.join(', ')}`);
-    console.log(`   Transaction: ${result.txHash}`);
+    console.log(`   Ticket IDs: ${(result.value ?? []).join(', ')}`);
+    console.log(`   Transaction: ${result.transactionHash}`);
     console.log(`   Ledger: ${result.ledger}\n`);
 
     // Step 4: Verify tickets
     console.log('📋 Step 4: Verifying your tickets...');
-    const myTickets = await ticketService.getUserTickets({ 
+    const myTicketsRes = await ticketService.getUserTickets({ 
       raffleId, 
       userAddress: publicKey 
     });
     
     console.log(`✅ All your tickets for raffle ${raffleId}:`);
-    console.log(`   [${myTickets.join(', ')}]\n`);
+    console.log(`   [${(myTicketsRes.value ?? []).join(', ')}]\n`);
 
   } catch (err: any) {
     console.error('\n❌ Error:', err.message);

--- a/sdk/src/contract/contract.service.ts
+++ b/sdk/src/contract/contract.service.ts
@@ -14,7 +14,7 @@ import { HorizonService } from '../network/horizon.service';
 import { NetworkConfig } from '../network/network.config';
 import { WalletAdapter } from '../wallet/wallet.interface';
 import { getRaffleContractId } from './constants';
-import { ContractFnName } from './bindings';
+import { ContractFn, ContractFnName } from './bindings';
 import { TikkaSdkError, TikkaSdkErrorCode } from '../utils/errors';
 import { TransactionLifecycle } from './lifecycle';
 import type { TxMemo, PollConfig } from './lifecycle';
@@ -227,7 +227,7 @@ export class ContractService {
     raffleId: number,
     count: number,
     options: InvokeOptions = {},
-  ): Promise<InvokeResult<T[]>> {
+  ): Promise<ContractResponse<T[]>> {
     if (!this.wallet && !options.simulateOnly) {
       throw new TikkaSdkError(
         TikkaSdkErrorCode.WalletNotInstalled,
@@ -274,12 +274,12 @@ export class ContractService {
     const preparedTx = rpc.assembleTransaction(tx, successSim).build();
 
     // With multiple ops, result is typically an array of results, but for now we just handle it generically.
-    const simResult = successSim.results
-      ? successSim.results.map(r => r.retval ? scValToNative(r.retval) : undefined)
+    const simResult: any[] = successSim.result?.retval
+      ? [scValToNative(successSim.result.retval)]
       : [];
 
     if (options.simulateOnly) {
-      return { result: simResult as any, txHash: '', ledger: 0 };
+      return { success: true, value: simResult as any, transactionHash: '', ledger: 0 };
     }
 
     const { signedXdr } = await this.wallet!.signTransaction(
@@ -313,8 +313,9 @@ export class ContractService {
     const successTx = txResp as rpc.Api.GetSuccessfulTransactionResponse;
 
     return {
-      result: (successTx.returnValue ? [scValToNative(successTx.returnValue)] : simResult) as any,
-      txHash: sendResp.hash,
+      success: true,
+      value: (successTx.returnValue ? [scValToNative(successTx.returnValue)] : simResult) as any,
+      transactionHash: sendResp.hash,
       ledger: successTx.ledger,
     };
   }


### PR DESCRIPTION
Close: #600 
Here's what was done to satisfy the acceptance criteria:

npm run examples:check now passes (0 errors)

Root cause: batchBuyTickets in 
contract.service.ts
 had three bugs — it referenced the non-existent InvokeResult type (should be ContractResponse), used ContractFn without importing it, and accessed .results (plural) on SimulateTransactionSuccessResponse which only has .result (singular) in SDK v14. All three fixed.

All 5 required examples exist and compile

Example	File	Network needed
quickstart	
quickstart.ts
yes (mocked via MockWalletAdapter)
create-raffle	
create-raffle.ts
yes
buy-tickets	
buy-tickets.ts
yes
listen-events	
listen-events.ts
yes (clearly gated)
offline-signing	
offline-signing.ts
yes (clearly gated)
ContractResponse<T> unwrapping fixed across all examples — every example was accessing .ticketIds, .txHash, .raffleId etc. directly on the response object instead of going through .value, .transactionHash. All examples now check .success and unwrap .value correctly.

Env template added — 
.env.example
 documents every env var used across all examples, grouped by example, with defaults noted.

README updated — new Examples section with a table per example showing required/optional env vars, usage commands, and network-required callouts for listen-events and offline-signing.