### PR TITLE
feat: oracle audit/validation, DLQ classification, ShareRaffle QR, network modal

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -26,6 +26,7 @@
         "i18next-browser-languagedetector": "^8.2.1",
         "i18next-http-backend": "^3.0.6",
         "lucide-react": "^0.544.0",
+        "qrcode.react": "^4.2.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-helmet-async": "^3.0.0",

--- a/client/src/components/NetworkWarning.tsx
+++ b/client/src/components/NetworkWarning.tsx
@@ -1,61 +1,141 @@
-/**
- * NetworkWarning Component
- * Goal: Alert users when they are on Mainnet but the app requires Testnet.
- * Part of Issue #120
- */
 import { useWalletContext } from "../providers/WalletProvider";
 
+/**
+ * Renders a full-screen blocking modal when the connected wallet's network
+ * does not match VITE_STELLAR_NETWORK.
+ *
+ * The overlay intercepts all pointer events so no raffle action can proceed
+ * until the user switches to the correct network.
+ */
 const NetworkWarning = () => {
-  const { isConnected, isWrongNetwork, requiredNetwork, switchNetwork } = useWalletContext();
+  const { isConnected, networkMismatch, requiredNetwork, switchNetwork, network } =
+    useWalletContext();
 
-  // If wallet isn't connected or the network is correct, don't show anything
-  if (!isConnected || !isWrongNetwork) {
-    return null;
-  }
+  if (!isConnected || !networkMismatch) return null;
+
+  const connected = network ?? "unknown";
+  const required = requiredNetwork.toUpperCase();
 
   return (
-    <div style={{
-      backgroundColor: '#e11d48', // Warning Red
-      color: 'white',
-      textAlign: 'center',
-      padding: '12px',
-      position: 'fixed',
-      top: 0,
-      left: 0,
-      width: '100%',
-      zIndex: 10000,
-      fontWeight: '600',
-      fontSize: '14px',
-      display: 'flex',
-      justifyContent: 'center',
-      alignItems: 'center',
-      gap: '12px',
-      boxShadow: '0 4px 6px -1px rgb(0 0 0 / 0.1)'
-    }}>
-      <span>
-         <strong>Wrong Network:</strong> Your wallet is not on {requiredNetwork.toUpperCase()}. 
-        Please switch to use the Tikka platform.
-      </span>
-      
-      <button 
-        onClick={switchNetwork}
+    <>
+      {/* Backdrop — blocks all underlying interactions */}
+      <div
+        aria-hidden="true"
         style={{
-          backgroundColor: 'white',
-          color: '#e11d48',
-          border: 'none',
-          padding: '4px 12px',
-          borderRadius: '6px',
-          cursor: 'pointer',
-          fontSize: '12px',
-          fontWeight: 'bold',
-          transition: 'opacity 0.2s'
+          position: "fixed",
+          inset: 0,
+          zIndex: 9998,
+          backgroundColor: "rgba(0, 0, 0, 0.65)",
+          backdropFilter: "blur(4px)",
         }}
-        onMouseOver={(e) => e.currentTarget.style.opacity = '0.8'}
-        onMouseOut={(e) => e.currentTarget.style.opacity = '1'}
+      />
+
+      {/* Modal dialog */}
+      <div
+        role="alertdialog"
+        aria-modal="true"
+        aria-labelledby="nw-title"
+        aria-describedby="nw-desc"
+        style={{
+          position: "fixed",
+          inset: 0,
+          zIndex: 9999,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          padding: "1rem",
+          pointerEvents: "all",
+        }}
       >
-        Switch Network
-      </button>
-    </div>
+        <div
+          style={{
+            backgroundColor: "#11172E",
+            border: "1px solid #e11d48",
+            borderRadius: "1rem",
+            padding: "2rem",
+            maxWidth: "420px",
+            width: "100%",
+            textAlign: "center",
+            boxShadow: "0 25px 50px -12px rgba(0,0,0,0.6)",
+          }}
+        >
+          <div
+            aria-hidden="true"
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              justifyContent: "center",
+              width: "3rem",
+              height: "3rem",
+              borderRadius: "50%",
+              backgroundColor: "rgba(225, 29, 72, 0.15)",
+              marginBottom: "1rem",
+              fontSize: "1.5rem",
+            }}
+          >
+            ⚠️
+          </div>
+
+          <h2
+            id="nw-title"
+            style={{
+              color: "#f9fafb",
+              fontWeight: 700,
+              fontSize: "1.2rem",
+              marginBottom: "0.75rem",
+            }}
+          >
+            Wrong Network
+          </h2>
+
+          <p
+            id="nw-desc"
+            style={{
+              color: "#9CA3AF",
+              fontSize: "0.9rem",
+              lineHeight: 1.6,
+              marginBottom: "1.5rem",
+            }}
+          >
+            Your wallet is connected to{" "}
+            <strong style={{ color: "#f87171" }}>{connected.toUpperCase()}</strong>, but this
+            app requires <strong style={{ color: "#34d399" }}>{required}</strong>.
+            <br />
+            All raffle actions are disabled until you switch.
+          </p>
+
+          <button
+            type="button"
+            onClick={switchNetwork}
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              justifyContent: "center",
+              gap: "0.5rem",
+              backgroundColor: "#e11d48",
+              color: "white",
+              border: "none",
+              borderRadius: "0.5rem",
+              padding: "0.65rem 1.5rem",
+              fontWeight: 600,
+              fontSize: "0.9rem",
+              cursor: "pointer",
+              transition: "opacity 0.2s",
+              width: "100%",
+            }}
+            onMouseOver={(e) => (e.currentTarget.style.opacity = "0.85")}
+            onMouseOut={(e) => (e.currentTarget.style.opacity = "1")}
+          >
+            Switch to {required}
+          </button>
+
+          <p style={{ color: "#6B7280", fontSize: "0.75rem", marginTop: "0.75rem" }}>
+            If your wallet doesn&apos;t support automatic switching, change the
+            network manually in your wallet extension and reconnect.
+          </p>
+        </div>
+      </div>
+    </>
   );
 };
 

--- a/client/src/components/ShareRaffle.tsx
+++ b/client/src/components/ShareRaffle.tsx
@@ -1,6 +1,7 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
+import { QRCodeSVG } from "qrcode.react";
 import Union from "../assets/Union.png";
-import { Link2, Share2, Twitter } from "lucide-react";
+import { Download, Link2, Share2, Twitter } from "lucide-react";
 import { toast } from "sonner";
 
 type ShareSource = "twitter" | "telegram" | "native" | "copy";
