### PR TITLE
feat: oracle heartbeat alerting with PagerDuty and Opsgenie (#488)

### DIFF
--- a/oracle/src/health/alerting.service.ts
+++ b/oracle/src/health/alerting.service.ts
@@ -1,0 +1,178 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+export type AlertSeverity = 'warning' | 'critical';
+
+export interface AlertPayload {
+  severity: AlertSeverity;
+  summary: string;
+  details?: string;
+  /** Stable key used to de-duplicate and auto-resolve the same alert. */
+  dedupKey: string;
+}
+
+type AlertingProvider = 'pagerduty' | 'opsgenie' | 'none';
+
+/**
+ * AlertingService
+ *
+ * Dispatches alerts to PagerDuty (Events API v2) or Opsgenie (Alert API),
+ * selected via the ALERTING_PROVIDER env var.  Defaults to "none".
+ *
+ * Auto-resolve is supported via the same dedupKey used to open the alert.
+ */
+@Injectable()
+export class AlertingService {
+  private readonly logger = new Logger(AlertingService.name);
+  private readonly provider: AlertingProvider;
+
+  // PagerDuty
+  private readonly pdRoutingKey: string;
+  private readonly pdApiUrl = 'https://events.pagerduty.com/v2/enqueue';
+
+  // Opsgenie
+  private readonly opsgenieApiKey: string;
+  private readonly opsgenieApiUrl = 'https://api.opsgenie.com/v2/alerts';
+
+  constructor() {
+    const raw = (process.env.ALERTING_PROVIDER ?? 'none').toLowerCase();
+    if (raw === 'pagerduty' || raw === 'opsgenie') {
+      this.provider = raw;
+    } else {
+      this.provider = 'none';
+    }
+
+    this.pdRoutingKey = process.env.PAGERDUTY_ROUTING_KEY ?? '';
+    this.opsgenieApiKey = process.env.OPSGENIE_API_KEY ?? '';
+
+    if (this.provider !== 'none') {
+      this.logger.log(`Alerting provider: ${this.provider}`);
+    }
+  }
+
+  /** Fire (trigger) an alert. No-op when provider is "none". */
+  async fire(payload: AlertPayload): Promise<void> {
+    if (this.provider === 'none') return;
+
+    try {
+      if (this.provider === 'pagerduty') {
+        await this.pagerdutyTrigger(payload);
+      } else {
+        await this.opsgenieTrigger(payload);
+      }
+    } catch (err) {
+      this.logger.error(`Failed to fire alert "${payload.dedupKey}": ${(err as Error).message}`);
+    }
+  }
+
+  /** Resolve a previously fired alert. No-op when provider is "none". */
+  async resolve(dedupKey: string): Promise<void> {
+    if (this.provider === 'none') return;
+
+    try {
+      if (this.provider === 'pagerduty') {
+        await this.pagerdutyResolve(dedupKey);
+      } else {
+        await this.opsgenieResolve(dedupKey);
+      }
+    } catch (err) {
+      this.logger.error(`Failed to resolve alert "${dedupKey}": ${(err as Error).message}`);
+    }
+  }
+
+  // ── PagerDuty ──────────────────────────────────────────────────────────────
+
+  private async pagerdutyTrigger(payload: AlertPayload): Promise<void> {
+    const body = {
+      routing_key: this.pdRoutingKey,
+      event_action: 'trigger',
+      dedup_key: payload.dedupKey,
+      payload: {
+        summary: payload.summary,
+        severity: payload.severity === 'critical' ? 'critical' : 'warning',
+        source: 'tikka-oracle',
+        custom_details: payload.details ? { details: payload.details } : undefined,
+      },
+    };
+
+    const res = await fetch(this.pdApiUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`PagerDuty trigger failed (${res.status}): ${text}`);
+    }
+
+    this.logger.warn(`PagerDuty alert triggered: ${payload.dedupKey}`);
+  }
+
+  private async pagerdutyResolve(dedupKey: string): Promise<void> {
+    const body = {
+      routing_key: this.pdRoutingKey,
+      event_action: 'resolve',
+      dedup_key: dedupKey,
+    };
+
+    const res = await fetch(this.pdApiUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`PagerDuty resolve failed (${res.status}): ${text}`);
+    }
+
+    this.logger.log(`PagerDuty alert resolved: ${dedupKey}`);
+  }
+
+  // ── Opsgenie ───────────────────────────────────────────────────────────────
+
+  private async opsgenieTrigger(payload: AlertPayload): Promise<void> {
+    const body = {
+      message: payload.summary,
+      alias: payload.dedupKey,
+      description: payload.details,
+      priority: payload.severity === 'critical' ? 'P1' : 'P3',
+      source: 'tikka-oracle',
+    };
+
+    const res = await fetch(this.opsgenieApiUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `GenieKey ${this.opsgenieApiKey}`,
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`Opsgenie trigger failed (${res.status}): ${text}`);
+    }
+
+    this.logger.warn(`Opsgenie alert triggered: ${payload.dedupKey}`);
+  }
+
+  private async opsgenieResolve(dedupKey: string): Promise<void> {
+    const encoded = encodeURIComponent(dedupKey);
+    const res = await fetch(`${this.opsgenieApiUrl}/${encoded}/close?identifierType=alias`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `GenieKey ${this.opsgenieApiKey}`,
+      },
+      body: JSON.stringify({ source: 'tikka-oracle' }),
+    });
+
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`Opsgenie resolve failed (${res.status}): ${text}`);
+    }
+
+    this.logger.log(`Opsgenie alert resolved: ${dedupKey}`);
+  }
+}

