### PR TITLE
feat(#599): standardize wallet adapter capability contract

### DIFF
--- a/sdk/src/wallet/albedo.adapter.spec.ts
+++ b/sdk/src/wallet/albedo.adapter.spec.ts
@@ -228,4 +228,24 @@ describe('AlbedoAdapter', () => {
       });
     });
   });
+
+  describe('capabilities', () => {
+    it('should report all capabilities as supported', () => {
+      const caps = adapter.getCapabilities();
+
+      expect(caps.supportsGetPublicKey).toBe(true);
+      expect(caps.supportsSignTransaction).toBe(true);
+      expect(caps.supportsSignMessage).toBe(true);
+      expect(caps.supportsGetNetwork).toBe(true);
+    });
+
+    it('should have consistent capability types', () => {
+      const caps = adapter.getCapabilities();
+
+      expect(typeof caps.supportsGetPublicKey).toBe('boolean');
+      expect(typeof caps.supportsSignTransaction).toBe('boolean');
+      expect(typeof caps.supportsSignMessage).toBe('boolean');
+      expect(typeof caps.supportsGetNetwork).toBe('boolean');
+    });
+  });
 });

--- a/sdk/src/wallet/albedo.adapter.ts
+++ b/sdk/src/wallet/albedo.adapter.ts
@@ -3,6 +3,7 @@ import {
   WalletAdapterOptions,
   WalletName,
   SignTransactionResult,
+  WalletCapabilities,
 } from './wallet.interface';
 import { TikkaSdkError, TikkaSdkErrorCode } from '../utils/errors';
 
@@ -113,6 +114,19 @@ export class AlbedoAdapter extends WalletAdapter {
    */
   async getNetwork(): Promise<string | undefined> {
     return this.options.networkPassphrase;
+  }
+
+  /* ------------------------------------------------------------------ */
+  /*  Capabilities                                                       */
+  /* ------------------------------------------------------------------ */
+
+  getCapabilities(): WalletCapabilities {
+    return {
+      supportsGetPublicKey: true,
+      supportsSignTransaction: true,
+      supportsSignMessage: true,
+      supportsGetNetwork: true,
+    };
   }
 
   /* ------------------------------------------------------------------ */

--- a/sdk/src/wallet/freighter.adapter.spec.ts
+++ b/sdk/src/wallet/freighter.adapter.spec.ts
@@ -309,4 +309,24 @@ describe('FreighterAdapter', () => {
       });
     });
   });
+
+  describe('capabilities', () => {
+    it('should report all capabilities as supported', () => {
+      const caps = adapter.getCapabilities();
+
+      expect(caps.supportsGetPublicKey).toBe(true);
+      expect(caps.supportsSignTransaction).toBe(true);
+      expect(caps.supportsSignMessage).toBe(true);
+      expect(caps.supportsGetNetwork).toBe(true);
+    });
+
+    it('should have consistent capability types', () => {
+      const caps = adapter.getCapabilities();
+
+      expect(typeof caps.supportsGetPublicKey).toBe('boolean');
+      expect(typeof caps.supportsSignTransaction).toBe('boolean');
+      expect(typeof caps.supportsSignMessage).toBe('boolean');
+      expect(typeof caps.supportsGetNetwork).toBe('boolean');
+    });
+  });
 });

--- a/sdk/src/wallet/freighter.adapter.ts
+++ b/sdk/src/wallet/freighter.adapter.ts
@@ -3,6 +3,7 @@ import {
   WalletAdapterOptions,
   WalletName,
   SignTransactionResult,
+  WalletCapabilities,
 } from './wallet.interface';
 import { TikkaSdkError, TikkaSdkErrorCode } from '../utils/errors';
 
@@ -132,6 +133,19 @@ export class FreighterAdapter extends WalletAdapter {
     } catch {
       return undefined;
     }
+  }
+
+  /* ------------------------------------------------------------------ */
+  /*  Capabilities                                                       */
+  /* ------------------------------------------------------------------ */
+
+  getCapabilities(): WalletCapabilities {
+    return {
+      supportsGetPublicKey: true,
+      supportsSignTransaction: true,
+      supportsSignMessage: true,
+      supportsGetNetwork: true,
+    };
   }
 
   /* ------------------------------------------------------------------ */

--- a/sdk/src/wallet/index.ts
+++ b/sdk/src/wallet/index.ts
@@ -3,6 +3,7 @@ export {
   WalletAdapterOptions,
   WalletName,
   SignTransactionResult,
+  WalletCapabilities,
 } from './wallet.interface';
 
 export { FreighterAdapter } from './freighter.adapter';

--- a/sdk/src/wallet/lobstr.adapter.spec.ts
+++ b/sdk/src/wallet/lobstr.adapter.spec.ts
@@ -163,4 +163,24 @@ describe('LobstrAdapter', () => {
       }
     });
   });
