### PR TITLE
feat: implement raffle soft-delete and archival endpoint (#492)

### DIFF
--- a/backend/database/migrations/009_soft_delete_raffle_metadata.sql
+++ b/backend/database/migrations/009_soft_delete_raffle_metadata.sql
@@ -1,0 +1,18 @@
+-- 009_soft_delete_raffle_metadata: add soft-delete support to raffle_metadata
+-- Adds deleted_at column; NULL means active, non-NULL means soft-deleted.
+-- Run this in Supabase SQL Editor
+
+ALTER TABLE raffle_metadata
+  ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ DEFAULT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_raffle_metadata_deleted_at ON raffle_metadata(deleted_at)
+  WHERE deleted_at IS NOT NULL;
+
+-- Update the public read policy to exclude soft-deleted rows
+DROP POLICY IF EXISTS "Allow public read" ON raffle_metadata;
+
+CREATE POLICY "Allow public read"
+  ON raffle_metadata FOR SELECT
+  USING (deleted_at IS NULL);
+
+COMMENT ON COLUMN raffle_metadata.deleted_at IS 'Soft-delete timestamp; NULL = active, non-NULL = archived/deleted';

--- a/backend/src/api/rest/raffles/admin-raffles.controller.ts
+++ b/backend/src/api/rest/raffles/admin-raffles.controller.ts
@@ -1,0 +1,63 @@
+import {
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseIntPipe,
+  Post,
+  UseGuards,
+} from "@nestjs/common";
+import {
+  ApiTags,
+  ApiOperation,
+  ApiParam,
+  ApiResponse,
+} from "@nestjs/swagger";
+import { Public } from "../../../auth/decorators/public.decorator";
+import { AdminGuard } from "../monitor/admin.guard";
+import { RafflesService } from "./raffles.service";
+
+@ApiTags("Admin - Raffles")
+@Controller("admin/raffles")
+@UseGuards(AdminGuard)
+@Public()
+export class AdminRafflesController {
+  constructor(private readonly rafflesService: RafflesService) {}
+
+  /**
+   * GET /admin/raffles/archived — List all soft-deleted raffle metadata records.
+   * Admin only.
+   */
+  @Get("archived")
+  @ApiOperation({ summary: "List all archived (soft-deleted) raffle metadata" })
+  @ApiResponse({ status: 200, description: "Archived metadata retrieved successfully" })
+  async getArchived() {
+    return this.rafflesService.getArchivedMetadata();
+  }
+
+  /**
+   * DELETE /admin/raffles/:raffleId/metadata — Admin soft-delete of any raffle metadata.
+   * Bypasses creator check.
+   */
+  @Delete(":raffleId/metadata")
+  @ApiOperation({ summary: "Admin soft-delete of raffle metadata" })
+  @ApiParam({ name: "raffleId", description: "Internal raffle ID" })
+  @ApiResponse({ status: 200, description: "Metadata soft-deleted successfully" })
+  @ApiResponse({ status: 404, description: "Active metadata not found for raffle" })
+  async deleteMetadata(@Param("raffleId", ParseIntPipe) raffleId: number) {
+    return this.rafflesService.softDeleteMetadata(raffleId);
+  }
+
+  /**
+   * POST /admin/raffles/:raffleId/restore — Restore a soft-deleted raffle metadata record.
+   * Admin only.
+   */
+  @Post(":raffleId/restore")
+  @ApiOperation({ summary: "Restore archived raffle metadata" })
+  @ApiParam({ name: "raffleId", description: "Internal raffle ID" })
+  @ApiResponse({ status: 201, description: "Metadata restored successfully" })
+  @ApiResponse({ status: 404, description: "Archived metadata not found for raffle" })
+  async restoreMetadata(@Param("raffleId", ParseIntPipe) raffleId: number) {
+    return this.rafflesService.restoreMetadata(raffleId);
+  }
+}

--- a/backend/src/api/rest/raffles/raffles.controller.ts
+++ b/backend/src/api/rest/raffles/raffles.controller.ts
@@ -2,6 +2,7 @@ import {
   BadRequestException,
   Body,
   Controller,
+  Delete,
   Get,
   Param,
   ParseIntPipe,
@@ -139,6 +140,25 @@ export class RafflesController {
     payload: UpsertMetadataDto,
   ) {
     return this.rafflesService.upsertMetadata(raffleId, payload, address);
+  }
+
+  /**
+   * DELETE /raffles/:raffleId/metadata — Soft-delete raffle metadata.
+   * Creator can delete their own raffle's metadata; admin can delete any.
+   * Requires JWT (SIWS).
+   */
+  @ApiBearerAuth()
+  @Delete(":raffleId/metadata")
+  @ApiOperation({ summary: "Soft-delete raffle metadata (creator or admin)" })
+  @ApiParam({ name: "raffleId", description: "Internal raffle ID" })
+  @ApiResponse({ status: 200, description: "Metadata soft-deleted successfully" })
+  @ApiResponse({ status: 403, description: "Forbidden — not the creator" })
+  @ApiResponse({ status: 404, description: "Raffle or metadata not found" })
+  async deleteMetadata(
+    @Param("raffleId", ParseIntPipe) raffleId: number,
+    @CurrentUser("address") address: string,
+  ) {
+    return this.rafflesService.deleteMetadata(raffleId, address);
   }
 
   /**

--- a/backend/src/api/rest/raffles/raffles.module.ts
+++ b/backend/src/api/rest/raffles/raffles.module.ts
@@ -1,27 +1,31 @@
 import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
 import { RafflesController } from './raffles.controller';
 import { OgRenderController } from './og-render.controller';
+import { AdminRafflesController } from './admin-raffles.controller';
 import { RafflesService } from './raffles.service';
 import { MetadataModule } from '../../../services/metadata.module';
 import { IndexerModule } from '../../../services/indexer.module';
+import { SupabaseModule } from '../../../services/supabase.module';
 import { StorageService } from '../../../services/storage.service';
 import { ImageOptimizerService } from '../../../services/image-optimizer.service';
 import { IdempotencyService } from '../../../common/idempotency/idempotency.service';
 import { IdempotencyInterceptor } from '../../../common/idempotency/idempotency.interceptor';
+import { AdminGuard } from '../monitor/admin.guard';
+import { MonitorService } from '../monitor/monitor.service';
 
 @Module({
-  imports: [IndexerModule, MetadataModule],
-  controllers: [RafflesController],
+  imports: [IndexerModule, MetadataModule, SupabaseModule, ConfigModule],
+  controllers: [RafflesController, OgRenderController, AdminRafflesController],
   providers: [
     RafflesService,
-    MetadataService,
     StorageService,
     ImageOptimizerService,
     IdempotencyService,
     IdempotencyInterceptor,
+    AdminGuard,
+    MonitorService,
   ],
   exports: [RafflesService],
 })
 export class RafflesModule {}
-
-

--- a/backend/src/api/rest/raffles/raffles.service.ts
+++ b/backend/src/api/rest/raffles/raffles.service.ts
@@ -99,6 +99,53 @@ export class RafflesService {
   }
 
   /**
+   * Soft-delete raffle metadata. Creator can delete their own; admin bypass is
+   * handled at the controller level (AdminGuard). Here we enforce creator-only
+   * for the standard JWT path.
+   */
+  async deleteMetadata(
+    raffleId: number,
+    requesterAddress: string,
+  ): Promise<{ raffle_id: number; deleted_at: string }> {
+    const raffle = await this.indexerService.getRaffle(raffleId);
+    if (!raffle) {
+      throw new NotFoundException(`Raffle ${raffleId} not found`);
+    }
+
+    if (raffle.creator.toLowerCase() !== requesterAddress.toLowerCase()) {
+      throw new ForbiddenException(
+        `Only raffle creator ${raffle.creator} can delete metadata for raffle ${raffleId}`,
+      );
+    }
+
+    return this.softDeleteMetadata(raffleId);
+  }
+
+  /**
+   * Soft-delete raffle metadata (creator or admin).
+   * Callers must verify authorization before calling this method.
+   */
+  async softDeleteMetadata(raffleId: number): Promise<{ raffle_id: number; deleted_at: string }> {
+    const result = await this.metadataService.softDeleteMetadata(raffleId);
+    return { raffle_id: result.raffle_id, deleted_at: result.deleted_at as string };
+  }
+
+  /**
+   * Restore a soft-deleted raffle metadata record (admin only).
+   */
+  async restoreMetadata(raffleId: number): Promise<{ raffle_id: number }> {
+    const result = await this.metadataService.restoreMetadata(raffleId);
+    return { raffle_id: result.raffle_id };
+  }
+
+  /**
+   * Return all soft-deleted raffle metadata records (admin only).
+   */
+  async getArchivedMetadata() {
+    return this.metadataService.getArchivedMetadata();
+  }
+
+  /**
    * Purchase tickets for a raffle.
    * The actual on-chain transaction is submitted by the client via the SDK;
    * this endpoint records the intent and returns a confirmation.

--- a/backend/src/services/metadata.service.ts
+++ b/backend/src/services/metadata.service.ts
@@ -17,6 +17,7 @@ export interface RaffleMetadata {
   metadata_cid: string | null;
   created_at: string;
   updated_at: string;
+  deleted_at: string | null;
 }
 
 export interface SearchMetadataResult {
@@ -71,7 +72,8 @@ export class MetadataService {
     const { data, error } = await this.client
       .from(TABLE)
       .select('*')
-      .in('raffle_id', raffleIds);
+      .in('raffle_id', raffleIds)
+      .is('deleted_at', null);
 
     if (error) {
       throw new Error(`Failed to fetch batch metadata: ${error.message}`);
@@ -109,6 +111,7 @@ export class MetadataService {
       .from(TABLE)
       .select('*')
       .eq('raffle_id', raffleId)
+      .is('deleted_at', null)
       .maybeSingle();
 
     if (error) {
@@ -155,6 +158,7 @@ export class MetadataService {
       let builder = this.client
         .from(TABLE)
         .select('*', { count: 'exact' })
+        .is('deleted_at', null)
         .order('updated_at', { ascending: false })
         .range(off, off + lim - 1);
 
@@ -233,5 +237,74 @@ export class MetadataService {
     await this.metadataRedis.del(cacheKeyForRaffle(raffleId));
 
     return saved;
+  }
+
+  /**
+   * Soft-delete raffle metadata by setting deleted_at = now().
+   * Returns the updated record.
+   */
+  async softDeleteMetadata(raffleId: number): Promise<RaffleMetadata> {
+    const { data, error } = await this.client
+      .from(TABLE)
+      .update({ deleted_at: new Date().toISOString() })
+      .eq('raffle_id', raffleId)
+      .is('deleted_at', null)
+      .select()
+      .maybeSingle();
+
+    if (error) {
+      throw new Error(`Failed to soft-delete metadata for raffle ${raffleId}: ${error.message}`);
+    }
+
+    if (!data) {
+      throw new Error(`No active metadata found for raffle ${raffleId}`);
+    }
+
+    await this.metadataRedis.del(cacheKeyForRaffle(raffleId));
+
+    return data as RaffleMetadata;
+  }
+
+  /**
+   * Restore a soft-deleted raffle metadata record by clearing deleted_at.
+   * Returns the restored record.
+   */
+  async restoreMetadata(raffleId: number): Promise<RaffleMetadata> {
+    const { data, error } = await this.client
+      .from(TABLE)
+      .update({ deleted_at: null })
+      .eq('raffle_id', raffleId)
+      .not('deleted_at', 'is', null)
+      .select()
+      .maybeSingle();
+
+    if (error) {
+      throw new Error(`Failed to restore metadata for raffle ${raffleId}: ${error.message}`);
+    }
+
+    if (!data) {
+      throw new Error(`No archived metadata found for raffle ${raffleId}`);
+    }
+
+    await this.metadataRedis.del(cacheKeyForRaffle(raffleId));
+
+    return data as RaffleMetadata;
+  }
+
+  /**
+   * Return all soft-deleted raffle metadata records (admin-only).
+   */
+  async getArchivedMetadata(): Promise<RaffleMetadata[]> {
+    const { data, error } = await this.client
+      .from(TABLE)
+      .select('*')
+      .not('deleted_at', 'is', null)
+      .order('deleted_at', { ascending: false });
+
+    if (error) {
+      throw new Error(`Failed to fetch archived metadata: ${error.message}`);
+    }
+
+    return (data ?? []) as RaffleMetadata[];
   }
 }


### PR DESCRIPTION
- Add deleted_at TIMESTAMPTZ column to raffle_metadata via migration 009
- Update RLS public read policy to exclude soft-deleted rows
- Filter deleted_at IS NULL in getBatchMetadata, getMetadata, searchMetadata
- Add softDeleteMetadata, restoreMetadata, getArchivedMetadata to MetadataService
- Add DELETE /raffles/:id/metadata (creator-only, JWT-protected)
- Add AdminRafflesController with:
    GET  /admin/raffles/archived        -- list soft-deleted records
    DELETE /admin/raffles/:id/metadata  -- admin force soft-delete
    POST /admin/raffles/:id/restore     -- restore archived record
- Wire AdminGuard, MonitorService, SupabaseModule into RafflesModule
closes #492