--- a/oracle/src/health/health.module.ts
+++ b/oracle/src/health/health.module.ts
@@ -3,13 +3,14 @@ import { HealthController } from './health.controller';
 import { HealthService } from './health.service';
 import { LagMonitorService } from './lag-monitor.service';
 import { HeartbeatService } from './heartbeat.service';
+import { AlertingService } from './alerting.service';
 import { ContractService } from '../contract/contract.service';
 import { TxSubmitterService } from '../submitter/tx-submitter.service';
 import { FeeEstimatorService } from '../submitter/fee-estimator.service';
 
 @Module({
   controllers: [HealthController],
-  providers: [HealthService, LagMonitorService, HeartbeatService, ContractService, TxSubmitterService, FeeEstimatorService],
-  exports: [HealthService, LagMonitorService, HeartbeatService],
+  providers: [HealthService, LagMonitorService, HeartbeatService, AlertingService, ContractService, TxSubmitterService, FeeEstimatorService],
+  exports: [HealthService, LagMonitorService, HeartbeatService, AlertingService],
 })
 export class HealthModule {}

--- a/oracle/src/health/heartbeat.service.ts
+++ b/oracle/src/health/heartbeat.service.ts
@@ -1,31 +1,48 @@
 import { Injectable, Logger, OnModuleInit, OnModuleDestroy } from '@nestjs/common';
 import { HealthService } from './health.service';
 import { ContractService } from '../contract/contract.service';