+
+  describe('capabilities', () => {
+    it('should report correct capabilities', () => {
+      const caps = adapter.getCapabilities();
+
+      expect(caps.supportsGetPublicKey).toBe(true);
+      expect(caps.supportsSignTransaction).toBe(true);
+      expect(caps.supportsSignMessage).toBe(false);
+      expect(caps.supportsGetNetwork).toBe(false);
+    });
+
+    it('should have consistent capability types', () => {
+      const caps = adapter.getCapabilities();
+
+      expect(typeof caps.supportsGetPublicKey).toBe('boolean');
+      expect(typeof caps.supportsSignTransaction).toBe('boolean');
+      expect(typeof caps.supportsSignMessage).toBe('boolean');
+      expect(typeof caps.supportsGetNetwork).toBe('boolean');
+    });
+  });
 });

--- a/sdk/src/wallet/lobstr.adapter.ts
+++ b/sdk/src/wallet/lobstr.adapter.ts
@@ -4,6 +4,7 @@ import {
   WalletAdapterOptions,
   WalletName,
   SignTransactionResult,
+  WalletCapabilities,
 } from './wallet.interface';
 import { TikkaSdkError, TikkaSdkErrorCode } from '../utils/errors';
 
@@ -85,6 +86,18 @@ export class LobstrAdapter extends WalletAdapter {
         error,
       );
     }
+  }
+
+  /**
+   * Returns the capabilities supported by LOBSTR adapter.
+   */
+  getCapabilities(): WalletCapabilities {
+    return {
+      supportsGetPublicKey: true,
+      supportsSignTransaction: true,
+      supportsSignMessage: false,
+      supportsGetNetwork: false,
+    };
   }
 
   private isUserRejection(err: any): boolean {

--- a/sdk/src/wallet/mock-wallet.adapter.spec.ts
+++ b/sdk/src/wallet/mock-wallet.adapter.spec.ts
@@ -13,5 +13,18 @@ describe('MockWalletAdapter', () => {
     const adapter = new MockWalletAdapter({ failSignTransaction: true });
     await expect(adapter.signTransaction('tx-xdr')).rejects.toThrow('MockWalletAdapter: signTransaction failure');
   });
+
+  describe('capabilities', () => {
+    it('should report all capabilities as supported', () => {
+      const adapter = new MockWalletAdapter();
+      const caps = adapter.getCapabilities();
+      
+      expect(caps.supportsGetPublicKey).toBe(true);
+      expect(caps.supportsSignTransaction).toBe(true);
+      expect(caps.supportsSignMessage).toBe(true);
+      expect(caps.supportsGetNetwork).toBe(true);
+    });
+  });
 });
+
 

--- a/sdk/src/wallet/mock-wallet.adapter.ts
+++ b/sdk/src/wallet/mock-wallet.adapter.ts
@@ -3,6 +3,7 @@ import {
   WalletAdapterOptions,
   WalletName,
   SignTransactionResult,
+  WalletCapabilities,
 } from './wallet.interface';
 
 export interface MockWalletOptions extends WalletAdapterOptions {
@@ -49,6 +50,27 @@ export class MockWalletAdapter extends WalletAdapter {
       throw new Error('MockWalletAdapter: signMessage failure');
     }
     return `mock-signature:${message}`;
+  }
+
+  /**
+   * Returns mock network (always returns configured network or undefined)
+   */
+  override async getNetwork(): Promise<string | undefined> {
+    await this.wait();
+    return this.mockOptions.networkPassphrase;
+  }
+
+  /**
+   * Returns the capabilities supported by the mock adapter.
+   * Mock adapter supports all capabilities for testing.
+   */
+  getCapabilities(): WalletCapabilities {
+    return {
+      supportsGetPublicKey: true,
+      supportsSignTransaction: true,
+      supportsSignMessage: true,
+      supportsGetNetwork: true,
+    };
   }
 
   private async wait() {

--- a/sdk/src/wallet/rabet.adapter.spec.ts
+++ b/sdk/src/wallet/rabet.adapter.spec.ts
@@ -335,4 +335,24 @@ describe('RabetAdapter', () => {
       expect(result.signedXdr).toBe(signedXdr);
     });
   });
+
+  describe('capabilities', () => {
+    it('should report correct capabilities', () => {
+      const caps = adapter.getCapabilities();
+
+      expect(caps.supportsGetPublicKey).toBe(true);
+      expect(caps.supportsSignTransaction).toBe(true);
+      expect(caps.supportsSignMessage).toBe(false);
+      expect(caps.supportsGetNetwork).toBe(true);
+    });
+
+    it('should have consistent capability types', () => {
+      const caps = adapter.getCapabilities();
+
+      expect(typeof caps.supportsGetPublicKey).toBe('boolean');
+      expect(typeof caps.supportsSignTransaction).toBe('boolean');
+      expect(typeof caps.supportsSignMessage).toBe('boolean');
+      expect(typeof caps.supportsGetNetwork).toBe('boolean');
+    });
+  });
 });