@@ -39,8 +40,24 @@ function TelegramIcon({ className }: { className?: string }) {
 const iconButtonClass =
     "inline-flex items-center justify-center rounded-full bg-[#090E1F] p-2.5 text-[#00E6CC] ring-1 ring-[#00E6CC]/20 transition hover:bg-[#00E6CC]/10 hover:ring-[#00E6CC]/40 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#00E6CC]";
 
+/** Fallback copy for environments without Clipboard API (non-HTTPS, legacy browsers). */
+function copyViaExecCommand(text: string): boolean {
+    const ta = document.createElement("textarea");
+    ta.value = text;
+    ta.style.cssText = "position:fixed;top:-9999px;left:-9999px;opacity:0";
+    document.body.appendChild(ta);
+    ta.focus();
+    ta.select();
+    try {
+        return document.execCommand("copy");
+    } finally {
+        document.body.removeChild(ta);
+    }
+}
+
 const ShareRaffle = ({ raffleId, title }: ShareRaffleProps) => {
     const [copied, setCopied] = useState(false);
+    const qrRef = useRef<SVGSVGElement | null>(null);
 
     const shareBlurb = useMemo(
         () => `Check out this raffle: ${title}`,
@@ -49,19 +66,13 @@ const ShareRaffle = ({ raffleId, title }: ShareRaffleProps) => {
 
     const twitterHref = useMemo(() => {
         const url = buildRaffleShareUrl(raffleId, "twitter");
-        const params = new URLSearchParams({
-            text: shareBlurb,
-            url: url,
-        });
+        const params = new URLSearchParams({ text: shareBlurb, url });
         return `https://twitter.com/intent/tweet?${params.toString()}`;
     }, [raffleId, shareBlurb]);
 
     const telegramHref = useMemo(() => {
         const url = buildRaffleShareUrl(raffleId, "telegram");
-        const params = new URLSearchParams({
-            url,
-            text: shareBlurb,
-        });
+        const params = new URLSearchParams({ url, text: shareBlurb });
         return `https://t.me/share/url?${params.toString()}`;
     }, [raffleId, shareBlurb]);
 
@@ -82,11 +93,7 @@ const ShareRaffle = ({ raffleId, title }: ShareRaffleProps) => {
     const handleNativeShare = useCallback(async () => {
         if (!canWebShare) return;
         try {
-            await navigator.share({
-                title,
-                text: shareBlurb,
-                url: nativeShareUrl,
-            });
+            await navigator.share({ title, text: shareBlurb, url: nativeShareUrl });
         } catch (err) {
             const name = err instanceof DOMException ? err.name : "";
             if (name === "AbortError") return;
@@ -95,15 +102,59 @@ const ShareRaffle = ({ raffleId, title }: ShareRaffleProps) => {
     }, [canWebShare, nativeShareUrl, shareBlurb, title]);
 
     const handleCopyLink = useCallback(async () => {
-        try {
-            await navigator.clipboard.writeText(copyHref);
+        let success = false;
+        if (navigator.clipboard && window.isSecureContext) {
+            try {
+                await navigator.clipboard.writeText(copyHref);
+                success = true;
+            } catch {
+                // fall through to execCommand
+            }
+        }
+        if (!success) {
+            success = copyViaExecCommand(copyHref);
+        }
+        if (success) {
             setCopied(true);
             toast.success("Link copied to clipboard");
             window.setTimeout(() => setCopied(false), 2000);
-        } catch {
+        } else {
             toast.error("Could not copy link");
         }
     }, [copyHref]);
+
+    const handleDownloadQr = useCallback(() => {
+        const svg = qrRef.current;
+        if (!svg) return;
+
+        const serialized = new XMLSerializer().serializeToString(svg);
+        const img = new Image();
+        const svgBlob = new Blob([serialized], { type: "image/svg+xml;charset=utf-8" });
+        const url = URL.createObjectURL(svgBlob);
+
+        img.onload = () => {
+            const canvas = document.createElement("canvas");
+            // Render at 2× for sharper prints
+            canvas.width = img.naturalWidth * 2;
+            canvas.height = img.naturalHeight * 2;
+            const ctx = canvas.getContext("2d");
+            if (!ctx) return;
+            ctx.scale(2, 2);
+            ctx.drawImage(img, 0, 0);
+            URL.revokeObjectURL(url);
+
+            canvas.toBlob((blob) => {
+                if (!blob) return;
+                const pngUrl = URL.createObjectURL(blob);
+                const a = document.createElement("a");
+                a.href = pngUrl;
+                a.download = `raffle-${raffleId}-qr.png`;
+                a.click();
+                URL.revokeObjectURL(pngUrl);
+            }, "image/png");
+        };
+        img.src = url;
+    }, [raffleId]);
 
     return (
         <div className="bg-white dark:bg-[#11172E] rounded-3xl flex flex-col md:flex-row justify-between items-center border border-gray-200 dark:border-[#1F263F] mt-8 overflow-hidden">
@@ -146,21 +197,46 @@ const ShareRaffle = ({ raffleId, title }: ShareRaffleProps) => {
                     >
                         <TelegramIcon className="h-5 w-5" />
                     </a>
+
+                    {/* Copy Link button */}
                     <button
                         type="button"
-                        className={iconButtonClass}
+                        className={`${iconButtonClass} gap-2 px-4 py-2 rounded-full text-sm font-medium`}
                         onClick={handleCopyLink}
-                        aria-label="Copy raffle link"
+                        aria-label={copied ? "Copied!" : "Copy raffle link"}
                     >
-                        <Link2 className="h-5 w-5" />
-                        {copied ? (
-                            <span className="sr-only">Copied</span>
-                        ) : null}
+                        <Link2 className="h-5 w-5 shrink-0" />
+                        <span className="text-gray-100">{copied ? "Copied!" : "Copy Link"}</span>
+                    </button>
+                </div>
+
+                {/* QR code section */}
+                <div className="mt-6 flex flex-col items-start gap-3">
+                    <p className="text-xs text-gray-500 dark:text-[#6B7280] uppercase tracking-wide font-medium">
+                        QR Code
+                    </p>
+                    <div className="p-3 bg-white rounded-xl ring-1 ring-gray-200 dark:ring-[#1F263F] inline-block">
+                        <QRCodeSVG
+                            ref={qrRef}
+                            value={copyHref}
+                            size={128}
+                            level="M"
+                            aria-label={`QR code for raffle: ${title}`}
+                        />
+                    </div>
+                    <button
+                        type="button"
+                        className={`${iconButtonClass} gap-2 px-4 py-2 rounded-full text-sm font-medium`}
+                        onClick={handleDownloadQr}
+                        aria-label="Download QR code as PNG"
+                    >
+                        <Download className="h-5 w-5 shrink-0" />
+                        <span className="text-gray-100">Download QR</span>
                     </button>
                 </div>
             </div>
 
-            <div className="md:flex-shrink-0 hidden w-full md:w-auto ">
+            <div className="md:flex-shrink-0 hidden w-full md:w-auto">
                 <img
                     src={Union}
                     alt=""

--- a/client/src/providers/WalletProvider.tsx
+++ b/client/src/providers/WalletProvider.tsx
@@ -1,16 +1,13 @@
-/**
- * WalletProvider
- * * React context provider for wallet state management across the application.
- * Updated to handle Issue #120: Network switching and connection state.
- */
-
 import { createContext, useContext, useMemo, type ReactNode } from "react";
 import { useWallet, type UseWalletReturn } from "../hooks/useWallet";
 
-// We extend the return type to include the network status check
 interface WalletContextType extends UseWalletReturn {
-  isCorrectNetwork: boolean;
+  /** true when the connected wallet's network does not match VITE_STELLAR_NETWORK. */
+  networkMismatch: boolean;
+  /** The network name the app requires (e.g. "testnet" or "public"). */
   requiredNetwork: string;
+  /** @deprecated Use networkMismatch. Kept for backwards-compat with existing consumers. */
+  isCorrectNetwork: boolean;
 }
 
 const WalletContext = createContext<WalletContextType | undefined>(undefined);
@@ -19,27 +16,25 @@ interface WalletProviderProps {
   children: ReactNode;
 }
 
-/**
- * WalletProvider component that wraps the app and provides wallet context.
- * Now includes validation for the Stellar network (testnet/mainnet).
- */
 export function WalletProvider({ children }: WalletProviderProps) {
   const wallet = useWallet();
-  
-  // Get the required network from environment variables
-  const requiredNetwork = import.meta.env.VITE_STELLAR_NETWORK || 'testnet';
+  const requiredNetwork = import.meta.env.VITE_STELLAR_NETWORK || "testnet";
 
-  // Check if the current wallet network matches our app configuration
-  const isCorrectNetwork = useMemo(() => {
-    if (!wallet.isConnected || !wallet.network) return true;
-    return wallet.network.toLowerCase() === requiredNetwork.toLowerCase();
+  /**
+   * Detect network mismatch immediately after connection.
+   * Returns false (no mismatch) when the wallet is disconnected or the
+   * network is not yet known — avoids a false-positive flash on mount.
+   */
+  const networkMismatch = useMemo(() => {
+    if (!wallet.isConnected || !wallet.network) return false;
+    return wallet.network.toLowerCase() !== requiredNetwork.toLowerCase();
   }, [wallet.isConnected, wallet.network, requiredNetwork]);
 
-  // Combine the hook data with our network validation logic
-  const value = {
+  const value: WalletContextType = {
     ...wallet,
-    isCorrectNetwork,
-    requiredNetwork
+    networkMismatch,
+    requiredNetwork,
+    isCorrectNetwork: !networkMismatch,
   };
 
   return (
@@ -49,16 +44,10 @@ export function WalletProvider({ children }: WalletProviderProps) {
   );
 }
 
-/**
- * Hook to access wallet context
- * Must be used within a WalletProvider
- */
 export function useWalletContext(): WalletContextType {
   const context = useContext(WalletContext);
-
   if (context === undefined) {
     throw new Error("useWalletContext must be used within a WalletProvider");
   }
-
   return context;
 }

--- a/indexer/src/database/entities/dead-letter-event.entity.ts
+++ b/indexer/src/database/entities/dead-letter-event.entity.ts
@@ -7,8 +7,23 @@ import {
   UpdateDateColumn,
 } from 'typeorm';
 
+/** Failure-reason categories persisted on every DLQ entry. */
+export enum DlqReason {
+  /** Event payload could not be parsed into a known schema. */
+  PARSE_ERROR = 'PARSE_ERROR',
+  /** Domain handler threw a non-transient business-logic error. */
+  HANDLER_ERROR = 'HANDLER_ERROR',
+  /** Database write failed with a transient error (connection drop, timeout). */
+  DB_TRANSIENT = 'DB_TRANSIENT',
+  /** Schema version in the event is not supported by this indexer build. */
+  SCHEMA_UNSUPPORTED = 'SCHEMA_UNSUPPORTED',
+}
+
 @Entity('dead_letter_events')
 @Index('idx_dle_retry_count', ['retryCount'])
+@Index('idx_dle_reason', ['reason'])
+@Index('idx_dle_ledger', ['ledger'])
+@Index('idx_dle_replayed_at', ['replayedAt'])
 export class DeadLetterEventEntity {
   @PrimaryGeneratedColumn('uuid')
   id!: string;
@@ -28,8 +43,24 @@ export class DeadLetterEventEntity {
   @Column({ type: 'text', name: 'error_message' })
   errorMessage!: string;
 
+  /** Failure category — used to decide retryability and escalation. */
+  @Column({ type: 'varchar', length: 32, name: 'reason', default: DlqReason.HANDLER_ERROR })
+  reason!: DlqReason;
+
+  /** Whether this entry is eligible for automatic replay. */
+  @Column({ type: 'boolean', name: 'retryable', default: true })
+  retryable!: boolean;
+
   @Column({ type: 'integer', name: 'retry_count', default: 0 })
   retryCount!: number;
+
+  /**
+   * Timestamp set when this entry was successfully replayed.
+   * A non-null value acts as an idempotency guard — the entry will not be
+   * replayed again unless `forceReplay` is explicitly passed.
+   */
+  @Column({ type: 'timestamptz', name: 'replayed_at', nullable: true })
+  replayedAt!: Date | null;
 
   @CreateDateColumn({ type: 'timestamptz', name: 'created_at' })
   createdAt!: Date;

--- a/indexer/src/ingestor/dlq.service.spec.ts
+++ b/indexer/src/ingestor/dlq.service.spec.ts
@@ -1,10 +1,36 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { DlqService, MAX_RETRIES } from './dlq.service';
+import { DlqService, MAX_RETRIES, DlqReason } from './dlq.service';
 import { DeadLetterEventEntity } from '../database/entities/dead-letter-event.entity';
 import { IngestionDispatcherService } from './ingestion-dispatcher.service';
 import { DomainEvent } from './event.types';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeEntry(overrides: Partial<DeadLetterEventEntity> = {}): DeadLetterEventEntity {
+  return {
+    id: `uuid-${Math.random().toString(36).slice(2)}`,
+    ledger: 1000,
+    contractId: 'CXYZ',
+    eventType: 'RaffleCreated',
+    rawPayload: { ledger: 1000 },
+    errorMessage: 'previous error',
+    reason: DlqReason.HANDLER_ERROR,
+    retryable: true,
+    retryCount: 0,
+    replayedAt: null,
+    createdAt: new Date(),
+    lastAttemptAt: new Date(),
+    ...overrides,
+  } as DeadLetterEventEntity;
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
 
 describe('DlqService', () => {
   let service: DlqService;
@@ -35,53 +61,69 @@ describe('DlqService', () => {
     service = module.get<DlqService>(DlqService);
   });
 
+  // -------------------------------------------------------------------------
+  // insert — reason classification
+  // -------------------------------------------------------------------------
+
   describe('insert', () => {
-    it('should save a failed event to the DLQ', async () => {
-      const event: DomainEvent = { type: 'RaffleCreated', raffle_id: 1, creator: 'GABC', params: {} as any };
-      const rawEvent = { ledger: 1000, contractId: 'CXYZ' };
-      const error = new Error('DB constraint violation');
+    const event: DomainEvent = {
+      type: 'RaffleCreated',
+      raffle_id: 1,
+      creator: 'GABC',
+      params: {} as any,
+    };
+    const rawEvent = { ledger: 1000, contractId: 'CXYZ' };
 
-      await service.insert(event, rawEvent, error);
-
-      expect(repo.create).toHaveBeenCalledWith({
-        ledger: 1000,
-        contractId: 'CXYZ',
-        eventType: 'RaffleCreated',
-        rawPayload: rawEvent,
-        errorMessage: 'DB constraint violation',
-        retryCount: 0,
-      });
-      expect(repo.save).toHaveBeenCalled();
+    it('defaults to HANDLER_ERROR and marks retryable=true', async () => {
+      await service.insert(event, rawEvent, new Error('oops'));
+      expect(repo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ reason: DlqReason.HANDLER_ERROR, retryable: true }),
+      );
     });
 
-    it('should handle non-Error objects', async () => {
-      const event: DomainEvent = { type: 'TicketPurchased', raffle_id: 2, buyer: 'GDEF', ticket_ids: [], total_paid: '0' };
-      const rawEvent = { ledger: 2000 };
-
-      await service.insert(event, rawEvent, 'string error');
-
+    it('stores PARSE_ERROR with retryable=false', async () => {
+      await service.insert(event, rawEvent, new Error('bad parse'), DlqReason.PARSE_ERROR);
       expect(repo.create).toHaveBeenCalledWith(
-        expect.objectContaining({ errorMessage: 'string error' }),
+        expect.objectContaining({ reason: DlqReason.PARSE_ERROR, retryable: false }),
+      );
+    });
+
+    it('stores SCHEMA_UNSUPPORTED with retryable=false', async () => {
+      await service.insert(event, rawEvent, new Error('v99'), DlqReason.SCHEMA_UNSUPPORTED);
+      expect(repo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ reason: DlqReason.SCHEMA_UNSUPPORTED, retryable: false }),
+      );
+    });
+
+    it('stores DB_TRANSIENT with retryable=true', async () => {
+      await service.insert(event, rawEvent, new Error('timeout'), DlqReason.DB_TRANSIENT);
+      expect(repo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ reason: DlqReason.DB_TRANSIENT, retryable: true }),
+      );
+    });
+
+    it('stores non-Error objects as string messages', async () => {
+      await service.insert(event, rawEvent, 'plain string error');
+      expect(repo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ errorMessage: 'plain string error' }),
+      );
+    });
+
+    it('initialises replayedAt as null', async () => {
+      await service.insert(event, rawEvent, new Error('x'));
+      expect(repo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ replayedAt: null }),
       );
     });
   });
 
-  describe('count', () => {
-    it('should return the DLQ size', async () => {
-      repo.count.mockResolvedValue(42);
-      expect(await service.count()).toBe(42);
-    });
-  });
+  // -------------------------------------------------------------------------
+  // replayAll — basic replay
+  // -------------------------------------------------------------------------
 
-  describe('replayAll', () => {
-    it('should replay eligible entries and delete on success', async () => {
-      const entry = {
-        id: 'uuid-1',
-        eventType: 'RaffleCreated',
-        rawPayload: { ledger: 1000 },
-        retryCount: 0,
-      } as unknown as DeadLetterEventEntity;
-
+  describe('replayAll — success path', () => {
+    it('replays eligible entries, sets replayedAt, and does not delete', async () => {
+      const entry = makeEntry();
       repo.find.mockResolvedValue([entry]);
       const mockQr = { commitTransaction: jest.fn(), release: jest.fn() };
       dispatcher.dispatch.mockResolvedValue(mockQr as any);
@@ -91,62 +133,138 @@ describe('DlqService', () => {
       expect(result.replayed).toBe(1);
       expect(result.failed).toBe(0);
       expect(mockQr.commitTransaction).toHaveBeenCalled();
-      expect(repo.delete).toHaveBeenCalledWith('uuid-1');
-    });
-
-    it('should increment retryCount on failure', async () => {
-      const entry = {
-        id: 'uuid-2',
-        eventType: 'TicketPurchased',
-        rawPayload: { ledger: 2000 },
-        retryCount: 1,
-        errorMessage: 'old error',
-      } as unknown as DeadLetterEventEntity;
-
-      repo.find.mockResolvedValue([entry]);
-      dispatcher.dispatch.mockRejectedValue(new Error('still failing'));
-
-      const result = await service.replayAll();
-
-      expect(result.replayed).toBe(0);
-      expect(result.failed).toBe(1);
-      expect(entry.retryCount).toBe(2);
-      expect(entry.errorMessage).toBe('still failing');
+      expect(entry.replayedAt).toBeInstanceOf(Date);
       expect(repo.save).toHaveBeenCalledWith(entry);
+      // entry should NOT be deleted — idempotency guard relies on replayedAt
+      expect(repo.delete).not.toHaveBeenCalled();
     });
 
-    it('should skip entries that have exceeded MAX_RETRIES', async () => {
-      const exhausted = {
-        id: 'uuid-3',
-        eventType: 'RaffleFinalized',
-        rawPayload: { ledger: 3000 },
-        retryCount: MAX_RETRIES,
-      } as unknown as DeadLetterEventEntity;
-
-      repo.find.mockResolvedValue([exhausted]);
-
-      const result = await service.replayAll();
-
-      expect(result.replayed).toBe(0);
-      expect(result.failed).toBe(0);
-      expect(dispatcher.dispatch).not.toHaveBeenCalled();
-    });
-
-    it('should handle null QueryRunner from dispatcher', async () => {
-      const entry = {
-        id: 'uuid-4',
-        eventType: 'DrawTriggered',
-        rawPayload: { ledger: 4000 },
-        retryCount: 0,
-      } as unknown as DeadLetterEventEntity;
-
+    it('handles a null QueryRunner from dispatcher', async () => {
+      const entry = makeEntry();
       repo.find.mockResolvedValue([entry]);
       dispatcher.dispatch.mockResolvedValue(null);
 
       const result = await service.replayAll();
-
       expect(result.replayed).toBe(1);
-      expect(repo.delete).toHaveBeenCalledWith('uuid-4');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // replayAll — failure and retry-count tracking
+  // -------------------------------------------------------------------------
+
+  describe('replayAll — failure path', () => {
+    it('increments retryCount on failure and preserves error message', async () => {
+      const entry = makeEntry({ retryCount: 1 });
+      repo.find.mockResolvedValue([entry]);
+      dispatcher.dispatch.mockRejectedValue(new Error('still failing'));
+
+      const result = await service.replayAll();
+      expect(result.failed).toBe(1);
+      expect(entry.retryCount).toBe(2);
+      expect(entry.errorMessage).toBe('still failing');
+    });
+
+    it('skips entries that have exceeded MAX_RETRIES', async () => {
+      const exhausted = makeEntry({ retryCount: MAX_RETRIES });
+      repo.find.mockResolvedValue([exhausted]);
+
+      const result = await service.replayAll();
+      expect(result.replayed).toBe(0);
+      expect(result.failed).toBe(0);
+      expect(dispatcher.dispatch).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // replayAll — idempotency guard
+  // -------------------------------------------------------------------------
+
+  describe('replayAll — idempotency', () => {
+    it('skips already-replayed entries by default', async () => {
+      const alreadyDone = makeEntry({ replayedAt: new Date() });
+      // repo.find respects where clause; simulate service filtering by returning
+      // only entries where replayedAt IS NULL when forceReplay is false.
+      // In tests we control what find returns.
+      repo.find.mockResolvedValue([]); // filtered out by query
+
+      const result = await service.replayAll();
+      expect(result.replayed).toBe(0);
+      expect(dispatcher.dispatch).not.toHaveBeenCalled();
+    });
+
+    it('replays already-replayed entries when forceReplay=true', async () => {
+      const alreadyDone = makeEntry({ replayedAt: new Date('2025-01-01') });
+      repo.find.mockResolvedValue([alreadyDone]);
+      const mockQr = { commitTransaction: jest.fn(), release: jest.fn() };
+      dispatcher.dispatch.mockResolvedValue(mockQr as any);
+
+      const result = await service.replayAll({ forceReplay: true });
+      expect(result.replayed).toBe(1);
+      expect(alreadyDone.replayedAt).not.toEqual(new Date('2025-01-01')); // updated
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // replayAll — dry-run mode
+  // -------------------------------------------------------------------------
+
+  describe('replayAll — dry-run', () => {
+    it('does not dispatch or save in dry-run mode', async () => {
+      const entry = makeEntry();
+      repo.find.mockResolvedValue([entry]);
+
+      const result = await service.replayAll({ dryRun: true });
+
+      expect(result.dryRun).toBe(true);
+      expect(result.skipped).toBe(1);
+      expect(result.replayed).toBe(0);
+      expect(dispatcher.dispatch).not.toHaveBeenCalled();
+      expect(repo.save).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // replayAll — non-retryable entries excluded
+  // -------------------------------------------------------------------------
+
+  describe('replayAll — non-retryable exclusion', () => {
+    it('does not replay entries with retryable=false', async () => {
+      // The service queries with retryable: true so find returns nothing for non-retryable
+      repo.find.mockResolvedValue([]); // DB filters them out
+
+      const result = await service.replayAll();
+      expect(result.replayed).toBe(0);
+      expect(dispatcher.dispatch).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // DlqReason categories — full coverage
+  // -------------------------------------------------------------------------
+
+  describe('DlqReason categories', () => {
+    const cases: Array<[DlqReason, boolean]> = [
+      [DlqReason.PARSE_ERROR, false],
+      [DlqReason.HANDLER_ERROR, true],
+      [DlqReason.DB_TRANSIENT, true],
+      [DlqReason.SCHEMA_UNSUPPORTED, false],
+    ];
+
+    it.each(cases)('%s → retryable=%s', async (reason, expectedRetryable) => {
+      const event: DomainEvent = {
+        type: 'TicketPurchased',
+        raffle_id: 1,
+        buyer: 'G123',
+        ticket_ids: [],
+        total_paid: '0',
+      };
+      await service.insert(event, { ledger: 100 }, new Error('test'), reason);
+      expect(repo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ reason, retryable: expectedRetryable }),
+      );
+      jest.clearAllMocks();
+      repo.create.mockImplementation((e) => e as DeadLetterEventEntity);
     });
   });
 });

--- a/indexer/src/ingestor/dlq.service.ts
+++ b/indexer/src/ingestor/dlq.service.ts
@@ -1,14 +1,51 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
-import { DeadLetterEventEntity } from '../database/entities/dead-letter-event.entity';
+import { Between, FindOptionsWhere, IsNull, Repository } from 'typeorm';
+import { DeadLetterEventEntity, DlqReason } from '../database/entities/dead-letter-event.entity';
 import { DomainEvent } from './event.types';
 import { IngestionDispatcherService } from './ingestion-dispatcher.service';
+
+export { DlqReason };
 
 export const MAX_RETRIES = 5;
 
 /** Base delay in ms for exponential back-off: delay = BASE_DELAY_MS * 2^retryCount */
 const BASE_DELAY_MS = 1_000;
+
+/**
+ * Map from DlqReason to whether automatic replay should be attempted.
+ *
+ * - PARSE_ERROR / SCHEMA_UNSUPPORTED → not retryable (a code fix is needed first).
+ * - HANDLER_ERROR → retryable (handler may be idempotent or the error transient).
+ * - DB_TRANSIENT → retryable (connection issues are usually self-healing).
+ */
+const REASON_RETRYABLE: Record<DlqReason, boolean> = {
+  [DlqReason.PARSE_ERROR]: false,
+  [DlqReason.HANDLER_ERROR]: true,
+  [DlqReason.DB_TRANSIENT]: true,
+  [DlqReason.SCHEMA_UNSUPPORTED]: false,
+};
+
+export interface ReplayOptions {
+  /** When true, no writes are made — the command logs what would happen. */
+  dryRun?: boolean;
+  /** Only replay entries where `ledger` is >= fromLedger. */
+  fromLedger?: number;
+  /** Only replay entries where `ledger` is <= toLedger. */
+  toLedger?: number;
+  /**
+   * When true, entries that have already been replayed (`replayedAt != null`)
+   * are eligible again. Use with caution.
+   */
+  forceReplay?: boolean;
+}
+
+export interface ReplayResult {
+  replayed: number;
+  skipped: number;
+  failed: number;
+  dryRun: boolean;
+}
 
 @Injectable()
 export class DlqService {
@@ -20,14 +57,24 @@ export class DlqService {
     private readonly dispatcher: IngestionDispatcherService,
   ) {}
 
+  /**
+   * Enqueue a failed event in the DLQ with a classified reason and retryability flag.
+   *
+   * @param event     The domain event that failed.
+   * @param rawEvent  The raw ledger payload (preserved for replay context).
+   * @param error     The error that caused the failure.
+   * @param reason    Why the event failed. Defaults to HANDLER_ERROR.
+   */
   async insert(
     event: DomainEvent,
     rawEvent: Record<string, unknown>,
     error: unknown,
+    reason: DlqReason = DlqReason.HANDLER_ERROR,
   ): Promise<void> {
     const ledger = Number(rawEvent['ledger'] ?? 0);
     const contractId = (rawEvent['contractId'] as string | undefined) ?? null;
     const errorMessage = error instanceof Error ? error.message : String(error);
+    const retryable = REASON_RETRYABLE[reason];
 
     await this.repo.save(
       this.repo.create({
@@ -36,12 +83,15 @@ export class DlqService {
         eventType: event.type,
         rawPayload: rawEvent,
         errorMessage,
+        reason,
+        retryable,
         retryCount: 0,
+        replayedAt: null,
       }),
     );
 
     this.logger.warn(
-      `DLQ: stored failed event ${event.type} at ledger ${ledger}: ${errorMessage}`,
+      `DLQ [${reason}] stored ${event.type} at ledger ${ledger} (retryable=${retryable}): ${errorMessage}`,
     );
   }
 
@@ -50,21 +100,51 @@ export class DlqService {
   }
 
   /**
-   * Retry all DLQ entries that have not yet exceeded MAX_RETRIES.
-   * Uses exponential back-off: delay = BASE_DELAY_MS * 2^retryCount.
-   * Successful entries are deleted; failed entries have retryCount incremented.
+   * Replay all eligible DLQ entries, optionally scoped to a ledger range.
+   *
+   * Eligibility rules (applied in order):
+   * 1. `retryable` must be `true` (PARSE_ERROR and SCHEMA_UNSUPPORTED are excluded).
+   * 2. `retryCount` must be < MAX_RETRIES.
+   * 3. `replayedAt` must be null unless `forceReplay` is set.
+   * 4. If `fromLedger` / `toLedger` are provided, `ledger` must be within range.
+   *
+   * Idempotency: successful replays set `replayedAt` to the current timestamp.
+   * Subsequent calls will skip those entries unless `forceReplay` is passed.
+   *
+   * Dry-run: when `dryRun` is true the method logs each eligible entry and
+   * returns counts, but makes no state changes.
    */
-  async replayAll(): Promise<{ replayed: number; failed: number }> {
-    const entries = await this.repo.find({
-      where: { retryCount: undefined as any },
-      order: { createdAt: 'ASC' },
-    });
+  async replayAll(options: ReplayOptions = {}): Promise<ReplayResult> {
+    const { dryRun = false, fromLedger, toLedger, forceReplay = false } = options;
 
+    const where: FindOptionsWhere<DeadLetterEventEntity> = {
+      retryable: true,
+      ...(forceReplay ? {} : { replayedAt: IsNull() }),
+      ...(fromLedger !== undefined && toLedger !== undefined
+        ? { ledger: Between(fromLedger, toLedger) }
+        : fromLedger !== undefined
+        ? { ledger: Between(fromLedger, Number.MAX_SAFE_INTEGER) }
+        : toLedger !== undefined
+        ? { ledger: Between(0, toLedger) }
+        : {}),
+    };
+
+    const entries = await this.repo.find({ where, order: { ledger: 'ASC', createdAt: 'ASC' } });
     const eligible = entries.filter((e) => e.retryCount < MAX_RETRIES);
+
     let replayed = 0;
+    let skipped = 0;
     let failed = 0;
 
     for (const entry of eligible) {
+      if (dryRun) {
+        this.logger.log(
+          `DLQ dry-run: would replay ${entry.eventType} ledger=${entry.ledger} id=${entry.id} (reason=${entry.reason} retries=${entry.retryCount})`,
+        );
+        skipped++;
+        continue;
+      }
+
       const delay = BASE_DELAY_MS * Math.pow(2, entry.retryCount);
       await sleep(delay);
 
@@ -75,21 +155,26 @@ export class DlqService {
           await qr.commitTransaction();
           qr.release();
         }
-        await this.repo.delete(entry.id);
+        // Mark as successfully replayed (idempotency guard)
+        entry.replayedAt = new Date();
+        await this.repo.save(entry);
         replayed++;
-        this.logger.log(`DLQ: replayed ${entry.eventType} (id=${entry.id})`);
+        this.logger.log(`DLQ: replayed ${entry.eventType} ledger=${entry.ledger} id=${entry.id}`);
       } catch (err) {
         entry.retryCount += 1;
         entry.errorMessage = err instanceof Error ? err.message : String(err);
         await this.repo.save(entry);
         failed++;
         this.logger.warn(
-          `DLQ: retry ${entry.retryCount}/${MAX_RETRIES} failed for ${entry.eventType} (id=${entry.id})`,
+          `DLQ: retry ${entry.retryCount}/${MAX_RETRIES} failed for ${entry.eventType} id=${entry.id}: ${entry.errorMessage}`,
         );
       }
     }
 
-    return { replayed, failed };
+    this.logger.log(
+      `DLQ replay complete${dryRun ? ' (dry-run)' : ''}: replayed=${replayed} skipped=${skipped} failed=${failed}`,
+    );
+    return { replayed, skipped, failed, dryRun };
   }
 }
 

--- a/oracle/src/multi-oracle/multi-oracle.types.ts
+++ b/oracle/src/multi-oracle/multi-oracle.types.ts
@@ -65,3 +65,30 @@ export interface SubmissionTracker {
   completed: boolean;
   aggregatedSeed?: string;
 }
+
+/** Actions tracked in the oracle registry audit log. */
+export type OracleAuditAction =
+  | 'ADD_ORACLE'
+  | 'REMOVE_ORACLE'
+  | 'ENABLE_ORACLE'
+  | 'DISABLE_ORACLE'
+  | 'ADD_PEER'
+  | 'REMOVE_PEER';
+
+/** A single immutable audit record for a registry change. */
+export interface OracleAuditEntry {
+  action: OracleAuditAction;
+  targetId: string;
+  actor?: string;
+  timestamp: number;
+  meta?: Record<string, unknown>;
+}
+
+/** Safe, redacted view of the registry exposed to callers (no private keys). */
+export interface OracleRegistrySnapshot {
+  mode: MultiOracleMode;
+  localOracleId: string;
+  threshold: number;
+  oracles: Array<Omit<OracleRegistryEntry, 'privateKey'>>;
+  peerCount: number;
+}

--- a/oracle/src/multi-oracle/oracle-registry.service.spec.ts
+++ b/oracle/src/multi-oracle/oracle-registry.service.spec.ts
@@ -1,0 +1,269 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { OracleRegistryService } from './oracle-registry.service';
+import { KeyService } from '../keys/key.service';
+import { MultiOracleMode, OracleConfig, PeerOracleEndpoint } from './multi-oracle.types';
+import { Keypair } from '@stellar/stellar-sdk';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function randomKeypair() {
+  return Keypair.random();
+}
+
+function makePeer(overrides: Partial<PeerOracleEndpoint> = {}): PeerOracleEndpoint {
+  return {
+    id: `peer-${Math.random().toString(36).slice(2)}`,
+    url: 'http://peer.example.com:4000',
+    publicKey: randomKeypair().publicKey(),
+    ...overrides,
+  };
+}
+
+function makeOracle(overrides: Partial<OracleConfig> = {}): OracleConfig {
+  return {
+    id: `oracle-${Math.random().toString(36).slice(2)}`,
+    publicKey: randomKeypair().publicKey(),
+    weight: 1,
+    isLocal: false,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+describe('OracleRegistryService', () => {
+  let service: OracleRegistryService;
+
+  beforeEach(async () => {
+    const keyService = { getPublicKey: jest.fn().mockResolvedValue(randomKeypair().publicKey()) };
+    const configService = {
+      get: jest.fn((key: string, defaultValue?: unknown) => {
+        const cfg: Record<string, unknown> = {
+          ORACLE_MODE: 'single',
+          MULTI_ORACLE_ENABLED: false,
+        };
+        return cfg[key] ?? defaultValue;
+      }),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        OracleRegistryService,
+        { provide: ConfigService, useValue: configService },
+        { provide: KeyService, useValue: keyService },
+      ],
+    }).compile();
+
+    service = module.get<OracleRegistryService>(OracleRegistryService);
+    await service.onModuleInit();
+  });
+
+  // -------------------------------------------------------------------------
+  // addOracle
+  // -------------------------------------------------------------------------
+
+  describe('addOracle', () => {
+    it('adds a valid oracle and records an audit entry', () => {
+      const cfg = makeOracle();
+      service.addOracle(cfg, 'admin');
+
+      expect(service.getOracle(cfg.id)).toBeDefined();
+      const log = service.getAuditLog();
+      expect(log[0]).toMatchObject({ action: 'ADD_ORACLE', targetId: cfg.id, actor: 'admin' });
+    });
+
+    it('rejects an oracle with an invalid public key', () => {
+      const cfg = makeOracle({ publicKey: 'not-a-valid-key' });
+      expect(() => service.addOracle(cfg)).toThrow(/Invalid public key/);
+    });
+
+    it('rejects a duplicate oracle ID', () => {
+      const cfg = makeOracle();
+      service.addOracle(cfg);
+      expect(() => service.addOracle(cfg)).toThrow(/Duplicate oracle ID/);
+    });
+
+    it('rejects a duplicate public key across different oracle IDs', () => {
+      const kp = randomKeypair();
+      const cfg1 = makeOracle({ publicKey: kp.publicKey() });
+      const cfg2 = makeOracle({ publicKey: kp.publicKey() });
+      service.addOracle(cfg1);
+      expect(() => service.addOracle(cfg2)).toThrow(/already registered/);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // setOracleActive (status transitions)
+  // -------------------------------------------------------------------------
+
+  describe('setOracleActive', () => {
+    it('disables an active oracle and audits the change', () => {
+      const cfg = makeOracle();
+      service.addOracle(cfg);
+
+      service.setOracleActive(cfg.id, false, 'ops-team');
+      expect(service.getOracle(cfg.id)!.isActive).toBe(false);
+
+      const log = service.getAuditLog();
+      expect(log[0]).toMatchObject({ action: 'DISABLE_ORACLE', targetId: cfg.id, actor: 'ops-team' });
+    });
+
+    it('enables a disabled oracle and audits the change', () => {
+      const cfg = makeOracle();
+      service.addOracle(cfg);
+      service.setOracleActive(cfg.id, false);
+      service.setOracleActive(cfg.id, true, 'admin');
+
+      expect(service.getOracle(cfg.id)!.isActive).toBe(true);
+      const log = service.getAuditLog();
+      expect(log[0]).toMatchObject({ action: 'ENABLE_ORACLE', actor: 'admin' });
+    });
+
+    it('is a no-op when status is already the same (no audit entry)', () => {
+      const cfg = makeOracle();
+      service.addOracle(cfg);
+      const logBefore = service.getAuditLog().length;
+      service.setOracleActive(cfg.id, true); // already active
+      expect(service.getAuditLog().length).toBe(logBefore);
+    });
+
+    it('throws for an unknown oracle ID', () => {
+      expect(() => service.setOracleActive('ghost-id', false)).toThrow(/Oracle not found/);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // removeOracle
+  // -------------------------------------------------------------------------
+
+  describe('removeOracle', () => {
+    it('removes an oracle and audits the change', () => {
+      const cfg = makeOracle();
+      service.addOracle(cfg);
+      const removed = service.removeOracle(cfg.id, 'admin');
+
+      expect(removed).toBe(true);
+      expect(service.getOracle(cfg.id)).toBeUndefined();
+      expect(service.getAuditLog()[0]).toMatchObject({ action: 'REMOVE_ORACLE', targetId: cfg.id });
+    });
+
+    it('returns false and does not audit when oracle does not exist', () => {
+      const logBefore = service.getAuditLog().length;
+      const removed = service.removeOracle('nonexistent');
+      expect(removed).toBe(false);
+      expect(service.getAuditLog().length).toBe(logBefore);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // addPeer
+  // -------------------------------------------------------------------------
+
+  describe('addPeer', () => {
+    it('adds a valid peer and records an audit entry', () => {
+      const peer = makePeer();
+      service.addPeer(peer, 'admin');
+
+      expect(service.getPeerEndpoints()).toContainEqual(expect.objectContaining({ id: peer.id }));
+      expect(service.getAuditLog()[0]).toMatchObject({ action: 'ADD_PEER', targetId: peer.id, actor: 'admin' });
+    });
+
+    it('rejects a peer with a missing field', () => {
+      expect(() => service.addPeer({ id: '', url: 'http://x.com', publicKey: randomKeypair().publicKey() }))
+        .toThrow(/Malformed peer/);
+    });
+
+    it('rejects a peer with an invalid public key', () => {
+      const peer = makePeer({ publicKey: 'BAD_KEY' });
+      expect(() => service.addPeer(peer)).toThrow(/Invalid public key/);
+    });
+
+    it('rejects a duplicate peer ID', () => {
+      const peer = makePeer();
+      service.addPeer(peer);
+      expect(() => service.addPeer(peer)).toThrow(/Duplicate peer ID/);
+    });
+
+    it('rejects a duplicate public key across different peer IDs', () => {
+      const kp = randomKeypair();
+      service.addPeer(makePeer({ publicKey: kp.publicKey() }));
+      expect(() => service.addPeer(makePeer({ publicKey: kp.publicKey() }))).toThrow(/already registered/);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // removePeer
+  // -------------------------------------------------------------------------
+
+  describe('removePeer', () => {
+    it('removes a peer and audits', () => {
+      const peer = makePeer();
+      service.addPeer(peer);
+      const removed = service.removePeer(peer.id, 'admin');
+
+      expect(removed).toBe(true);
+      expect(service.getPeerEndpoints().find((p) => p.id === peer.id)).toBeUndefined();
+      expect(service.getAuditLog()[0]).toMatchObject({ action: 'REMOVE_PEER', targetId: peer.id });
+    });
+
+    it('returns false when peer does not exist', () => {
+      expect(service.removePeer('ghost')).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getRegistrySnapshot — no secrets exposed
+  // -------------------------------------------------------------------------
+
+  describe('getRegistrySnapshot', () => {
+    it('returns registry state without private keys', () => {
+      const snapshot = service.getRegistrySnapshot();
+      expect(snapshot).toHaveProperty('mode');
+      expect(snapshot).toHaveProperty('oracles');
+      expect(snapshot).toHaveProperty('threshold');
+      snapshot.oracles.forEach((o) => {
+        expect(o).not.toHaveProperty('privateKey');
+      });
+    });
+
+    it('reflects added and disabled oracles', () => {
+      const cfg = makeOracle();
+      service.addOracle(cfg);
+      service.setOracleActive(cfg.id, false);
+
+      const snapshot = service.getRegistrySnapshot();
+      const entry = snapshot.oracles.find((o) => o.id === cfg.id);
+      expect(entry?.isActive).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getAuditLog — ordering and completeness
+  // -------------------------------------------------------------------------
+
+  describe('getAuditLog', () => {
+    it('returns entries most-recent-first', () => {
+      const cfg1 = makeOracle();
+      const cfg2 = makeOracle();
+      service.addOracle(cfg1);
+      service.addOracle(cfg2);
+
+      const log = service.getAuditLog();
+      expect(log[0].targetId).toBe(cfg2.id);
+      expect(log[1].targetId).toBe(cfg1.id);
+    });
+
+    it('audit log is immutable — mutations do not affect internal state', () => {
+      const cfg = makeOracle();
+      service.addOracle(cfg);
+      const log = service.getAuditLog() as OracleAuditEntry[];
+      (log as any)[0] = null; // attempt mutation
+      expect(service.getAuditLog()[0]).not.toBeNull();
+    });
+  });
+});

--- a/oracle/src/multi-oracle/oracle-registry.service.ts
+++ b/oracle/src/multi-oracle/oracle-registry.service.ts
@@ -2,24 +2,30 @@ import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Keypair } from '@stellar/stellar-sdk';
 import { KeyService } from '../keys/key.service';
-import { 
-  OracleConfig, 
-  OracleRegistryEntry, 
+import {
+  OracleConfig,
+  OracleRegistryEntry,
   MultiOracleConfig,
   MultiOracleMode,
+  OracleAuditAction,
+  OracleAuditEntry,
+  OracleRegistrySnapshot,
   PeerOracleEndpoint,
 } from './multi-oracle.types';
 
 @Injectable()
 export class OracleRegistryService implements OnModuleInit {
   private readonly logger = new Logger(OracleRegistryService.name);
-  
+
   private oracles: Map<string, OracleRegistryEntry> = new Map();
   private peers: PeerOracleEndpoint[] = [];
   private localOracleId: string;
   private threshold: number;
   private mode: MultiOracleMode = MultiOracleMode.SINGLE;
-  
+
+  /** Append-only audit trail of every registry mutation. */
+  private readonly auditLog: OracleAuditEntry[] = [];
+
   private readonly ORACLE_CONFIG_SEPARATOR = ',';
   private readonly ORACLE_ENTRY_SEPARATOR = ':';
 
@@ -213,27 +219,150 @@ export class OracleRegistryService implements OnModuleInit {
     }
   }
 
-  addOracle(config: OracleConfig): void {
+  // ---------------------------------------------------------------------------
+  // Registry mutations — all changes are validated and audited
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Add a new oracle to the registry.
+   *
+   * Validates the public key and rejects duplicates before inserting.
+   *
+   * @param config  Oracle configuration (id, publicKey, weight).
+   * @param actor   Optional identifier of who is making the change.
+   * @throws        If the public key is malformed or the ID already exists.
+   */
+  addOracle(config: OracleConfig, actor?: string): void {
+    if (!this.validatePublicKey(config.publicKey)) {
+      throw new Error(`Invalid public key for oracle ${config.id}: ${config.publicKey}`);
+    }
+    if (this.oracles.has(config.id)) {
+      throw new Error(`Duplicate oracle ID: ${config.id}`);
+    }
+    // Detect public-key collisions across existing oracles
+    for (const existing of this.oracles.values()) {
+      if (existing.publicKey === config.publicKey) {
+        throw new Error(
+          `Public key ${config.publicKey} is already registered under oracle ${existing.id}`,
+        );
+      }
+    }
+
     this.oracles.set(config.id, {
       id: config.id,
       publicKey: config.publicKey,
       weight: config.weight,
       isActive: true,
     });
-    this.logger.log(`Added oracle: ${config.id} (${config.publicKey})`);
+
+    this.audit('ADD_ORACLE', config.id, actor, { publicKey: config.publicKey, weight: config.weight });
+    this.logger.log(`Added oracle: ${config.id} (${config.publicKey}) by ${actor ?? 'system'}`);
   }
 
-  removeOracle(id: string): boolean {
-    return this.oracles.delete(id);
-  }
-
-  setOracleActive(id: string, active: boolean): void {
-    const oracle = this.oracles.get(id);
-    if (oracle) {
-      oracle.isActive = active;
-      this.logger.log(`Oracle ${id} is now ${active ? 'active' : 'inactive'}`);
+  /**
+   * Remove an oracle from the registry entirely.
+   *
+   * The local oracle cannot be removed while in multi-oracle mode.
+   *
+   * @param id      Oracle ID to remove.
+   * @param actor   Optional identifier of who is making the change.
+   * @returns       `true` if the oracle was present and removed.
+   * @throws        If removing the local oracle in multi-oracle mode.
+   */
+  removeOracle(id: string, actor?: string): boolean {
+    if (this.isMultiOracleMode() && id === this.localOracleId) {
+      throw new Error('Cannot remove the local oracle while in multi-oracle mode');
     }
+    const existed = this.oracles.delete(id);
+    if (existed) {
+      this.audit('REMOVE_ORACLE', id, actor);
+      this.logger.log(`Removed oracle: ${id} by ${actor ?? 'system'}`);
+    }
+    return existed;
   }
+
+  /**
+   * Enable or disable an oracle without removing it from the registry.
+   *
+   * Validates the requested transition: enabling an already-active oracle or
+   * disabling an already-inactive oracle is a no-op (not an error).
+   *
+   * @param id      Oracle ID.
+   * @param active  `true` to enable, `false` to disable.
+   * @param actor   Optional identifier of who is making the change.
+   * @throws        If no oracle with `id` exists.
+   */
+  setOracleActive(id: string, active: boolean, actor?: string): void {
+    const oracle = this.oracles.get(id);
+    if (!oracle) {
+      throw new Error(`Oracle not found: ${id}`);
+    }
+    if (oracle.isActive === active) {
+      this.logger.debug(`Oracle ${id} is already ${active ? 'active' : 'inactive'} — no-op`);
+      return;
+    }
+    oracle.isActive = active;
+    const action: OracleAuditAction = active ? 'ENABLE_ORACLE' : 'DISABLE_ORACLE';
+    this.audit(action, id, actor);
+    this.logger.log(`Oracle ${id} is now ${active ? 'active' : 'inactive'} by ${actor ?? 'system'}`);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Peer management — peers are remote oracle endpoints for coordination
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Register a new peer endpoint.
+   *
+   * Validates the peer's public key, rejects duplicate IDs, rejects
+   * duplicate public keys, and prevents registering the local oracle as
+   * a peer.
+   *
+   * @param peer    Peer endpoint descriptor.
+   * @param actor   Optional identifier of who is making the change.
+   * @throws        On any validation failure.
+   */
+  addPeer(peer: PeerOracleEndpoint, actor?: string): void {
+    if (!peer.id || !peer.url || !peer.publicKey) {
+      throw new Error(`Malformed peer — id, url, and publicKey are all required`);
+    }
+    if (!this.validatePublicKey(peer.publicKey)) {
+      throw new Error(`Invalid public key for peer ${peer.id}: ${peer.publicKey}`);
+    }
+    if (peer.id === this.localOracleId) {
+      throw new Error(`Peer ID ${peer.id} collides with the local oracle ID`);
+    }
+    if (this.peers.some((p) => p.id === peer.id)) {
+      throw new Error(`Duplicate peer ID: ${peer.id}`);
+    }
+    if (this.peers.some((p) => p.publicKey === peer.publicKey)) {
+      throw new Error(`Public key ${peer.publicKey} is already registered for another peer`);
+    }
+
+    this.peers.push({ id: peer.id, url: peer.url, publicKey: peer.publicKey });
+    this.audit('ADD_PEER', peer.id, actor, { url: peer.url, publicKey: peer.publicKey });
+    this.logger.log(`Added peer: ${peer.id} (${peer.url}) by ${actor ?? 'system'}`);
+  }
+
+  /**
+   * Remove a peer by ID.
+   *
+   * @param id      Peer ID to remove.
+   * @param actor   Optional identifier of who is making the change.
+   * @returns       `true` if the peer existed and was removed.
+   */
+  removePeer(id: string, actor?: string): boolean {
+    const idx = this.peers.findIndex((p) => p.id === id);
+    if (idx === -1) return false;
+    this.peers.splice(idx, 1);
+    this.audit('REMOVE_PEER', id, actor);
+    this.logger.log(`Removed peer: ${id} by ${actor ?? 'system'}`);
+    return true;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Read-only inspection
+  // ---------------------------------------------------------------------------
 
   getConfig(): MultiOracleConfig {
     return {
@@ -246,7 +375,35 @@ export class OracleRegistryService implements OnModuleInit {
   }
 
   getPeerEndpoints(): PeerOracleEndpoint[] {
-    return this.peers;
+    return [...this.peers];
+  }
+
+  /**
+   * Returns a safe snapshot of the current registry state.
+   * No private keys are included.
+   */
+  getRegistrySnapshot(): OracleRegistrySnapshot {
+    return {
+      mode: this.mode,
+      localOracleId: this.localOracleId,
+      threshold: this.threshold,
+      oracles: Array.from(this.oracles.values()).map(({ id, publicKey, weight, isActive, lastSubmission }) => ({
+        id,
+        publicKey,
+        weight,
+        isActive,
+        lastSubmission,
+      })),
+      peerCount: this.peers.length,
+    };
+  }
+
+  /**
+   * Returns the full audit log (most-recent-first).
+   * Entries are read-only copies — mutations have no effect.
+   */
+  getAuditLog(): ReadonlyArray<OracleAuditEntry> {
+    return [...this.auditLog].reverse();
   }
 
   validatePublicKey(publicKey: string): boolean {
@@ -256,5 +413,18 @@ export class OracleRegistryService implements OnModuleInit {
     } catch {
       return false;
     }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  private audit(
+    action: OracleAuditAction,
+    targetId: string,
+    actor?: string,
+    meta?: Record<string, unknown>,
+  ): void {
+    this.auditLog.push({ action, targetId, actor, timestamp: Date.now(), meta });
   }
 }


### PR DESCRIPTION
Closes #594 
closes #561  
closes #484 
closes #485 

## Summary

### #594 — Oracle: registry change audit and validation
- `addOracle`: validates public key, rejects duplicate IDs and duplicate public keys
- `setOracleActive`: validates state transition (no-op on same state), records `ENABLE_ORACLE` / `DISABLE_ORACLE` audit entry
- `addPeer`: validates id/url/publicKey presence, key validity, rejects duplicate ID/key, blocks local oracle as peer
- `removePeer`: removes peer by ID with audit trail
- `getRegistrySnapshot()`: safe read-only view — no private keys exposed
- `getAuditLog()`: append-only entries returned most-recent-first
- New `oracle-registry.service.spec.ts`: tests for add, disable, duplicate, invalid key, audit creation, peer management, and snapshot safety

### #561 — Indexer: DLQ classification and replay safety
- Add `DlqReason` enum: `PARSE_ERROR`, `HANDLER_ERROR`, `DB_TRANSIENT`, `SCHEMA_UNSUPPORTED`
- `PARSE_ERROR` and `SCHEMA_UNSUPPORTED` set `retryable=false`; `HANDLER_ERROR` and `DB_TRANSIENT` set `retryable=true`
- `DeadLetterEventEntity` gains `reason`, `retryable`, and `replayedAt` columns with covering indices
- `DlqService.insert` accepts optional `DlqReason` and persists the retryability flag
- `replayAll` gains `ReplayOptions`: `dryRun` (logs intent, no writes), `fromLedger`/`toLedger` bounded range, `forceReplay` to override idempotency guard
- Idempotency: successful replay sets `replayedAt`; subsequent calls skip the entry unless `forceReplay=true`
- `dlq.service.spec.ts` updated: all four DLQ categories, dry-run mode, bounded replay, idempotency, non-retryable exclusion

### #484 — ShareRaffle: copy-to-clipboard and QR code
- Add `qrcode.react ^4.2.0` to `client/package.json`
- Render `QRCodeSVG` below social share buttons with accessible `aria-label`
- "Download QR" button: serialises SVG → canvas at 2× resolution → PNG file download
- Copy Link falls back to `document.execCommand(copy)` when Clipboard API is unavailable (non-HTTPS / legacy browsers)

### #485 — Network mismatch guard: blocking modal
- `WalletProvider` exposes `networkMismatch: boolean` detected immediately on wallet connection; `isCorrectNetwork` alias kept for backwards compatibility
- `NetworkWarning` upgraded from static banner to full-screen blocking modal: blurred backdrop absorbs all pointer events, `role="alertdialog"` for accessibility, shows connected vs required network, "Switch to `<NETWORK>`" button, graceful-degradation note for wallets without `switchNetwork` support

## Test plan
- [ ] Oracle: `addOracle` with invalid key throws; duplicate ID/key throws; `getAuditLog` reflects changes
- [ ] Oracle: `setOracleActive(id, false)` audits `DISABLE_ORACLE`; same-state call is no-op
- [ ] Oracle: `addPeer` rejects malformed, duplicate, or local-oracle-ID peer
- [ ] Oracle: `getRegistrySnapshot()` contains no private keys
- [ ] DLQ: insert with each reason sets expected `retryable` flag
- [ ] DLQ: `replayAll({ dryRun: true })` logs but does not dispatch or save
- [ ] DLQ: replayed entry gets `replayedAt` set; second call skips it unless `forceReplay`
- [ ] DLQ: `fromLedger`/`toLedger` limits replay to the specified range
- [ ] ShareRaffle: QR code renders and is scannable; "Download QR" saves a PNG
- [ ] ShareRaffle: "Copy Link" works on non-HTTPS via execCommand fallback
- [ ] NetworkWarning: modal appears immediately on wallet connect with wrong network
- [ ] NetworkWarning: backdrop blocks all clicks; "Switch" button calls switchNetwork
