### PR TITLE
feat: add user participation history CSV export (#489)

### DIFF
--- a/backend/src/api/rest/users/users.controller.ts
+++ b/backend/src/api/rest/users/users.controller.ts
@@ -1,13 +1,14 @@
-import { Controller, Get, Param, Query, UsePipes } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiParam, ApiQuery, ApiResponse } from '@nestjs/swagger';
+import { Controller, Get, Param, Query, Res, UsePipes } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiParam, ApiQuery, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
+import { FastifyReply } from 'fastify';
 import { Public } from '../../../auth/decorators/public.decorator';
 import { UsersService } from './users.service';
 import { UserHistoryQuerySchema, UserHistoryQueryDto } from './dto/user-history-query.dto';
 import { createZodPipe } from '../raffles/pipes/zod-validation.pipe';
+import { Throttle } from '../../../middleware/throttle.decorator';
 
 @ApiTags('Users')
 @Controller('users')
-@Public()
 export class UsersController {
   constructor(private readonly usersService: UsersService) {}
 
@@ -16,6 +17,7 @@ export class UsersController {
    * Returns: address, total_tickets_bought, total_raffles_entered,
    *          total_raffles_won, total_prize_xlm, first_seen_ledger, updated_at.
    */
+  @Public()
   @Get(':address')
   @ApiOperation({ summary: 'Get user profile by Stellar address' })
   @ApiParam({ name: 'address', description: 'Stellar address of the user' })
@@ -28,6 +30,7 @@ export class UsersController {
    * GET /users/:address/history — Paginated raffle participation history.
    * Query params: limit (1–100, default 20), offset (default 0).
    */
+  @Public()
   @Get(':address/history')
   @ApiOperation({ summary: 'Get user raffle participation history' })
   @ApiParam({ name: 'address', description: 'Stellar address of the user' })
@@ -38,5 +41,32 @@ export class UsersController {
     @Query() query: UserHistoryQueryDto,
   ) {
     return this.usersService.getHistory(address, query);
+  }
+
+  /**
+   * GET /users/:address/history/export?format=csv — Full history as a CSV download.
+   * Requires JWT. Rate-limited to 1 request per minute per user.
+   * Must be declared before :address/history/:id to avoid route conflicts.
+   */
+  @ApiBearerAuth()
+  @Throttle({ default: { limit: 1, ttl: 60000 } })
+  @Get(':address/history/export')
+  @ApiOperation({ summary: 'Export full raffle participation history as CSV' })
+  @ApiParam({ name: 'address', description: 'Stellar address of the user' })
+  @ApiQuery({ name: 'format', enum: ['csv'], required: false, description: 'Export format (csv)' })
+  @ApiResponse({ status: 200, description: 'CSV file download' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 429, description: 'Rate limit exceeded — 1 export per minute' })
+  async exportHistory(
+    @Param('address') address: string,
+    @Res() reply: FastifyReply,
+  ) {
+    const csv = await this.usersService.getHistoryAsCsv(address);
+    const filename = `tikka-history-${address}.csv`;
+
+    reply
+      .header('Content-Type', 'text/csv; charset=utf-8')
+      .header('Content-Disposition', `attachment; filename="${filename}"`)
+      .send(csv);
   }
 }

--- a/backend/src/api/rest/users/users.service.ts
+++ b/backend/src/api/rest/users/users.service.ts
@@ -31,4 +31,48 @@ export class UsersService {
     }
     return this.indexerService.getUserHistory(address, query.limit, query.offset);
   }
+
+  /**
+   * Fetch the full (unpaginated) history for a user and serialise it as CSV.
+   * Columns: raffle_id, role, tickets_bought, ticket_price, asset, status, outcome, timestamp
+   */
+  async getHistoryAsCsv(address: string): Promise<string> {
+    const user = await this.indexerService.getUser(address);
+    if (!user) {
+      throw new NotFoundException(`User ${address} not found`);
+    }
+
+    // Fetch up to 10 000 records — sufficient for any realistic history
+    const { items } = await this.indexerService.getUserHistory(address, 10000, 0);
+
+    const header = 'raffle_id,role,tickets_bought,ticket_price,asset,status,outcome,timestamp';
+
+    const rows = items.map((item) => {
+      const outcome = item.is_winner ? 'won' : 'entered';
+      const ticketPrice = '';   // not returned by indexer history endpoint
+      const asset = '';         // not returned by indexer history endpoint
+      const timestamp = '';     // not returned by indexer history endpoint (ledger only)
+
+      // Escape any field that might contain commas or quotes
+      const escape = (v: string | number) => {
+        const s = String(v);
+        return s.includes(',') || s.includes('"') || s.includes('\n')
+          ? `"${s.replace(/"/g, '""')}"`
+          : s;
+      };
+
+      return [
+        escape(item.raffle_id),
+        escape('participant'),
+        escape(item.tickets_bought),
+        escape(ticketPrice),
+        escape(asset),
+        escape(item.status),
+        escape(outcome),
+        escape(timestamp),
+      ].join(',');
+    });
+
+    return [header, ...rows].join('\r\n');
+  }
 }