--- a/sdk/src/wallet/rabet.adapter.ts
+++ b/sdk/src/wallet/rabet.adapter.ts
@@ -3,6 +3,7 @@ import {
   WalletAdapterOptions,
   WalletName,
   SignTransactionResult,
+  WalletCapabilities,
 } from './wallet.interface';
 import { TikkaSdkError, TikkaSdkErrorCode } from '../utils/errors';
 
@@ -113,6 +114,19 @@ export class RabetAdapter extends WalletAdapter {
     // Rabet doesn't expose a direct method to get the current network
     // Return the configured network from adapter options
     return this.options.networkPassphrase;
+  }
+
+  /* ------------------------------------------------------------------ */
+  /*  Capabilities                                                       */
+  /* ------------------------------------------------------------------ */
+
+  getCapabilities(): WalletCapabilities {
+    return {
+      supportsGetPublicKey: true,
+      supportsSignTransaction: true,
+      supportsSignMessage: false,
+      supportsGetNetwork: true,
+    };
   }
 
   /* ------------------------------------------------------------------ */

--- a/sdk/src/wallet/wallet.interface.ts
+++ b/sdk/src/wallet/wallet.interface.ts
@@ -24,6 +24,36 @@ export interface SignTransactionResult {
 }
 
 /**
+ * Describes which operations a wallet adapter supports.
+ * Used to enable adaptive UI behavior based on wallet capabilities.
+ */
+export interface WalletCapabilities {
+  /**
+   * Whether the adapter supports retrieving the user's public key.
+   * @default true
+   */
+  supportsGetPublicKey: boolean;
+
+  /**
+   * Whether the adapter supports signing Soroban transactions.
+   * @default true
+   */
+  supportsSignTransaction: boolean;
+
+  /**
+   * Whether the adapter supports signing arbitrary messages (SIWS, etc).
+   * @default false
+   */
+  supportsSignMessage: boolean;
+
+  /**
+   * Whether the adapter can retrieve the currently selected network.
+   * @default false
+   */
+  supportsGetNetwork: boolean;
+}
+
+/**
  * Common interface every wallet adapter must implement.
  */
 export abstract class WalletAdapter {
@@ -69,4 +99,10 @@ export abstract class WalletAdapter {
   async getNetwork(): Promise<string | undefined> {
     return undefined;
   }
+
+  /**
+   * Returns the capabilities supported by this wallet adapter.
+   * Allows UI to adapt dynamically based on wallet features.
+   */
+  abstract getCapabilities(): WalletCapabilities;
 }

--- a/sdk/src/wallet/xbull.adapter.spec.ts
+++ b/sdk/src/wallet/xbull.adapter.spec.ts
@@ -233,4 +233,24 @@ describe('XBullAdapter', () => {
       });
     });
   });
+
+  describe('capabilities', () => {
+    it('should report correct capabilities', () => {
+      const caps = adapter.getCapabilities();
+
+      expect(caps.supportsGetPublicKey).toBe(true);
+      expect(caps.supportsSignTransaction).toBe(true);
+      expect(caps.supportsSignMessage).toBe(false);
+      expect(caps.supportsGetNetwork).toBe(false);
+    });
+
+    it('should have consistent capability types', () => {
+      const caps = adapter.getCapabilities();
+
+      expect(typeof caps.supportsGetPublicKey).toBe('boolean');
+      expect(typeof caps.supportsSignTransaction).toBe('boolean');
+      expect(typeof caps.supportsSignMessage).toBe('boolean');
+      expect(typeof caps.supportsGetNetwork).toBe('boolean');
+    });
+  });
 });

--- a/sdk/src/wallet/xbull.adapter.ts
+++ b/sdk/src/wallet/xbull.adapter.ts
@@ -3,6 +3,7 @@ import {
   WalletAdapterOptions,
   WalletName,
   SignTransactionResult,
+  WalletCapabilities,
 } from './wallet.interface';
 import { TikkaSdkError, TikkaSdkErrorCode } from '../utils/errors';
 
@@ -84,6 +85,17 @@ export class XBullAdapter extends WalletAdapter {
         err
       );
     }
+  }
+
+  /* ---------------------- Capabilities ---------------------- */
+
+  getCapabilities(): WalletCapabilities {
+    return {
+      supportsGetPublicKey: true,
+      supportsSignTransaction: true,
+      supportsSignMessage: false,
+      supportsGetNetwork: false,
+    };
   }
 
   /* ---------------------- Helpers ---------------------- */


### PR DESCRIPTION
- Add WalletCapabilities interface to define supported operations
- Add abstract getCapabilities() method to WalletAdapter
- Implement getCapabilities() in all adapters:
  * Freighter: supports all 4 capabilities
  * xBull: getPublicKey, signTransaction only
  * Albedo: supports all 4 capabilities
  * LOBSTR: getPublicKey, signTransaction only
  * Rabet: getPublicKey, signTransaction, getNetwork (not signMessage)
  * Mock: supports all 4 capabilities for testing
- Add comprehensive capability tests to all adapter test files
- Export WalletCapabilities from wallet module index
- Allows clients to choose UI behavior based on adapter capabilities

Closes #599 