+import { AlertingService } from './alerting.service';
+
+const HEARTBEAT_ALERT_DEDUP_KEY = 'tikka-oracle-heartbeat-missed';
 
 @Injectable()
 export class HeartbeatService implements OnModuleInit, OnModuleDestroy {
   private readonly logger = new Logger(HeartbeatService.name);
   private intervalId: NodeJS.Timeout;
+  private watchdogId: NodeJS.Timeout;
   private readonly heartbeatIntervalMs: number;
+  private readonly heartbeatAlertTimeoutMs: number;
+  private lastHeartbeatAt: number | null = null;
+  private heartbeatAlertFired = false;
 
   constructor(
     private readonly healthService: HealthService,
     private readonly contractService: ContractService,
+    private readonly alertingService: AlertingService,
   ) {
     // Default to 1 hour (3600000 ms) if not configured
     this.heartbeatIntervalMs = process.env.HEARTBEAT_INTERVAL_MS 
       ? parseInt(process.env.HEARTBEAT_INTERVAL_MS, 10) 
       : 3600000;
+
+    // Default to 90 000 ms if not configured
+    this.heartbeatAlertTimeoutMs = process.env.HEARTBEAT_ALERT_TIMEOUT_MS
+      ? parseInt(process.env.HEARTBEAT_ALERT_TIMEOUT_MS, 10)
+      : 90000;
   }
 
   onModuleInit() {
     this.logger.log(`Starting Oracle Heartbeat Service with interval ${this.heartbeatIntervalMs}ms`);
     this.startHeartbeat();
+    this.startWatchdog();
   }
 
   onModuleDestroy() {
     if (this.intervalId) {
       clearInterval(this.intervalId);
+    }
+    if (this.watchdogId) {
+      clearInterval(this.watchdogId);
     }
   }
 
@@ -33,6 +50,44 @@ export class HeartbeatService implements OnModuleInit, OnModuleDestroy {
     this.intervalId = setInterval(async () => {
       await this.emitHeartbeat();
     }, this.heartbeatIntervalMs);
+  }
+
+  /**
+   * Watchdog: checks every HEARTBEAT_ALERT_TIMEOUT_MS whether a heartbeat has
+   * been sent recently.  Fires a critical alert if not; auto-resolves when the
+   * heartbeat resumes.
+   */
+  private startWatchdog() {
+    this.watchdogId = setInterval(async () => {
+      await this.checkHeartbeatAlive();
+    }, this.heartbeatAlertTimeoutMs);
+  }
+
+  private async checkHeartbeatAlive(): Promise<void> {
+    const now = Date.now();
+    const missedHeartbeat =
+      this.lastHeartbeatAt === null ||
+      now - this.lastHeartbeatAt > this.heartbeatAlertTimeoutMs;
+
+    if (missedHeartbeat && !this.heartbeatAlertFired) {
+      this.heartbeatAlertFired = true;
+      const idleMs = this.lastHeartbeatAt === null ? null : now - this.lastHeartbeatAt;
+      const details = idleMs === null
+        ? 'No heartbeat has ever been sent since startup.'
+        : `Last heartbeat was ${Math.round(idleMs / 1000)}s ago (threshold: ${this.heartbeatAlertTimeoutMs / 1000}s).`;
+
+      this.logger.error(`Heartbeat alert: ${details}`);
+      await this.alertingService.fire({
+        severity: 'critical',
+        summary: 'Tikka Oracle heartbeat missed',
+        details,
+        dedupKey: HEARTBEAT_ALERT_DEDUP_KEY,
+      });
+    } else if (!missedHeartbeat && this.heartbeatAlertFired) {
+      this.heartbeatAlertFired = false;
+      this.logger.log('Heartbeat resumed — resolving alert.');
+      await this.alertingService.resolve(HEARTBEAT_ALERT_DEDUP_KEY);
+    }
   }
 
   private async emitHeartbeat() {
@@ -46,6 +101,7 @@ export class HeartbeatService implements OnModuleInit, OnModuleDestroy {
       }
 
       await this.contractService.ping();
+      this.lastHeartbeatAt = Date.now();
       this.logger.log('Oracle heartbeat emitted successfully: healthy');
       
     } catch (error) {

--- a/oracle/src/health/lag-monitor.service.ts
+++ b/oracle/src/health/lag-monitor.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { AlertingService } from './alerting.service';
 
 export interface PendingRequest {
   requestId: string;
@@ -13,6 +14,10 @@ export class LagMonitorService {
   private readonly pendingRequests = new Map<string, PendingRequest>();
   private readonly LAG_THRESHOLD_LEDGERS = 100;
   private currentLedger = 0;
+  /** Tracks which requestIds have already had a lag alert fired. */
+  private readonly firedAlerts = new Set<string>();
+
+  constructor(private readonly alertingService: AlertingService) {}
 
   trackRequest(requestId: string, raffleId: number, ledger: number): void {
     this.pendingRequests.set(requestId, {
@@ -24,6 +29,10 @@ export class LagMonitorService {
   }
 
   fulfillRequest(requestId: string): void {
+    if (this.firedAlerts.has(requestId)) {
+      this.firedAlerts.delete(requestId);
+      void this.alertingService.resolve(this.lagDedupKey(requestId));
+    }
     this.pendingRequests.delete(requestId);
   }
 
@@ -39,9 +48,24 @@ export class LagMonitorService {
         this.logger.error(
           `ALERT: Request ${requestId} for raffle ${request.raffleId} not fulfilled within ${this.LAG_THRESHOLD_LEDGERS} ledgers. Lag: ${lag}`,
         );
+
+        if (!this.firedAlerts.has(requestId)) {
+          this.firedAlerts.add(requestId);
+          void this.alertingService.fire({
+            severity: 'warning',
+            summary: `Oracle lag: request ${requestId} unfulfilled after ${lag} ledgers`,
+            details: `Raffle ${request.raffleId} — requested at ledger ${request.requestedAtLedger}, current ledger ${this.currentLedger}. Threshold: ${this.LAG_THRESHOLD_LEDGERS} ledgers.`,
+            dedupKey: this.lagDedupKey(requestId),
+          });
+        }
+
         this.pendingRequests.delete(requestId);
       }
     }
+  }
+
+  private lagDedupKey(requestId: string): string {
+    return `tikka-oracle-lag-${requestId}`;
   }
 
   getPendingCount(): number {


### PR DESCRIPTION
- Add AlertingService (oracle/src/health/alerting.service.ts): Dispatches fire() and resolve() to PagerDuty Events API v2 or Opsgenie Alert API, selected via ALERTING_PROVIDER env var. Defaults to 'none' (no external calls). Errors are caught and logged without crashing the oracle.

- Update HeartbeatService: Inject AlertingService. Add watchdog timer that runs every HEARTBEAT_ALERT_TIMEOUT_MS (default 90 000 ms). Fires a critical alert if no heartbeat has been sent within the timeout window. Auto-resolves the alert when the heartbeat resumes.

- Update LagMonitorService: Inject AlertingService. Fire a warning alert (once per requestId) when lag crosses LAG_THRESHOLD_LEDGERS. Auto-resolves the alert when fulfillRequest() is called for that requestId.

- Update HealthModule: Register and export AlertingService.

Env vars:
  ALERTING_PROVIDER=pagerduty|opsgenie|none (default: none) PAGERDUTY_ROUTING_KEY=<integration key> OPSGENIE_API_KEY=<api key> HEARTBEAT_ALERT_TIMEOUT_MS=90000
closes #488