--- a/client/src/config/api.ts
+++ b/client/src/config/api.ts
@@ -25,6 +25,7 @@ export const API_CONFIG = {
     users: {
       profile: (address: string) => `/users/${address}`,
       history: (address: string) => `/users/${address}/history`,
+      historyExport: (address: string) => `/users/${address}/history/export?format=csv`,
     },
     search: '/search',
     leaderboard: '/leaderboard',

--- a/client/src/pages/MyRaffles.tsx
+++ b/client/src/pages/MyRaffles.tsx
@@ -5,6 +5,8 @@ import { useUserProfile, useUserHistory } from "../hooks/useRaffles";
 import ErrorMessage from "../components/ui/ErrorMessage";
 import { Breadcrumbs } from "../components/ui/Breadcrumbs";
 import type { ApiUserHistoryItem } from "../types/types";
+import { API_CONFIG } from "../config/api";
+import { getToken } from "../services/apiClient";
 
 // ── Status badge ──────────────────────────────────────────────────────────────
 
@@ -101,6 +103,80 @@ const StatItem: React.FC<{ label: string; value: string | number }> = ({ label, 
         <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">{label}</p>
     </div>
 );
+
+// ── CSV export ────────────────────────────────────────────────────────────────
+
+function useExportCsv(address: string | null) {
+    const [isExporting, setIsExporting] = useState(false);
+    const [exportError, setExportError] = useState<string | null>(null);
+
+    const exportCsv = async () => {
+        if (!address) return;
+        const token = getToken();
+        if (!token) {
+            setExportError("Sign in to export your history.");
+            return;
+        }
+
+        setIsExporting(true);
+        setExportError(null);
+
+        try {
+            const url = `${API_CONFIG.baseUrl}${API_CONFIG.endpoints.users.historyExport(address)}`;
+            const response = await fetch(url, {
+                headers: { Authorization: `Bearer ${token}` },
+            });
+
+            if (response.status === 429) {
+                setExportError("Rate limit reached — please wait a minute before exporting again.");
+                return;
+            }
+            if (!response.ok) {
+                setExportError("Export failed. Please try again.");
+                return;
+            }
+
+            const blob = await response.blob();
+            const objectUrl = URL.createObjectURL(blob);
+            const anchor = document.createElement("a");
+            anchor.href = objectUrl;
+            anchor.download = `tikka-history-${address}.csv`;
+            document.body.appendChild(anchor);
+            anchor.click();
+            anchor.remove();
+            URL.revokeObjectURL(objectUrl);
+        } catch {
+            setExportError("Export failed. Please try again.");
+        } finally {
+            setIsExporting(false);
+        }
+    };
+
+    return { exportCsv, isExporting, exportError };
+}
+
+const ExportCsvButton: React.FC<{ address: string }> = ({ address }) => {
+    const { exportCsv, isExporting, exportError } = useExportCsv(address);
+    return (
+        <div className="flex flex-col items-center gap-1">
+            <button
+                onClick={exportCsv}
+                disabled={isExporting}
+                className="flex items-center gap-1.5 text-xs text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                title="Export participation history as CSV"
+            >
+                <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                        d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+                </svg>
+                {isExporting ? "Exporting…" : "Export CSV"}
+            </button>
+            {exportError && (
+                <p className="text-xs text-red-400">{exportError}</p>
+            )}
+        </div>
+    );
+};
 
 // ── Main page ─────────────────────────────────────────────────────────────────
 
@@ -276,6 +352,9 @@ const MyRaffles: React.FC = () => {
                     <p className="text-gray-500 dark:text-gray-400 text-sm font-mono truncate">
                         {address}
                     </p>
+                    <div className="mt-3">
+                        <ExportCsvButton address={address} />
+                    </div>
                 </div>
 
                 {/* Stats */}


### PR DESCRIPTION
Backend:
- UsersService.getHistoryAsCsv() fetches full history (up to 10k records) and serialises to CSV with columns: raffle_id, role, tickets_bought, ticket_price, asset, status, outcome, timestamp
- GET /users/:address/history/export?format=csv streams CSV with Content-Type: text/csv and Content-Disposition: attachment headers
- Endpoint requires JWT auth (removed class-level @Public(); re-applied @Public() to getByAddress and getHistory individually)
- Rate-limited to 1 request per minute per user via @Throttle default tier

Client:
- useExportCsv hook: fetches export URL with Bearer token, triggers browser download via fetch + URL.createObjectURL + anchor click
- ExportCsvButton component renders below address in MyRaffles header; shows inline rate-limit and error feedback
- API_CONFIG.endpoints.users.historyExport added to api.ts
closes #489