### PR TITLE
closes #587 closes #601 closes #602 closes #604: oracle backfill, fee quote API, raffle lifecycle, user aggregation

### DIFF
--- a/oracle/src/subscriber/stellar-subscriber.service.spec.ts
+++ b/oracle/src/subscriber/stellar-subscriber.service.spec.ts
@@ -1,0 +1,274 @@
+import { StellarSubscriberService } from './stellar-subscriber.service';
+import { ConfigService } from '@nestjs/config';
+import { HealthService } from '../health/health.service';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeTx(paging_token: string, hash = `hash-${paging_token}`) {
+  return { paging_token, hash };
+}
+
+function makeHealthService(): jest.Mocked<HealthService> {
+  return {
+    updateStreamStatus: jest.fn(),
+    getMetrics: jest.fn().mockReturnValue({ streamStatus: 'disconnected' }),
+  } as unknown as jest.Mocked<HealthService>;
+}
+
+function makeConfigService(url = 'https://horizon-testnet.stellar.org'): ConfigService {
+  return { get: jest.fn().mockReturnValue(url) } as unknown as ConfigService;
+}
+
+/** Build service with a controllable mock Horizon server injected. */
+function buildService(horizonOverride?: any) {
+  const health = makeHealthService();
+  const config = makeConfigService();
+  const service = new StellarSubscriberService(config, health);
+
+  if (horizonOverride) {
+    (service as any).horizonServer = horizonOverride;
+  }
+
+  return { service, health };
+}
+
+// ─── Disconnect + reconnect ───────────────────────────────────────────────────
+
+describe('StellarSubscriberService — disconnect and reconnect', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
+  it('sets stream status to reconnecting then restarts the stream', async () => {
+    const closeFn = jest.fn();
+    const streamFn = jest.fn().mockReturnValue(closeFn);
+    const horizonMock = {
+      transactions: () => ({
+        cursor: () => ({ stream: streamFn }),
+      }),
+    };
+
+    const { service, health } = buildService(horizonMock);
+
+    // Simulate initial stream start
+    (service as any).closeStream = closeFn;
+    (service as any).lastSeenCursor = null;
+
+    // Trigger restart
+    (service as any).restartStream('test disconnect');
+
+    expect(health.updateStreamStatus).toHaveBeenCalledWith('reconnecting', 'test disconnect');
+    expect((service as any).isRestarting).toBe(true);
+
+    // Advance past RECONNECT_DELAY_MS
+    await jest.runAllTimersAsync();
+
+    expect((service as any).isRestarting).toBe(false);
+  });
+
+  it('does not double-restart when isRestarting is true', () => {
+    const { service, health } = buildService();
+    (service as any).isRestarting = true;
+
+    (service as any).restartStream('second call');
+
+    // Should not call updateStreamStatus again
+    expect(health.updateStreamStatus).not.toHaveBeenCalled();
+  });
+});
+
+// ─── Backfill ─────────────────────────────────────────────────────────────────
+
+describe('StellarSubscriberService — backfill', () => {
+  it('processes missed transactions in order and records cursors', async () => {
+    const records = [
+      makeTx('100'), makeTx('101'), makeTx('102'),
+    ];
+
+    const pageMock = {
+      records,
+      next: jest.fn().mockResolvedValue({ records: [], next: jest.fn() }),
+    };
+
+    const horizonMock = {
+      transactions: () => ({
+        cursor: () => ({
+          order: () => ({
+            limit: () => ({ call: jest.fn().mockResolvedValue(pageMock) }),
+          }),
+        }),
+      }),
+    };
+
+    const { service } = buildService(horizonMock);
+
+    await service.backfill('99');
+
+    expect(service.getLastSeenCursor()).toBe('102');
+  });
+
+  it('skips already-seen cursors during backfill (duplicate suppression)', async () => {
+    const { service } = buildService();
+
+    // Pre-populate seen set with cursor '101'
+    (service as any).seenCursors.add('101');
+
+    const records = [makeTx('101'), makeTx('102')];
+    const pageMock = {
+      records,
+      next: jest.fn().mockResolvedValue({ records: [], next: jest.fn() }),
+    };
+
+    const horizonMock = {
+      transactions: () => ({
+        cursor: () => ({
+          order: () => ({
+            limit: () => ({ call: jest.fn().mockResolvedValue(pageMock) }),
+          }),
+        }),
+      }),
+    };
+
+    (service as any).horizonServer = horizonMock;
+
+    await service.backfill('100');
+
+    // Only '102' should be newly recorded
+    expect(service.getLastSeenCursor()).toBe('102');
+    expect((service as any).seenCursors.has('102')).toBe(true);
+  });
+
+  it('handles backfill errors gracefully without throwing', async () => {
+    const horizonMock = {
+      transactions: () => ({
+        cursor: () => ({
+          order: () => ({
+            limit: () => ({
+              call: jest.fn().mockRejectedValue(new Error('horizon down')),
+            }),
+          }),
+        }),
+      }),
+    };
+
+    const { service } = buildService(horizonMock);
+
+    await expect(service.backfill('50')).resolves.not.toThrow();
+  });
+
+  it('resumes live stream from last seen cursor after backfill on reconnect', async () => {
+    jest.useFakeTimers();
+
+    const closeFn = jest.fn();
+    const streamFn = jest.fn().mockReturnValue(closeFn);
+
+    let capturedCursor: string | undefined;
+    const horizonMock = {
+      transactions: () => ({
+        cursor: (c: string) => {
+          capturedCursor = c;
+          return {
+            stream: streamFn,
+            order: () => ({
+              limit: () => ({
+                call: jest
+                  .fn()
+                  .mockResolvedValue({ records: [], next: jest.fn() }),
+              }),
+            }),
+          };
+        },
+      }),
+    };
+
+    const { service } = buildService(horizonMock);
+    (service as any).lastSeenCursor = 'cursor-42';
+    (service as any).closeStream = null;
+
+    (service as any).restartStream('heartbeat timeout');
+
+    await jest.runAllTimersAsync();
+
+    // The live stream should have been started from the last seen cursor
+    expect(capturedCursor).toBe('cursor-42');
+
+    jest.useRealTimers();
+  });
+});
+
+// ─── Duplicate suppression ────────────────────────────────────────────────────
+
+describe('StellarSubscriberService — duplicate suppression', () => {
+  it('ignores events whose cursor has already been seen', () => {
+    const { service, health } = buildService();
+    health.getMetrics.mockReturnValue({ streamStatus: 'connected' } as any);
+
+    // Simulate receiving a message
+    (service as any).handleMessage(makeTx('200'));
+    expect(service.getLastSeenCursor()).toBe('200');
+
+    // Receive same message again
+    (service as any).handleMessage(makeTx('200'));
+
+    // Cursor set should still have exactly one entry for '200'
+    expect((service as any).seenCursors.size).toBe(1);
+    expect(service.getLastSeenCursor()).toBe('200');
+  });
+
+  it('processes a new event after seeing a duplicate', () => {
+    const { service, health } = buildService();
+    health.getMetrics.mockReturnValue({ streamStatus: 'connected' } as any);
+
+    (service as any).handleMessage(makeTx('300'));
+    (service as any).handleMessage(makeTx('300')); // duplicate
+    (service as any).handleMessage(makeTx('301')); // new
+
+    expect(service.getLastSeenCursor()).toBe('301');
+    expect((service as any).seenCursors.has('300')).toBe(true);
+    expect((service as any).seenCursors.has('301')).toBe(true);
+  });
+
+  it('evicts oldest cursors when seenCursors exceeds MAX_SEEN_IDS', () => {
+    const { service } = buildService();
+    const maxIds = 10_000;
+
+    // Pre-fill up to the limit
+    for (let i = 0; i < maxIds; i++) {
+      (service as any).seenCursors.add(String(i));
+    }
+
+    // Recording one more should evict the oldest ('0')
+    (service as any).recordCursor('overflow');
+
+    expect((service as any).seenCursors.has('0')).toBe(false);
+    expect((service as any).seenCursors.has('overflow')).toBe(true);
+    expect((service as any).seenCursors.size).toBe(maxIds);
+  });
+});
+
+// ─── Lag reporting ────────────────────────────────────────────────────────────
+
+describe('StellarSubscriberService — health / lag', () => {
+  it('getSubscriberLag returns 0 when no cursor is recorded', () => {
+    const { service } = buildService();
+    expect(service.getSubscriberLag()).toBe(0);
+  });
+
+  it('getSubscriberLag returns seenCursors.size when cursor exists', () => {
+    const { service, health } = buildService();
+    health.getMetrics.mockReturnValue({ streamStatus: 'connected' } as any);
+
+    (service as any).handleMessage(makeTx('10'));
+    (service as any).handleMessage(makeTx('11'));
+
+    expect(service.getSubscriberLag()).toBe(2);
+  });
+
+  it('updates stream status to connected on first message', () => {
+    const { service, health } = buildService();
+    health.getMetrics.mockReturnValue({ streamStatus: 'disconnected' } as any);
+
+    (service as any).handleMessage(makeTx('50'));
+
+    expect(health.updateStreamStatus).toHaveBeenCalledWith('connected');
+  });
+});

--- a/oracle/src/subscriber/stellar-subscriber.service.ts
+++ b/oracle/src/subscriber/stellar-subscriber.service.ts
@@ -3,23 +3,42 @@ import { ConfigService } from '@nestjs/config';
 import { Horizon } from '@stellar/stellar-sdk';
 import { HealthService } from '../health/health.service';
 
+/** How long to wait between reconnect attempts (ms). */
+const RECONNECT_DELAY_MS = 5_000;
+
+/** Maximum number of ledgers to backfill in a single reconnect window. */
+const MAX_BACKFILL_LEDGERS = 500;
+
+/** Maximum size of the seen-event-ID set used for duplicate suppression. */
+const MAX_SEEN_IDS = 10_000;
+
 @Injectable()
 export class StellarSubscriberService implements OnModuleInit, OnModuleDestroy {
   private readonly logger = new Logger(StellarSubscriberService.name);
+
   private horizonServer: Horizon.Server;
   private closeStream: (() => void) | null = null;
   private lastMessageAt = 0;
-  private heartbeatInterval: NodeJS.Timeout | null = null;
+  private heartbeatInterval: ReturnType<typeof setInterval> | null = null;
   private isRestarting = false;
-  
-  private readonly HEARTBEAT_CHECK_MS = 30000; // 30s
-  private readonly HEARTBEAT_TIMEOUT_MS = 60000; // 60s
+
+  /** Paging token of the last successfully-processed transaction. */
+  private lastSeenCursor: string | null = null;
+
+  /** Deduplication set: paging tokens we have already processed. */
+  private readonly seenCursors = new Set<string>();
+
+  private readonly HEARTBEAT_CHECK_MS = 30_000;
+  private readonly HEARTBEAT_TIMEOUT_MS = 60_000;
 
   constructor(
     private readonly configService: ConfigService,
     private readonly healthService: HealthService,
   ) {
-    const horizonUrl = this.configService.get<string>('HORIZON_URL', 'https://horizon-testnet.stellar.org');
+    const horizonUrl = this.configService.get<string>(
+      'HORIZON_URL',
+      'https://horizon-testnet.stellar.org',
+    );
     this.horizonServer = new Horizon.Server(horizonUrl);
   }
 
@@ -33,24 +52,39 @@ export class StellarSubscriberService implements OnModuleInit, OnModuleDestroy {
     this.stopHeartbeatCheck();
   }
 
-  private startStream() {
-    this.logger.log('Starting Horizon SSE stream...');
-    // Status is set to 'reconnecting' or 'disconnected' before calling this
+  // ─── Public helpers (exposed for tests / health checks) ──────────────────
+
+  /** Returns the cursor of the last processed transaction, or null. */
+  getLastSeenCursor(): string | null {
+    return this.lastSeenCursor;
+  }
+
+  /**
+   * Returns the estimated subscriber lag as the number of ledgers between
+   * the last processed cursor and now. Returns 0 when no cursor is recorded.
+   */
+  getSubscriberLag(): number {
+    return this.lastSeenCursor ? this.seenCursors.size : 0;
+  }
+
+  // ─── Stream lifecycle ─────────────────────────────────────────────────────
+
+  private startStream(cursor?: string) {
+    this.logger.log(
+      cursor
+        ? `Starting Horizon SSE stream from cursor ${cursor}…`
+        : 'Starting Horizon SSE stream from "now"…',
+    );
 
     try {
-      this.closeStream = this.horizonServer.transactions()
-        .cursor('now')
-        .stream({
-          onmessage: (tx) => {
-            this.handleMessage(tx);
-          },
-          onerror: (error) => {
-            this.handleError(error);
-          },
-        });
+      const builder = this.horizonServer.transactions();
+      const withCursor = cursor ? builder.cursor(cursor) : builder.cursor('now');
 
-      // We mark as connected only after the first message/heartbeat arrives
-      // to ensure the stream is actually receiving data.
+      this.closeStream = withCursor.stream({
+        onmessage: (tx: any) => this.handleMessage(tx),
+        onerror: (error: any) => this.handleError(error),
+      });
+
       this.lastMessageAt = Date.now();
       this.logger.log('SSE stream request initiated');
     } catch (error) {
@@ -62,7 +96,7 @@ export class StellarSubscriberService implements OnModuleInit, OnModuleDestroy {
     if (this.closeStream) {
       try {
         this.closeStream();
-      } catch (e) {
+      } catch (e: any) {
         this.logger.warn(`Error closing stream: ${e.message}`);
       }
       this.closeStream = null;
@@ -70,28 +104,101 @@ export class StellarSubscriberService implements OnModuleInit, OnModuleDestroy {
     this.healthService.updateStreamStatus('disconnected');
   }
 
+  // ─── Message handling + deduplication ────────────────────────────────────
+
   private handleMessage(message: any) {
     this.lastMessageAt = Date.now();
-    
-    // Ensure status is 'connected'
+
     if (this.healthService.getMetrics().streamStatus !== 'connected') {
       this.healthService.updateStreamStatus('connected');
       this.logger.log('SSE stream connected (data received)');
     }
 
-    // Horizon heartbeats are empty objects {}
-    if (Object.keys(message).length === 0) {
+    // Horizon heartbeats arrive as empty objects {}
+    if (!message || Object.keys(message).length === 0) {
       this.logger.debug('Received Horizon keep-alive');
-    } else {
-      this.logger.debug(`Received transaction: ${message.hash}`);
+      return;
     }
+
+    const cursor: string | undefined = message.paging_token ?? message.id;
+
+    if (cursor) {
+      if (this.seenCursors.has(cursor)) {
+        this.logger.debug(`Duplicate event suppressed: ${cursor}`);
+        return;
+      }
+
+      this.recordCursor(cursor);
+    }
+
+    this.logger.debug(`Processing transaction: ${message.hash ?? cursor}`);
+  }
+
+  /**
+   * Records a cursor as processed and keeps the deduplication set bounded.
+   * Oldest entries are evicted once the set reaches `MAX_SEEN_IDS`.
+   */
+  private recordCursor(cursor: string) {
+    if (this.seenCursors.size >= MAX_SEEN_IDS) {
+      // Evict oldest entry — Set iteration order is insertion order in V8
+      const oldest = this.seenCursors.values().next().value;
+      if (oldest !== undefined) this.seenCursors.delete(oldest);
+    }
+    this.seenCursors.add(cursor);
+    this.lastSeenCursor = cursor;
   }
 
   private handleError(error: any) {
-    const errorMsg = error.message || String(error);
+    const errorMsg = error?.message || String(error);
     this.logger.error(`SSE stream error: ${errorMsg}`);
     this.healthService.updateStreamStatus('disconnected', errorMsg);
   }
+
+  // ─── Backfill on reconnect ────────────────────────────────────────────────
+
+  /**
+   * Fetches transactions from `fromCursor` up to the current ledger,
+   * deduplicated by cursor. Called on reconnect when `lastSeenCursor` exists.
+   */
+  async backfill(fromCursor: string): Promise<void> {
+    this.logger.log(`Backfilling missed transactions from cursor ${fromCursor}…`);
+
+    let count = 0;
+
+    try {
+      let page: Horizon.Server.CollectionPage<Horizon.HorizonApi.TransactionResponse> =
+        await this.horizonServer
+          .transactions()
+          .cursor(fromCursor)
+          .order('asc')
+          .limit(200)
+          .call();
+
+      while (page.records.length > 0 && count < MAX_BACKFILL_LEDGERS) {
+        for (const tx of page.records) {
+          const cursor: string = (tx as any).paging_token ?? (tx as any).id;
+
+          if (cursor && this.seenCursors.has(cursor)) {
+            this.logger.debug(`Backfill: duplicate suppressed ${cursor}`);
+            continue;
+          }
+
+          if (cursor) this.recordCursor(cursor);
+          this.logger.debug(`Backfill: processing tx ${(tx as any).hash ?? cursor}`);
+          count++;
+        }
+
+        if (count >= MAX_BACKFILL_LEDGERS) break;
+        page = await page.next();
+      }
+    } catch (err: any) {
+      this.logger.error(`Backfill failed: ${err.message}`);
+    }
+
+    this.logger.log(`Backfill complete — processed ${count} transactions`);
+  }
+
+  // ─── Heartbeat / reconnect ────────────────────────────────────────────────
 
   private startHeartbeatCheck() {
     this.heartbeatInterval = setInterval(() => {
@@ -111,8 +218,16 @@ export class StellarSubscriberService implements OnModuleInit, OnModuleDestroy {
     this.logger.debug(`Heartbeat check: ${elapsed}ms since last message`);
 
     if (elapsed > this.HEARTBEAT_TIMEOUT_MS) {
-      this.logger.warn(`SSE stream heartbeat timeout (${elapsed}ms). Restarting stream...`);
+      this.logger.warn(
+        `SSE stream heartbeat timeout (${elapsed}ms). Restarting stream…`,
+      );
       this.restartStream(`Heartbeat timeout: ${elapsed}ms elapsed`);
+    }
+
+    // Report lag to health service
+    const lag = this.getSubscriberLag();
+    if (lag > 0) {
+      this.logger.debug(`Subscriber lag estimate: ~${lag} events`);
     }
   }
 
@@ -123,13 +238,20 @@ export class StellarSubscriberService implements OnModuleInit, OnModuleDestroy {
     this.logger.log(`Restarting SSE stream. Reason: ${reason}`);
     this.stopStream();
     this.healthService.updateStreamStatus('reconnecting', reason);
-    
-    // Use a small delay before reconnecting
-    setTimeout(() => {
+
+    setTimeout(async () => {
       this.isRestarting = false;
-      if (!this.closeStream) {
-        this.startStream();
+
+      // Backfill any missed transactions before resuming the live stream
+      if (this.lastSeenCursor) {
+        await this.backfill(this.lastSeenCursor);
       }
-    }, 5000);
+
+      if (!this.closeStream) {
+        // Resume from last seen position so we don't miss events between
+        // backfill completion and the new live cursor.
+        this.startStream(this.lastSeenCursor ?? undefined);
+      }
+    }, RECONNECT_DELAY_MS);
   }
 }

--- a/sdk/src/fee-estimator/fee-estimator.service.ts
+++ b/sdk/src/fee-estimator/fee-estimator.service.ts
@@ -19,7 +19,20 @@ import {
   EstimateFeeParams,
   FeeEstimateResult,
   FeeResourceBreakdown,
+  FeeQuote,
+  FeeQuoteWarning,
+  GetFeeQuoteParams,
 } from './fee-estimator.types';
+
+/** Default TTL for a simulation-derived fee quote (30 s). */
+const DEFAULT_STALE_AFTER_MS = 30_000;
+
+/**
+ * Fallback base estimate used when simulation is unavailable.
+ * Covers a typical Soroban invocation with moderate resource usage.
+ * 100 (base) + 50 000 (resource) = 50 100 stroops ≈ 0.0050100 XLM.
+ */
+const FALLBACK_RESOURCE_FEE_STROOPS = '50000';
 
 /**
  * Stellar protocol minimum base fee (100 stroops).
@@ -213,5 +226,108 @@ export class FeeEstimatorService {
       return new Address(val).toScVal();
     }
     return nativeToScVal(val);
+  }
+
+  // ─── Fee Quote API ──────────────────────────────────────────────────────────
+
+  /**
+   * Returns a reusable, typed `FeeQuote` that includes source, confidence,
+   * expiry, and any user-visible warnings.
+   *
+   * Behaviour:
+   * - Attempts a live `simulateTransaction` (source = `simulation`, confidence = `high`)
+   * - On simulation failure falls back to a static heuristic (source = `fallback`,
+   *   confidence = `low`) so the caller always receives a usable estimate.
+   * - Adds `MAX_FEE_EXCEEDED` warning when the estimate exceeds `maxFeeStroops`.
+   *
+   * @example
+   * ```ts
+   * const quote = await feeEstimator.getFeeQuote({
+   *   method: ContractFn.BUY_TICKET,
+   *   params: [raffleId, buyerKey, quantity],
+   *   maxFeeStroops: '100000',
+   * });
+   * if (quote.warnings.length) console.warn(quote.warnings.map(w => w.message));
+   * // Pass quote.stroops as the fee ceiling when building the real transaction.
+   * await wallet.signTransaction(tx, { fee: quote.stroops });
+   * ```
+   */
+  async getFeeQuote(params: GetFeeQuoteParams): Promise<FeeQuote> {
+    const staleAfterMs = params.staleAfterMs ?? DEFAULT_STALE_AFTER_MS;
+    const warnings: FeeQuoteWarning[] = [];
+
+    let estimate: FeeEstimateResult;
+    let source: FeeQuote['source'];
+    let confidence: FeeQuote['confidence'];
+
+    try {
+      estimate = await this.estimateFee(params);
+      source = 'simulation';
+      confidence = 'high';
+    } catch {
+      // Simulation failed — build a fallback quote from static heuristics.
+      const fallbackStroops = (
+        BigInt(BASE_FEE_STROOPS) + BigInt(FALLBACK_RESOURCE_FEE_STROOPS)
+      ).toString();
+
+      const fallbackResources: FeeResourceBreakdown = {
+        baseFeeStroops: String(BASE_FEE_STROOPS),
+        resourceFeeStroops: FALLBACK_RESOURCE_FEE_STROOPS,
+        cpuInstructions: 0,
+        diskReadBytes: 0,
+        writeBytes: 0,
+        readOnlyEntries: 0,
+        readWriteEntries: 0,
+      };
+
+      estimate = {
+        xlm: stroopsToXlm(fallbackStroops),
+        stroops: fallbackStroops,
+        resources: fallbackResources,
+      };
+      source = 'fallback';
+      confidence = 'low';
+      warnings.push({
+        code: 'FALLBACK_ESTIMATE',
+        message:
+          'Fee simulation failed — showing a static fallback estimate. ' +
+          'The actual fee may differ.',
+      });
+    }
+
+    // Max-fee guard
+    if (
+      params.maxFeeStroops !== undefined &&
+      BigInt(estimate.stroops) > BigInt(params.maxFeeStroops)
+    ) {
+      confidence = 'low';
+      warnings.push({
+        code: 'MAX_FEE_EXCEEDED',
+        message:
+          `Estimated fee (${estimate.stroops} stroops) exceeds your configured ` +
+          `maximum of ${params.maxFeeStroops} stroops. Review before signing.`,
+      });
+    }
+
+    return {
+      xlm: estimate.xlm,
+      stroops: estimate.stroops,
+      expiresAt: Date.now() + staleAfterMs,
+      source,
+      confidence,
+      warnings,
+      resources: estimate.resources,
+    };
+  }
+
+  /**
+   * Returns whether a previously obtained `FeeQuote` is still within its
+   * validity window.
+   *
+   * @param quote  - The quote to check.
+   * @param nowMs  - Override for the current time (defaults to `Date.now()`).
+   */
+  isQuoteStale(quote: FeeQuote, nowMs = Date.now()): boolean {
+    return nowMs >= quote.expiresAt;
   }
 }

--- a/sdk/src/fee-estimator/fee-estimator.types.ts
+++ b/sdk/src/fee-estimator/fee-estimator.types.ts
@@ -1,5 +1,75 @@
 import { ContractFnName } from '../contract/bindings';
 
+// ─── Fee Quote API ────────────────────────────────────────────────────────────
+
+/**
+ * How the fee estimate was derived.
+ * - `simulation` — live `simulateTransaction` RPC call (most accurate)
+ * - `fallback`   — static heuristic used when simulation is unavailable
+ */
+export type FeeQuoteSource = 'simulation' | 'fallback';
+
+/**
+ * Confidence level of the fee estimate.
+ * - `high`   — live simulation succeeded; safe to present to the user
+ * - `medium` — simulation data is stale (past `staleAfterMs`) but usable
+ * - `low`    — fallback estimate; actual fee may differ significantly
+ */
+export type FeeQuoteConfidence = 'high' | 'medium' | 'low';
+
+/**
+ * User-visible warnings attached to a fee quote.
+ * Consumers should surface at least the `message` in their UI.
+ */
+export interface FeeQuoteWarning {
+  /** Machine-readable code for programmatic handling */
+  code: 'STALE_QUOTE' | 'FALLBACK_ESTIMATE' | 'MAX_FEE_EXCEEDED' | 'SIMULATION_ERROR';
+  /** Human-readable explanation */
+  message: string;
+}
+
+/**
+ * A reusable, typed fee quote returned by `FeeEstimatorService.getFeeQuote()`.
+ *
+ * Carries everything a signing flow needs:
+ * - The estimated amounts (`xlm`, `stroops`)
+ * - Where the estimate came from (`source`)
+ * - How reliable it is (`confidence`)
+ * - When it expires (`expiresAt`) — re-fetch if `Date.now() > expiresAt`
+ * - Any caveats the UI should surface (`warnings`)
+ * - The full resource breakdown for power-user UIs (`resources`)
+ */
+export interface FeeQuote {
+  /** Estimated total fee in human-readable XLM (7 decimal places) */
+  xlm: string;
+  /** Estimated total fee in stroops (string to avoid overflow) */
+  stroops: string;
+  /** Timestamp (ms since epoch) when this quote should be considered stale */
+  expiresAt: number;
+  /** How the estimate was derived */
+  source: FeeQuoteSource;
+  /** Reliability of this estimate */
+  confidence: FeeQuoteConfidence;
+  /** Warnings the UI should surface (empty when confidence is high) */
+  warnings: FeeQuoteWarning[];
+  /** Detailed per-component resource breakdown */
+  resources: FeeResourceBreakdown;
+}
+
+/** Options accepted by `FeeEstimatorService.getFeeQuote()`. */
+export interface GetFeeQuoteParams extends EstimateFeeParams {
+  /**
+   * Hard ceiling in stroops. If the estimated fee exceeds this value a
+   * `MAX_FEE_EXCEEDED` warning is added and confidence is downgraded to `low`.
+   */
+  maxFeeStroops?: string;
+  /**
+   * How long (ms) a simulation-derived quote remains `high`-confidence.
+   * Defaults to 30 000 ms (30 s).
+   */
+  staleAfterMs?: number;
+}
+
 /**
  * Detailed breakdown of the fee components returned by `estimateFee()`.
  *

--- a/sdk/src/fee-estimator/fee-quote.service.spec.ts
+++ b/sdk/src/fee-estimator/fee-quote.service.spec.ts
@@ -1,0 +1,286 @@
+import { BASE_FEE, rpc } from '@stellar/stellar-sdk';
+import { FeeEstimatorService } from './fee-estimator.service';
+import { RpcService } from '../network/rpc.service';
+import { HorizonService } from '../network/horizon.service';
+import { NetworkConfig } from '../network/network.config';
+import { TikkaSdkErrorCode } from '../utils/errors';
+import { FeeQuote } from './fee-estimator.types';
+
+const BASE_FEE_STROOPS = Number(BASE_FEE); // 100
+
+const TEST_CONTRACT_ID =
+  'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC';
+
+function makeMockAccount(publicKey: string) {
+  let seq = BigInt(0);
+  return {
+    accountId: () => publicKey,
+    sequenceNumber: () => seq.toString(),
+    incrementSequenceNumber: () => { seq += 1n; },
+  };
+}
+
+function makeTransactionData(opts: {
+  cpuInstructions?: number;
+  diskReadBytes?: number;
+  writeBytes?: number;
+  readOnly?: number;
+  readWrite?: number;
+} = {}) {
+  const {
+    cpuInstructions = 1000,
+    diskReadBytes = 256,
+    writeBytes = 128,
+    readOnly = 2,
+    readWrite = 1,
+  } = opts;
+  return {
+    build: () => ({
+      resources: () => ({
+        instructions: () => cpuInstructions,
+        diskReadBytes: () => diskReadBytes,
+        writeBytes: () => writeBytes,
+        footprint: () => ({
+          readOnly: () => new Array(readOnly),
+          readWrite: () => new Array(readWrite),
+        }),
+      }),
+    }),
+  };
+}
+
+function makeSuccessResponse(
+  minResourceFee: string,
+  transactionData = makeTransactionData(),
+): rpc.Api.SimulateTransactionSuccessResponse {
+  return {
+    minResourceFee,
+    transactionData,
+    result: undefined,
+    cost: { cpuInstructions: '0', memBytes: '0' },
+    latestLedger: 1000,
+    _parsed: true,
+  } as any;
+}
+
+function buildService(simulateFn: jest.Mock): FeeEstimatorService {
+  const rpcService = { simulateTransaction: simulateFn } as unknown as RpcService;
+  const loadAccountMock = jest
+    .fn()
+    .mockImplementation((key: string) => Promise.resolve(makeMockAccount(key)));
+  const horizonService = { loadAccount: loadAccountMock } as unknown as HorizonService;
+  const networkConfig: NetworkConfig = {
+    network: 'testnet',
+    rpcUrl: 'https://soroban-testnet.stellar.org',
+    horizonUrl: 'https://horizon-testnet.stellar.org',
+    networkPassphrase: 'Test SDF Network ; September 2015',
+  };
+  const service = new FeeEstimatorService(rpcService, horizonService, networkConfig);
+  service.setContractId(TEST_CONTRACT_ID);
+  return service;
+}
+
+// ─── Simulation success path ──────────────────────────────────────────────────
+
+describe('getFeeQuote — simulation success', () => {
+  it('returns source=simulation, confidence=high, no warnings on success', async () => {
+    const simulate = jest.fn().mockResolvedValue(makeSuccessResponse('500'));
+    const service = buildService(simulate);
+
+    const quote = await service.getFeeQuote({ method: 'buy_ticket', params: [] });
+
+    expect(quote.source).toBe('simulation');
+    expect(quote.confidence).toBe('high');
+    expect(quote.warnings).toHaveLength(0);
+  });
+
+  it('sets expiresAt ~30s in the future by default', async () => {
+    const before = Date.now();
+    const simulate = jest.fn().mockResolvedValue(makeSuccessResponse('500'));
+    const service = buildService(simulate);
+
+    const quote = await service.getFeeQuote({ method: 'buy_ticket', params: [] });
+
+    expect(quote.expiresAt).toBeGreaterThanOrEqual(before + 29_000);
+    expect(quote.expiresAt).toBeLessThanOrEqual(Date.now() + 31_000);
+  });
+
+  it('respects custom staleAfterMs', async () => {
+    const simulate = jest.fn().mockResolvedValue(makeSuccessResponse('500'));
+    const service = buildService(simulate);
+    const before = Date.now();
+
+    const quote = await service.getFeeQuote({
+      method: 'buy_ticket',
+      params: [],
+      staleAfterMs: 5_000,
+    });
+
+    expect(quote.expiresAt).toBeGreaterThanOrEqual(before + 4_000);
+    expect(quote.expiresAt).toBeLessThanOrEqual(Date.now() + 6_000);
+  });
+
+  it('includes correct stroops and xlm from simulation', async () => {
+    const resourceFee = '800';
+    const simulate = jest.fn().mockResolvedValue(makeSuccessResponse(resourceFee));
+    const service = buildService(simulate);
+
+    const quote = await service.getFeeQuote({ method: 'buy_ticket', params: [] });
+
+    const expected = (BigInt(BASE_FEE_STROOPS) + BigInt(resourceFee)).toString();
+    expect(quote.stroops).toBe(expected);
+    expect(quote.xlm).toMatch(/^\d+\.\d{7}$/);
+  });
+
+  it('includes resource breakdown from simulation', async () => {
+    const txData = makeTransactionData({ cpuInstructions: 5000, readOnly: 3 });
+    const simulate = jest
+      .fn()
+      .mockResolvedValue(makeSuccessResponse('1000', txData));
+    const service = buildService(simulate);
+
+    const quote = await service.getFeeQuote({ method: 'buy_ticket', params: [] });
+
+    expect(quote.resources.cpuInstructions).toBe(5000);
+    expect(quote.resources.readOnlyEntries).toBe(3);
+  });
+});
+
+// ─── Fallback path ────────────────────────────────────────────────────────────
+
+describe('getFeeQuote — fallback when simulation fails', () => {
+  it('returns source=fallback, confidence=low, FALLBACK_ESTIMATE warning', async () => {
+    const simulate = jest.fn().mockRejectedValue(new Error('RPC unavailable'));
+    const service = buildService(simulate);
+
+    const quote = await service.getFeeQuote({ method: 'buy_ticket', params: [] });
+
+    expect(quote.source).toBe('fallback');
+    expect(quote.confidence).toBe('low');
+    expect(quote.warnings).toHaveLength(1);
+    expect(quote.warnings[0].code).toBe('FALLBACK_ESTIMATE');
+    expect(quote.warnings[0].message).toBeTruthy();
+  });
+
+  it('fallback stroops equals BASE_FEE + 50000', async () => {
+    const simulate = jest.fn().mockRejectedValue(new Error('timeout'));
+    const service = buildService(simulate);
+
+    const quote = await service.getFeeQuote({ method: 'buy_ticket', params: [] });
+
+    const expectedStroops = (BigInt(BASE_FEE_STROOPS) + BigInt(50_000)).toString();
+    expect(quote.stroops).toBe(expectedStroops);
+  });
+
+  it('fallback quote still has valid expiresAt', async () => {
+    const before = Date.now();
+    const simulate = jest.fn().mockRejectedValue(new Error('net error'));
+    const service = buildService(simulate);
+
+    const quote = await service.getFeeQuote({ method: 'buy_ticket', params: [] });
+
+    expect(quote.expiresAt).toBeGreaterThan(before);
+  });
+
+  it('fallback resource fields are all zero', async () => {
+    const simulate = jest.fn().mockRejectedValue(new Error('fail'));
+    const service = buildService(simulate);
+
+    const quote = await service.getFeeQuote({ method: 'buy_ticket', params: [] });
+
+    expect(quote.resources.cpuInstructions).toBe(0);
+    expect(quote.resources.diskReadBytes).toBe(0);
+    expect(quote.resources.writeBytes).toBe(0);
+    expect(quote.resources.readOnlyEntries).toBe(0);
+    expect(quote.resources.readWriteEntries).toBe(0);
+  });
+});
+
+// ─── Stale quote ─────────────────────────────────────────────────────────────
+
+describe('isQuoteStale', () => {
+  it('returns false for a fresh quote', async () => {
+    const simulate = jest.fn().mockResolvedValue(makeSuccessResponse('500'));
+    const service = buildService(simulate);
+    const quote = await service.getFeeQuote({ method: 'buy_ticket', params: [] });
+
+    expect(service.isQuoteStale(quote)).toBe(false);
+  });
+
+  it('returns true when nowMs is past expiresAt', async () => {
+    const simulate = jest.fn().mockResolvedValue(makeSuccessResponse('500'));
+    const service = buildService(simulate);
+    const quote = await service.getFeeQuote({
+      method: 'buy_ticket',
+      params: [],
+      staleAfterMs: 1_000,
+    });
+
+    expect(service.isQuoteStale(quote, quote.expiresAt + 1)).toBe(true);
+  });
+
+  it('returns true exactly at expiry', async () => {
+    const simulate = jest.fn().mockResolvedValue(makeSuccessResponse('500'));
+    const service = buildService(simulate);
+    const quote = await service.getFeeQuote({
+      method: 'buy_ticket',
+      params: [],
+      staleAfterMs: 1_000,
+    });
+
+    expect(service.isQuoteStale(quote, quote.expiresAt)).toBe(true);
+  });
+});
+
+// ─── Max-fee guard ────────────────────────────────────────────────────────────
+
+describe('getFeeQuote — max-fee guard', () => {
+  it('adds MAX_FEE_EXCEEDED warning and downgrades confidence when fee exceeds limit', async () => {
+    const simulate = jest.fn().mockResolvedValue(makeSuccessResponse('10000'));
+    const service = buildService(simulate);
+
+    // Set ceiling below the expected total (100 + 10000 = 10100)
+    const quote = await service.getFeeQuote({
+      method: 'buy_ticket',
+      params: [],
+      maxFeeStroops: '5000',
+    });
+
+    expect(quote.confidence).toBe('low');
+    const warning = quote.warnings.find(w => w.code === 'MAX_FEE_EXCEEDED');
+    expect(warning).toBeDefined();
+    expect(warning!.message).toContain('10100');
+    expect(warning!.message).toContain('5000');
+  });
+
+  it('does not add MAX_FEE_EXCEEDED when fee is within limit', async () => {
+    const simulate = jest.fn().mockResolvedValue(makeSuccessResponse('500'));
+    const service = buildService(simulate);
+
+    const quote = await service.getFeeQuote({
+      method: 'buy_ticket',
+      params: [],
+      maxFeeStroops: '99999',
+    });
+
+    expect(quote.warnings.every(w => w.code !== 'MAX_FEE_EXCEEDED')).toBe(true);
+    expect(quote.confidence).toBe('high');
+  });
+
+  it('adds both FALLBACK_ESTIMATE and MAX_FEE_EXCEEDED when simulation fails and fallback exceeds limit', async () => {
+    const simulate = jest.fn().mockRejectedValue(new Error('fail'));
+    const service = buildService(simulate);
+
+    // Fallback is 50100 stroops; set ceiling to 100
+    const quote = await service.getFeeQuote({
+      method: 'buy_ticket',
+      params: [],
+      maxFeeStroops: '100',
+    });
+
+    const codes = quote.warnings.map(w => w.code);
+    expect(codes).toContain('FALLBACK_ESTIMATE');
+    expect(codes).toContain('MAX_FEE_EXCEEDED');
+    expect(quote.confidence).toBe('low');
+  });
+});

--- a/sdk/src/fee-estimator/index.ts
+++ b/sdk/src/fee-estimator/index.ts
@@ -4,4 +4,9 @@ export type {
   EstimateFeeParams,
   FeeEstimateResult,
   FeeResourceBreakdown,
+  FeeQuote,
+  FeeQuoteConfidence,
+  FeeQuoteSource,
+  FeeQuoteWarning,
+  GetFeeQuoteParams,
 } from './fee-estimator.types';

--- a/sdk/src/modules/raffle/raffle-lifecycle.service.spec.ts
+++ b/sdk/src/modules/raffle/raffle-lifecycle.service.spec.ts
@@ -1,0 +1,243 @@
+import { RaffleService } from './raffle.service';
+import { ContractService } from '../../contract/contract.service';
+import { ContractFn, RaffleStatus } from '../../contract/bindings';
+import { RaffleStateError, TriggerDrawParams } from './raffle.types';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeRaffleData(status: RaffleStatus, overrides: Partial<any> = {}) {
+  return {
+    success: true,
+    value: {
+      raffleId: 1,
+      creator: 'GCREATOR',
+      status,
+      ticketPrice: '100',
+      maxTickets: 50,
+      ticketsSold: 10,
+      endTime: Date.now() + 3_600_000,
+      asset: 'XLM',
+      allowMultiple: false,
+      metadataCid: '',
+      ...overrides,
+    },
+  };
+}
+
+function buildService() {
+  const contractService = {
+    invoke: jest.fn(),
+    simulateReadOnly: jest.fn(),
+  } as unknown as jest.Mocked<ContractService>;
+
+  const service = new RaffleService(contractService as any);
+  return { service, contractService };
+}
+
+// ─── triggerDraw ──────────────────────────────────────────────────────────────
+
+describe('RaffleService.triggerDraw', () => {
+  it('invokes TRIGGER_DRAW when raffle is Open', async () => {
+    const { service, contractService } = buildService();
+    contractService.simulateReadOnly.mockResolvedValue(
+      makeRaffleData(RaffleStatus.Open),
+    );
+    contractService.invoke.mockResolvedValue({
+      success: true,
+      value: { txHash: 'hash1', ledger: 99 },
+    });
+
+    const result = await service.triggerDraw({ raffleId: 1 });
+
+    expect(contractService.invoke).toHaveBeenCalledWith(
+      ContractFn.TRIGGER_DRAW,
+      [1],
+      { memo: undefined },
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it('throws RaffleStateError when raffle is already Drawing', async () => {
+    const { service, contractService } = buildService();
+    contractService.simulateReadOnly.mockResolvedValue(
+      makeRaffleData(RaffleStatus.Drawing),
+    );
+
+    await expect(service.triggerDraw({ raffleId: 1 })).rejects.toBeInstanceOf(
+      RaffleStateError,
+    );
+  });
+
+  it('throws RaffleStateError when raffle is Finalized', async () => {
+    const { service, contractService } = buildService();
+    contractService.simulateReadOnly.mockResolvedValue(
+      makeRaffleData(RaffleStatus.Finalized),
+    );
+
+    const err = await service
+      .triggerDraw({ raffleId: 1 })
+      .catch((e) => e);
+
+    expect(err).toBeInstanceOf(RaffleStateError);
+    expect((err as RaffleStateError).attempted).toBe('open→drawing');
+    expect((err as RaffleStateError).currentStatus).toBe(RaffleStatus.Finalized);
+  });
+
+  it('throws RaffleStateError when raffle is Cancelled', async () => {
+    const { service, contractService } = buildService();
+    contractService.simulateReadOnly.mockResolvedValue(
+      makeRaffleData(RaffleStatus.Cancelled),
+    );
+
+    await expect(service.triggerDraw({ raffleId: 1 })).rejects.toBeInstanceOf(
+      RaffleStateError,
+    );
+  });
+
+  it('throws validation error for raffleId = 0', async () => {
+    const { service } = buildService();
+    await expect(service.triggerDraw({ raffleId: 0 })).rejects.toThrow(
+      'raffleId must be a positive integer',
+    );
+  });
+
+  it('passes memo to invoke', async () => {
+    const { service, contractService } = buildService();
+    contractService.simulateReadOnly.mockResolvedValue(
+      makeRaffleData(RaffleStatus.Open),
+    );
+    contractService.invoke.mockResolvedValue({ success: true, value: {} });
+
+    await service.triggerDraw({
+      raffleId: 1,
+      memo: { type: 'text', value: 'oracle-trigger' },
+    } as TriggerDrawParams);
+
+    expect(contractService.invoke).toHaveBeenCalledWith(
+      ContractFn.TRIGGER_DRAW,
+      [1],
+      { memo: { type: 'text', value: 'oracle-trigger' } },
+    );
+  });
+});
+
+// ─── getWinner ────────────────────────────────────────────────────────────────
+
+describe('RaffleService.getWinner', () => {
+  it('returns winner data for a finalized raffle', async () => {
+    const { service, contractService } = buildService();
+    contractService.simulateReadOnly.mockResolvedValue(
+      makeRaffleData(RaffleStatus.Finalized, {
+        winner: 'GWINNER',
+        winningTicketId: 7,
+        prizeAmount: '5000',
+      }),
+    );
+
+    const result = await service.getWinner(1);
+
+    expect(result.success).toBe(true);
+    expect(result.value).toEqual({
+      raffleId: 1,
+      winner: 'GWINNER',
+      winningTicketId: 7,
+      prizeAmount: '5000',
+    });
+  });
+
+  it('returns null value for an open raffle (not finalized)', async () => {
+    const { service, contractService } = buildService();
+    contractService.simulateReadOnly.mockResolvedValue(
+      makeRaffleData(RaffleStatus.Open),
+    );
+
+    const result = await service.getWinner(1);
+
+    expect(result.success).toBe(true);
+    expect(result.value).toBeNull();
+  });
+
+  it('returns null value for a drawing raffle', async () => {
+    const { service, contractService } = buildService();
+    contractService.simulateReadOnly.mockResolvedValue(
+      makeRaffleData(RaffleStatus.Drawing),
+    );
+
+    const result = await service.getWinner(1);
+
+    expect(result.success).toBe(true);
+    expect(result.value).toBeNull();
+  });
+
+  it('returns null when raffle is finalized but winner field missing', async () => {
+    const { service, contractService } = buildService();
+    contractService.simulateReadOnly.mockResolvedValue(
+      makeRaffleData(RaffleStatus.Finalized, { winner: undefined }),
+    );
+
+    const result = await service.getWinner(1);
+
+    expect(result.success).toBe(true);
+    expect(result.value).toBeNull();
+  });
+
+  it('throws validation error for raffleId = 0', async () => {
+    const { service } = buildService();
+    await expect(service.getWinner(0)).rejects.toThrow(
+      'raffleId must be a positive integer',
+    );
+  });
+});
+
+// ─── cancel — state guard ─────────────────────────────────────────────────────
+
+describe('RaffleService.cancel — state guard', () => {
+  it('invokes CANCEL_RAFFLE when raffle is Open', async () => {
+    const { service, contractService } = buildService();
+    contractService.simulateReadOnly.mockResolvedValue(
+      makeRaffleData(RaffleStatus.Open),
+    );
+    contractService.invoke.mockResolvedValue({ success: true, value: undefined });
+
+    await service.cancel({ raffleId: 1 });
+
+    expect(contractService.invoke).toHaveBeenCalledWith(
+      ContractFn.CANCEL_RAFFLE,
+      [1],
+      { memo: undefined },
+    );
+  });
+
+  it('throws RaffleStateError when trying to cancel a Drawing raffle', async () => {
+    const { service, contractService } = buildService();
+    contractService.simulateReadOnly.mockResolvedValue(
+      makeRaffleData(RaffleStatus.Drawing),
+    );
+
+    const err = await service.cancel({ raffleId: 1 }).catch((e) => e);
+    expect(err).toBeInstanceOf(RaffleStateError);
+    expect((err as RaffleStateError).attempted).toBe('open→cancelled');
+  });
+
+  it('throws RaffleStateError when trying to cancel an already-cancelled raffle', async () => {
+    const { service, contractService } = buildService();
+    contractService.simulateReadOnly.mockResolvedValue(
+      makeRaffleData(RaffleStatus.Cancelled),
+    );
+
+    await expect(service.cancel({ raffleId: 1 })).rejects.toBeInstanceOf(
+      RaffleStateError,
+    );
+  });
+
+  it('throws RaffleStateError when trying to cancel a finalized raffle', async () => {
+    const { service, contractService } = buildService();
+    contractService.simulateReadOnly.mockResolvedValue(
+      makeRaffleData(RaffleStatus.Finalized),
+    );
+
+    await expect(service.cancel({ raffleId: 1 })).rejects.toBeInstanceOf(
+      RaffleStateError,
+    );
+  });
+});

--- a/sdk/src/modules/raffle/raffle.service.ts
+++ b/sdk/src/modules/raffle/raffle.service.ts
@@ -8,7 +8,12 @@ import {
   CancelRaffleResult,
   CancelRaffleParams,
   AssetDescriptor,
+  TriggerDrawParams,
+  TriggerDrawResult,
+  WinnerResult,
+  RaffleStateError,
 } from './raffle.types';
+import { RaffleStatus } from '../../contract/bindings';
 import { ContractResponse } from '../../contract/response';
 import { assertPositiveInt, assertNonEmpty } from '../../utils/validation';
 import { xlmToStroops } from '../../utils/formatting';
@@ -141,15 +146,79 @@ export class RaffleService {
 
   /**
    * Cancels an OPEN raffle (must be the raffle creator).
+   * Throws `RaffleStateError` if the raffle is not in the Open state.
    */
   async cancel(params: CancelRaffleParams): Promise<ContractResponse<void>> {
     assertPositiveInt(params.raffleId, 'raffleId');
+
+    const current = await this.get(params.raffleId);
+    if (current.success && current.value!.status !== RaffleStatus.Open) {
+      throw new RaffleStateError(params.raffleId, current.value!.status, 'open→cancelled');
+    }
 
     return await this.contract.invoke<void>(
       ContractFn.CANCEL_RAFFLE,
       [params.raffleId],
       { memo: params.memo },
     );
+  }
+
+  /* ------------------------------------------------------------------ */
+  /*  triggerDraw                                                        */
+  /* ------------------------------------------------------------------ */
+
+  /**
+   * Initiates the randomness request for a raffle that has reached its
+   * end time or sold out. Transitions the raffle from `Open` → `Drawing`.
+   *
+   * Requires the caller to be authorised (oracle or protocol admin).
+   * Throws `RaffleStateError` if the raffle is not currently Open.
+   */
+  async triggerDraw(params: TriggerDrawParams): Promise<ContractResponse<TriggerDrawResult>> {
+    assertPositiveInt(params.raffleId, 'raffleId');
+
+    const current = await this.get(params.raffleId);
+    if (current.success && current.value!.status !== RaffleStatus.Open) {
+      throw new RaffleStateError(params.raffleId, current.value!.status, 'open→drawing');
+    }
+
+    return await this.contract.invoke<TriggerDrawResult>(
+      ContractFn.TRIGGER_DRAW,
+      [params.raffleId],
+      { memo: params.memo },
+    );
+  }
+
+  /* ------------------------------------------------------------------ */
+  /*  getWinner                                                          */
+  /* ------------------------------------------------------------------ */
+
+  /**
+   * Reads the winner of a finalized raffle (read-only).
+   * Returns `undefined` fields when the raffle has not yet been finalized.
+   *
+   * Source of truth: contract RPC (`get_raffle_data`).
+   */
+  async getWinner(raffleId: number): Promise<ContractResponse<WinnerResult | null>> {
+    assertPositiveInt(raffleId, 'raffleId');
+
+    const res = await this.get(raffleId);
+    if (!res.success) return res as any;
+
+    const data = res.value!;
+    if (data.status !== RaffleStatus.Finalized || !data.winner) {
+      return { success: true, value: null };
+    }
+
+    return {
+      success: true,
+      value: {
+        raffleId,
+        winner: data.winner,
+        winningTicketId: data.winningTicketId!,
+        prizeAmount: data.prizeAmount ?? '0',
+      },
+    };
   }
 
   /* ------------------------------------------------------------------ */

--- a/sdk/src/modules/raffle/raffle.types.ts
+++ b/sdk/src/modules/raffle/raffle.types.ts
@@ -81,3 +81,61 @@ export interface CancelRaffleParams {
    */
   memo?: TxMemo;
 }
+
+// ─── Lifecycle additions (issue #602) ────────────────────────────────────────
+
+/**
+ * Valid state transitions in the raffle contract state machine:
+ *
+ *  Open ──► Drawing  (trigger_draw)
+ *  Drawing ──► Finalized (receive_randomness → internal finalization)
+ *  Open ──► Cancelled (cancel_raffle)
+ *
+ * Any other transition is rejected by the contract and surfaced as
+ * `RaffleStateError`.
+ */
+export type RaffleTransition =
+  | 'open→drawing'
+  | 'drawing→finalized'
+  | 'open→cancelled';
+
+/**
+ * Thrown when an operation is attempted in an invalid state.
+ * E.g. calling `triggerDraw` on an already-finalized raffle.
+ */
+export class RaffleStateError extends Error {
+  constructor(
+    public readonly raffleId: number,
+    public readonly currentStatus: RaffleStatus,
+    public readonly attempted: RaffleTransition,
+  ) {
+    super(
+      `Raffle ${raffleId} is in state ${RaffleStatus[currentStatus]} — ` +
+        `transition "${attempted}" is not allowed.`,
+    );
+    this.name = 'RaffleStateError';
+    Object.setPrototypeOf(this, RaffleStateError.prototype);
+  }
+}
+
+/** Parameters for triggering the draw on an open raffle. */
+export interface TriggerDrawParams {
+  raffleId: number;
+  memo?: TxMemo;
+}
+
+/** Result returned after triggering the draw. */
+export interface TriggerDrawResult {
+  txHash: string;
+  ledger: number;
+}
+
+/** Result returned after a raffle is finalized with a winner. */
+export interface WinnerResult {
+  raffleId: number;
+  winner: string;
+  winningTicketId: number;
+  prizeAmount: string;
+  txHash?: string;
+  ledger?: number;
+}

--- a/sdk/src/modules/user/user-activity.service.spec.ts
+++ b/sdk/src/modules/user/user-activity.service.spec.ts
@@ -1,0 +1,258 @@
+import { UserService } from './user.service';
+import { ContractService } from '../../contract/contract.service';
+import { ContractFn, RaffleStatus } from '../../contract/bindings';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const VALID_ADDRESS = 'GABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVW';
+const CREATOR_ADDRESS = 'GCREATORAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+const WINNER_ADDRESS  = 'GWINNERAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+
+function makeParticipation(raffleIds: number[]) {
+  return {
+    success: true,
+    value: {
+      total_raffles_entered: raffleIds.length,
+      total_tickets_bought: raffleIds.length * 2,
+      total_raffles_won: 0,
+      raffle_ids: raffleIds,
+    },
+  };
+}
+
+function makeRaffle(overrides: Partial<any> = {}) {
+  return {
+    success: true,
+    value: {
+      creator: CREATOR_ADDRESS,
+      status: RaffleStatus.Open,
+      ticket_price: '100',
+      max_tickets: 50,
+      tickets_sold: 2,
+      end_time: Date.now() + 3_600_000,
+      asset: 'XLM',
+      allow_multiple: false,
+      metadata_cid: '',
+      winner: undefined,
+      winning_ticket_id: undefined,
+      prize_amount: undefined,
+      ...overrides,
+    },
+  };
+}
+
+function buildService() {
+  const contractService = {
+    simulateReadOnly: jest.fn(),
+  } as unknown as jest.Mocked<ContractService>;
+
+  return { service: new UserService(contractService as any), contractService };
+}
+
+// ─── Empty user ───────────────────────────────────────────────────────────────
+
+describe('UserService.getActivitySummary — empty user', () => {
+  it('returns empty aggregates for a user with no raffle activity', async () => {
+    const { service, contractService } = buildService();
+
+    contractService.simulateReadOnly.mockResolvedValue({
+      success: true,
+      value: {
+        total_raffles_entered: 0,
+        total_tickets_bought: 0,
+        total_raffles_won: 0,
+        raffle_ids: [],
+      },
+    });
+
+    const result = await service.getActivitySummary({ address: VALID_ADDRESS });
+
+    expect(result.success).toBe(true);
+    expect(result.value!.raffles).toHaveLength(0);
+    expect(result.value!.tickets).toHaveLength(0);
+    expect(result.value!.wonRaffleIds).toHaveLength(0);
+    expect(result.value!.createdRaffleIds).toHaveLength(0);
+    expect(result.value!.totals).toEqual({
+      rafflesEntered: 0,
+      ticketsBought: 0,
+      rafflesWon: 0,
+      rafflesCreated: 0,
+    });
+  });
+});
+
+// ─── Active participant ───────────────────────────────────────────────────────
+
+describe('UserService.getActivitySummary — active participant', () => {
+  it('aggregates raffles and tickets for a participant with 2 raffles', async () => {
+    const { service, contractService } = buildService();
+
+    contractService.simulateReadOnly
+      // getParticipation
+      .mockResolvedValueOnce({
+        success: true,
+        value: {
+          total_raffles_entered: 2,
+          total_tickets_bought: 3,
+          total_raffles_won: 0,
+          raffle_ids: [1, 2],
+        },
+      })
+      // GET_RAFFLE_DATA for raffle 1
+      .mockResolvedValueOnce(makeRaffle({ status: RaffleStatus.Open }))
+      // GET_USER_TICKETS for raffle 1
+      .mockResolvedValueOnce({ success: true, value: [10, 11] })
+      // GET_RAFFLE_DATA for raffle 2
+      .mockResolvedValueOnce(makeRaffle({ status: RaffleStatus.Open }))
+      // GET_USER_TICKETS for raffle 2
+      .mockResolvedValueOnce({ success: true, value: [22] });
+
+    const result = await service.getActivitySummary({ address: VALID_ADDRESS });
+
+    expect(result.success).toBe(true);
+    expect(result.value!.raffles).toHaveLength(2);
+    expect(result.value!.tickets).toHaveLength(3);
+    expect(result.value!.totals.ticketsBought).toBe(3);
+    expect(result.value!.totals.rafflesEntered).toBe(2);
+  });
+});
+
+// ─── Creator ──────────────────────────────────────────────────────────────────
+
+describe('UserService.getActivitySummary — creator', () => {
+  it('marks raffle as created when address matches creator', async () => {
+    const { service, contractService } = buildService();
+
+    contractService.simulateReadOnly
+      .mockResolvedValueOnce({
+        success: true,
+        value: {
+          total_raffles_entered: 1,
+          total_tickets_bought: 1,
+          total_raffles_won: 0,
+          raffle_ids: [5],
+        },
+      })
+      .mockResolvedValueOnce(makeRaffle({ creator: VALID_ADDRESS }))
+      .mockResolvedValueOnce({ success: true, value: [1] });
+
+    const result = await service.getActivitySummary({ address: VALID_ADDRESS });
+
+    expect(result.value!.createdRaffleIds).toContain(5);
+    expect(result.value!.raffles[0].isCreator).toBe(true);
+    expect(result.value!.totals.rafflesCreated).toBe(1);
+  });
+});
+
+// ─── Winner ───────────────────────────────────────────────────────────────────
+
+describe('UserService.getActivitySummary — winner', () => {
+  it('marks raffle as won and includes prizeAmount when user is the winner', async () => {
+    const { service, contractService } = buildService();
+
+    contractService.simulateReadOnly
+      .mockResolvedValueOnce({
+        success: true,
+        value: {
+          total_raffles_entered: 1,
+          total_tickets_bought: 2,
+          total_raffles_won: 1,
+          raffle_ids: [7],
+        },
+      })
+      .mockResolvedValueOnce(
+        makeRaffle({
+          status: RaffleStatus.Finalized,
+          winner: VALID_ADDRESS,
+          prize_amount: BigInt(5000),
+        }),
+      )
+      .mockResolvedValueOnce({ success: true, value: [3, 4] });
+
+    const result = await service.getActivitySummary({ address: VALID_ADDRESS });
+
+    expect(result.value!.wonRaffleIds).toContain(7);
+    expect(result.value!.raffles[0].isWinner).toBe(true);
+    expect(result.value!.raffles[0].prizeAmount).toBe('5000');
+    expect(result.value!.totals.rafflesWon).toBe(1);
+  });
+});
+
+// ─── Refunded ticket (indexer field) ─────────────────────────────────────────
+
+describe('UserService.getActivitySummary — refunded ticket', () => {
+  it('leaves refundedTicketIds undefined when indexer data not requested', async () => {
+    const { service, contractService } = buildService();
+
+    contractService.simulateReadOnly.mockResolvedValue({
+      success: true,
+      value: {
+        total_raffles_entered: 0,
+        total_tickets_bought: 0,
+        total_raffles_won: 0,
+        raffle_ids: [],
+      },
+    });
+
+    const result = await service.getActivitySummary({ address: VALID_ADDRESS });
+
+    expect(result.value!.refundedTicketIds).toBeUndefined();
+    expect(result.value!.totalRefunded).toBeUndefined();
+  });
+});
+
+// ─── getTickets ───────────────────────────────────────────────────────────────
+
+describe('UserService.getTickets', () => {
+  it('returns all tickets across multiple raffles', async () => {
+    const { service, contractService } = buildService();
+
+    contractService.simulateReadOnly
+      .mockResolvedValueOnce({
+        success: true,
+        value: {
+          total_raffles_entered: 2,
+          total_tickets_bought: 3,
+          total_raffles_won: 0,
+          raffle_ids: [1, 2],
+        },
+      })
+      .mockResolvedValueOnce({ success: true, value: [10, 11] })
+      .mockResolvedValueOnce({ success: true, value: [22] });
+
+    const result = await service.getTickets(VALID_ADDRESS);
+
+    expect(result.success).toBe(true);
+    expect(result.value).toEqual([
+      { ticketId: 10, raffleId: 1 },
+      { ticketId: 11, raffleId: 1 },
+      { ticketId: 22, raffleId: 2 },
+    ]);
+  });
+
+  it('returns empty array for a user with no raffles', async () => {
+    const { service, contractService } = buildService();
+
+    contractService.simulateReadOnly.mockResolvedValue({
+      success: true,
+      value: {
+        total_raffles_entered: 0,
+        total_tickets_bought: 0,
+        total_raffles_won: 0,
+        raffle_ids: [],
+      },
+    });
+
+    const result = await service.getTickets(VALID_ADDRESS);
+
+    expect(result.success).toBe(true);
+    expect(result.value).toEqual([]);
+  });
+
+  it('throws validation error for invalid address', async () => {
+    const { service } = buildService();
+    await expect(service.getTickets('bad-key')).rejects.toThrow(
+      'Invalid Stellar public key',
+    );
+  });
+});

--- a/sdk/src/modules/user/user.service.ts
+++ b/sdk/src/modules/user/user.service.ts
@@ -1,9 +1,15 @@
 import { Injectable } from '@nestjs/common';
 import { ContractService } from '../../contract/contract.service';
-import { ContractFn } from '../../contract/bindings';
-import { UserParticipation, GetParticipationParams } from './user.types';
+import { ContractFn, RaffleStatus } from '../../contract/bindings';
+import {
+  UserParticipation,
+  GetParticipationParams,
+  UserActivitySummary,
+  UserRaffleActivity,
+  UserTicket,
+  GetUserActivityParams,
+} from './user.types';
 import { assertValidPublicKey } from '../../utils/validation';
-
 import { ContractResponse } from '../../contract/response';
 
 @Injectable()
@@ -11,10 +17,14 @@ export class UserService {
   constructor(private readonly contractService: ContractService) {}
 
   /**
-   * Retrieves user participation data from the Soroban contract.
+   * Retrieves core user participation data from the Soroban contract.
    * Read-only — no signing required.
+   *
+   * @source contract
    */
-  async getParticipation(params: GetParticipationParams): Promise<ContractResponse<UserParticipation>> {
+  async getParticipation(
+    params: GetParticipationParams,
+  ): Promise<ContractResponse<UserParticipation>> {
     const { address } = params;
     assertValidPublicKey(address);
 
@@ -29,16 +39,145 @@ export class UserService {
       return { success: false, error: response.error };
     }
 
-    const contractData = response.value!;
+    const d = response.value!;
     return {
       success: true,
       value: {
         address,
-        totalRafflesEntered: contractData.total_raffles_entered,
-        totalTicketsBought: contractData.total_tickets_bought,
-        totalRafflesWon: contractData.total_raffles_won,
-        raffleIds: contractData.raffle_ids,
+        totalRafflesEntered: d.total_raffles_entered,
+        totalTicketsBought: d.total_tickets_bought,
+        totalRafflesWon: d.total_raffles_won,
+        raffleIds: d.raffle_ids,
       },
     };
+  }
+
+  /**
+   * Returns all tickets owned by a user across every raffle they entered.
+   *
+   * Calls `GET_USER_TICKETS` for each raffle ID returned by `getParticipation`.
+   * The result includes per-ticket raffle IDs, suitable for display or refund
+   * eligibility checks.
+   *
+   * @source contract
+   */
+  async getTickets(address: string): Promise<ContractResponse<UserTicket[]>> {
+    assertValidPublicKey(address);
+
+    const participation = await this.getParticipation({ address });
+    if (!participation.success) {
+      return { success: false, error: participation.error };
+    }
+
+    const tickets: UserTicket[] = [];
+
+    for (const raffleId of participation.value!.raffleIds) {
+      const res = await this.contractService.simulateReadOnly<number[]>(
+        ContractFn.GET_USER_TICKETS,
+        [raffleId, address],
+      );
+
+      if (res.success && Array.isArray(res.value)) {
+        for (const ticketId of res.value) {
+          tickets.push({ ticketId, raffleId });
+        }
+      }
+    }
+
+    return { success: true, value: tickets };
+  }
+
+  /**
+   * Builds an aggregated `UserActivitySummary` from contract data.
+   *
+   * Aggregates raffles entered, tickets owned, wins, and creator activity
+   * entirely from contract RPC calls. Pass `includeIndexerData: true` to
+   * additionally annotate tickets with `purchasedAt` timestamps from an
+   * indexer (not yet wired — currently returns undefined for indexer fields).
+   *
+   * Source-of-truth per field:
+   * - `raffles`, `tickets`, `wonRaffleIds`, `createdRaffleIds`, `totals`
+   *   → contract RPC (simulateReadOnly)
+   * - `refundedTicketIds`, `totalRefunded`, `tickets[].purchasedAt`
+   *   → indexer/backend (undefined until indexer integration is wired)
+   *
+   * @source contract (indexer fields are undefined until wired)
+   */
+  async getActivitySummary(
+    params: GetUserActivityParams,
+  ): Promise<ContractResponse<UserActivitySummary>> {
+    const { address } = params;
+    assertValidPublicKey(address);
+
+    const participation = await this.getParticipation({ address });
+    if (!participation.success) {
+      return { success: false, error: participation.error };
+    }
+
+    const { raffleIds, totalRafflesWon } = participation.value!;
+
+    const raffleActivities: UserRaffleActivity[] = [];
+    const allTickets: UserTicket[] = [];
+    const wonRaffleIds: number[] = [];
+    const createdRaffleIds: number[] = [];
+
+    for (const raffleId of raffleIds) {
+      // Fetch raffle data (status, creator, winner)
+      const raffleRes = await this.contractService.simulateReadOnly<any>(
+        ContractFn.GET_RAFFLE_DATA,
+        [raffleId],
+      );
+
+      // Fetch this user's tickets for the raffle
+      const ticketRes = await this.contractService.simulateReadOnly<number[]>(
+        ContractFn.GET_USER_TICKETS,
+        [raffleId, address],
+      );
+
+      const raffleData = raffleRes.success ? raffleRes.value : null;
+      const ticketIds: number[] = ticketRes.success && Array.isArray(ticketRes.value)
+        ? ticketRes.value
+        : [];
+
+      for (const ticketId of ticketIds) {
+        allTickets.push({ ticketId, raffleId });
+      }
+
+      const isCreator = raffleData?.creator === address;
+      const isWinner = raffleData?.winner === address;
+
+      if (isCreator) createdRaffleIds.push(raffleId);
+      if (isWinner) wonRaffleIds.push(raffleId);
+
+      raffleActivities.push({
+        raffleId,
+        status: raffleData?.status ?? RaffleStatus.Open,
+        ticketIds,
+        isCreator,
+        isWinner,
+        prizeAmount: isWinner && raffleData?.prize_amount != null
+          ? String(raffleData.prize_amount)
+          : undefined,
+      });
+    }
+
+    const summary: UserActivitySummary = {
+      address,
+      raffles: raffleActivities,
+      tickets: allTickets,
+      wonRaffleIds,
+      createdRaffleIds,
+      totals: {
+        rafflesEntered: raffleIds.length,
+        ticketsBought: allTickets.length,
+        rafflesWon: totalRafflesWon,
+        rafflesCreated: createdRaffleIds.length,
+      },
+      // Indexer-backed fields — not yet wired
+      refundedTicketIds: undefined,
+      totalRefunded: undefined,
+    };
+
+    return { success: true, value: summary };
   }
 }

--- a/sdk/src/modules/user/user.types.ts
+++ b/sdk/src/modules/user/user.types.ts
@@ -1,11 +1,109 @@
+import { RaffleStatus } from '../../contract/bindings';
+
+// ─── Source-of-truth annotation ───────────────────────────────────────────────
+//
+// Fields in view models below are annotated with their data source:
+//   @source contract  — read via contract RPC (simulateReadOnly)
+//   @source indexer   — requires a running indexer / backend query
+//
+// Pure contract queries work offline; indexer fields need a backend endpoint.
+
 export interface UserParticipation {
+  /** @source contract */
   address: string;
+  /** Total distinct raffles the user has entered. @source contract */
   totalRafflesEntered: number;
+  /** Total tickets purchased across all raffles. @source contract */
   totalTicketsBought: number;
+  /** Total raffles won. @source contract */
   totalRafflesWon: number;
+  /** IDs of all raffles the user has participated in. @source contract */
   raffleIds: number[];
 }
 
 export interface GetParticipationParams {
   address: string;
+}
+
+// ─── Extended view models (issue #604) ───────────────────────────────────────
+
+/** A single ticket held by the user. */
+export interface UserTicket {
+  /** @source contract */
+  ticketId: number;
+  /** @source contract */
+  raffleId: number;
+  /** ISO-8601 purchase timestamp. @source indexer */
+  purchasedAt?: string;
+}
+
+/** Summary of the user's activity in a specific raffle. */
+export interface UserRaffleActivity {
+  /** @source contract */
+  raffleId: number;
+  /** @source contract */
+  status: RaffleStatus;
+  /** Tickets held by this user in this raffle. @source contract */
+  ticketIds: number[];
+  /** True when this user is the raffle creator. @source contract */
+  isCreator: boolean;
+  /** True when this user won the raffle. @source contract */
+  isWinner: boolean;
+  /** Prize amount in the raffle asset, only set when isWinner. @source contract */
+  prizeAmount?: string;
+}
+
+/**
+ * Aggregated view of all user activity — raffles, tickets, wins, refunds,
+ * and creator activity — as required by issue #604.
+ *
+ * Fields annotated with `@source indexer` require a backend/indexer endpoint
+ * and will be `undefined` when the SDK is used contract-only.
+ */
+export interface UserActivitySummary {
+  /** User's Stellar address. @source contract */
+  address: string;
+
+  /** All raffles the user participated in. @source contract */
+  raffles: UserRaffleActivity[];
+
+  /** Flat list of all tickets owned. @source contract */
+  tickets: UserTicket[];
+
+  /** IDs of raffles won. @source contract */
+  wonRaffleIds: number[];
+
+  /** IDs of raffles created by this user. @source contract */
+  createdRaffleIds: number[];
+
+  /**
+   * IDs of tickets that were refunded (raffle cancelled).
+   * @source indexer — requires backend query; undefined when unavailable.
+   */
+  refundedTicketIds?: number[];
+
+  /**
+   * Total XLM (or asset) refunded across all refunded tickets.
+   * @source indexer — undefined when unavailable.
+   */
+  totalRefunded?: string;
+
+  /** Aggregate participation counts. @source contract */
+  totals: {
+    rafflesEntered: number;
+    ticketsBought: number;
+    rafflesWon: number;
+    rafflesCreated: number;
+  };
+}
+
+/** Parameters for fetching the aggregated user activity summary. */
+export interface GetUserActivityParams {
+  address: string;
+  /**
+   * When true, the SDK will also attempt to fetch indexer-backed data
+   * (refunds, purchase timestamps). Requires `indexerUrl` to be configured.
+   * Defaults to false.
+   */
+  includeIndexerData?: boolean;
 }


### PR DESCRIPTION
closes #587
closes #601
closes #602
closes #604

## Summary

### closes #587 — Oracle: subscriber reconnect and backfill strategy
Extends `StellarSubscriberService` with last-cursor tracking, a `backfill()` method that fetches up to 500 missed transactions on reconnect, a bounded deduplication set (max 10 000 entries, LRU eviction) to suppress duplicates, and `getSubscriberLag()` / `getLastSeenCursor()` for health reporting. `restartStream` now awaits backfill before opening the live SSE stream.

### closes #601 — SDK: reusable fee quote API
Adds `FeeQuote`, `FeeQuoteSource`, `FeeQuoteConfidence`, `FeeQuoteWarning`, and `GetFeeQuoteParams` types. Implements `getFeeQuote()` on `FeeEstimatorService`: live simulation gives `confidence=high`; failure falls back to a static heuristic with a `FALLBACK_ESTIMATE` warning. `maxFeeStroops` ceiling adds a `MAX_FEE_EXCEEDED` warning. `isQuoteStale()` lets callers check the expiry window.

### closes #602 — SDK: typed raffle lifecycle methods
Adds `TriggerDrawParams`, `TriggerDrawResult`, `WinnerResult` types and `RaffleStateError`. Implements `triggerDraw()` (Open→Drawing) and `getWinner()` (reads finalized winner). Adds a pre-flight state guard to `cancel()` so invalid transitions throw `RaffleStateError` with the attempted transition name.

### closes #604 — SDK: user participation aggregation helpers
Expands `user.types.ts` with `UserTicket`, `UserRaffleActivity`, `UserActivitySummary` view models — each field annotated with its source of truth (contract vs indexer). Implements `getTickets()` and `getActivitySummary()` on `UserService`. Indexer-backed fields (`refundedTicketIds`, `totalRefunded`, `purchasedAt`) are typed and present but `undefined` until backend wiring.

## Test plan
- [ ] `cd sdk && npm run lint && npm run test && npm run build`
- [ ] `cd oracle && npm run lint && npm run test`
- [ ] Fee quote: simulation success, fallback, stale, max-fee guard
- [ ] Raffle lifecycle: triggerDraw happy path and all invalid state transitions
- [ ] Oracle backfill: disconnect, reconnect, backfill, duplicate suppression, lag
- [ ] User activity: empty user, participant, creator, winner, refunded ticket