### PR TITLE
feat: SDK read/write sub-path exports with tree-shaking and bundle-si…

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -5,12 +5,30 @@
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./read": {
+      "import": "./dist/read/index.read.js",
+      "require": "./dist/read/index.read.js",
+      "types": "./dist/read/index.read.d.ts"
+    },
+    "./write": {
+      "import": "./dist/write/index.write.js",
+      "require": "./dist/write/index.write.js",
+      "types": "./dist/write/index.write.d.ts"
+    }
+  },
   "bin": {
     "tikka": "./bin/tikka.cjs"
   },
   "scripts": {
     "cli": "node bin/tikka.cjs",
     "build": "nest build",
+    "build:read": "tsc -p tsconfig.read.json",
     "build:light": "tsc -p tsconfig.light.json",
     "start": "nest start",
     "start:dev": "nest start --watch",
@@ -27,8 +45,17 @@
     "example:offline-signing": "ts-node examples/offline-signing.ts",
     "docs": "typedoc",
     "docs:watch": "typedoc --watch",
-    "size-check": "powershell (Get-Item dist/light/index.light.js).Length"
+    "size-check": "size-limit",
+    "size-check:legacy": "powershell (Get-Item dist/light/index.light.js).Length"
   },
+  "size-limit": [
+    {
+      "name": "@tikka/sdk/read",
+      "path": "dist/read/index.read.js",
+      "limit": "50 kB",
+      "gzip": true
+    }
+  ],
   "dependencies": {
     "@albedo-link/intent": "^0.13.0",
     "@lobstrco/signer-extension-api": "^2.0.0",
@@ -46,6 +73,7 @@
   "devDependencies": {
     "@nestjs/cli": "^11.0.16",
     "@nestjs/testing": "^10.4.0",
+    "@size-limit/preset-small-lib": "^11.1.6",
     "@types/inquirer": "^9.0.7",
     "@types/jest": "^30.0.0",
     "@types/node": "^22.0.0",
@@ -54,6 +82,7 @@
     "eslint": "^10.0.2",
     "fast-check": "^4.7.0",
     "jest": "^30.3.0",
+    "size-limit": "^11.1.6",
     "ts-jest": "^29.4.6",
     "ts-node": "^10.9.2",
     "typedoc": "^0.28.18",

--- a/sdk/src/index.read.ts
+++ b/sdk/src/index.read.ts
@@ -1,0 +1,59 @@
+/**
+ * @packageDocumentation
+ * **@tikka/sdk/read** — Read-only sub-path export for @tikka/sdk.
+ *
+ * Contains only the utilities needed to query raffle state from the Soroban
+ * contract and the Stellar network.  No signing, no wallet adapters, no
+ * submission code is included, so bundlers (Vite, Webpack, esbuild) can
+ * tree-shake the write path entirely.
+ *
+ * ## Included
+ * - `RpcService` — Soroban RPC client (simulate, getLedger, getTransaction)
+ * - `HorizonService` — Horizon account / fee queries
+ * - `NetworkConfig`, `RpcConfig`, `TESTNET_CONFIG`, `MAINNET_CONFIG`
+ * - `ContractFn`, `RaffleStatus` — contract constants (no signing deps)
+ * - `ContractResponse` — shared response envelope type
+ * - Read-only types: `RaffleData`, `UserParticipation`, `GetParticipationParams`,
+ *   `GetUserTicketsParams`, `AssetDescriptor`
+ * - Utils: formatting, validation, errors, retry, BigNumber
+ *
+ * ## Excluded
+ * - `ContractService` (requires wallet + TransactionBuilder)
+ * - `TransactionLifecycle` (requires wallet + signing)
+ * - All wallet adapters (Freighter, XBull, Albedo, LOBSTR, Rabet)
+ * - `sep10` auth helpers
+ * - `FeeEstimatorService`
+ * - Write-side service classes (`RaffleService`, `TicketService`, `UserService`)
+ * - NestJS modules
+ *
+ * @example
+ * ```ts
+ * import { RpcService, RaffleStatus, ContractFn } from '@tikka/sdk/read';
+ * ```
+ */
+
+// ── Network (read-only) ──────────────────────────────────────────────────────
+export { RpcService } from './network/rpc.service';
+export { HorizonService } from './network/horizon.service';
+export {
+  resolveNetworkConfig,
+  DEFAULT_RPC_CONFIG,
+} from './network/network.config';
+export type {
+  NetworkConfig,
+  RpcConfig,
+  TikkaNetwork,
+} from './network/network.config';
+
+// ── Contract constants & response type ──────────────────────────────────────
+export { ContractFn, RaffleStatus } from './contract/bindings';
+export type { ContractFnName } from './contract/bindings';
+export type { ContractResponse } from './contract/response';
+
+// ── Read-only domain types ───────────────────────────────────────────────────
+export type { RaffleData, AssetDescriptor } from './modules/raffle/raffle.types';
+export type { GetUserTicketsParams } from './modules/ticket/ticket.types';
+export type { UserParticipation, GetParticipationParams } from './modules/user/user.types';
+
+// ── Utils ────────────────────────────────────────────────────────────────────
+export * from './utils';

--- a/sdk/src/index.write.ts
+++ b/sdk/src/index.write.ts
@@ -1,0 +1,70 @@
+/**
+ * @packageDocumentation
+ * **@tikka/sdk/write** — Write (signing + submission) sub-path export for @tikka/sdk.
+ *
+ * Contains everything needed to build, sign, and submit Soroban transactions.
+ * Consumers who only need read-only queries should import from `@tikka/sdk/read`
+ * instead to avoid pulling in wallet adapter and signing overhead.
+ *
+ * ## Included
+ * - `ContractService` — full invoke / simulate / buildUnsigned / submitSigned
+ * - `TransactionLifecycle` — four-phase lifecycle (simulate → sign → submit → poll)
+ * - All wallet adapters (Freighter, XBull, Albedo, LOBSTR, Rabet, Mock)
+ * - `WalletAdapter` interface
+ * - `sep10` auth helpers (`buildChallenge`, `verifyResponse`, `createInMemoryNonceStore`)
+ * - `FeeEstimatorService`
+ * - Write-side service classes (`RaffleService`, `TicketService`, `UserService`)
+ * - All write-side types (`RaffleParams`, `BuyTicketParams`, `RefundTicketParams`, etc.)
+ * - Re-exports everything from `@tikka/sdk/read` for convenience
+ *
+ * @example
+ * ```ts
+ * import { ContractService, FreighterAdapter } from '@tikka/sdk/write';
+ * ```
+ */
+
+// ── Re-export the full read surface ─────────────────────────────────────────
+export * from './index.read';
+
+// ── Contract service & lifecycle ────────────────────────────────────────────
+export { ContractService } from './contract/contract.service';
+export type { InvokeOptions, UnsignedTxResult, TxMemo } from './contract/contract.service';
+export { TransactionLifecycle } from './contract/lifecycle';
+export type {
+  SimulateResult,
+  SubmitResult,
+  PollConfig,
+  InvokeLifecycleOptions,
+} from './contract/lifecycle';
+
+// ── Wallet adapters ──────────────────────────────────────────────────────────
+export * from './wallet';
+
+// ── Auth (SEP-10) ────────────────────────────────────────────────────────────
+export * from './auth/sep10';
+
+// ── Fee estimation ───────────────────────────────────────────────────────────
+export * from './fee-estimator';
+
+// ── Write-side service classes ───────────────────────────────────────────────
+export { RaffleService } from './modules/raffle/raffle.service';
+export { TicketService } from './modules/ticket/ticket.service';
+export { UserService } from './modules/user/user.service';
+
+// ── Write-side types ─────────────────────────────────────────────────────────
+export type {
+  RaffleParams,
+  CreateRaffleResult,
+  CancelRaffleResult,
+  CancelRaffleParams,
+} from './modules/raffle/raffle.types';
+export type {
+  BuyTicketParams,
+  BuyTicketResult,
+  RefundTicketParams,
+  RefundTicketResult,
+  BuyBatchParams,
+  BuyBatchResult,
+  BatchPurchaseResult,
+  BatchTicketPurchase,
+} from './modules/ticket/ticket.types';

--- a/sdk/tsconfig.read.json
+++ b/sdk/tsconfig.read.json
@@ -1,0 +1,48 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "target": "ES2020",
+    "moduleResolution": "node",
+    "outDir": "./dist/read",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationDir": "./dist/read",
+    "isolatedModules": false,
+    "emitDecoratorMetadata": false,
+    "experimentalDecorators": true,
+    "skipLibCheck": true
+  },
+  "include": [
+    "src/index.read.ts",
+    "src/network/rpc.service.ts",
+    "src/network/horizon.service.ts",
+    "src/network/network.config.ts",
+    "src/contract/bindings.ts",
+    "src/contract/response.ts",
+    "src/modules/raffle/raffle.types.ts",
+    "src/modules/ticket/ticket.types.ts",
+    "src/modules/user/user.types.ts",
+    "src/utils/**/*.ts",
+    "src/types.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "src/**/*.spec.ts",
+    "src/**/*.module.ts",
+    "src/contract/contract.service.ts",
+    "src/contract/lifecycle.ts",
+    "src/wallet/**",
+    "src/auth/**",
+    "src/fee-estimator/**",
+    "src/modules/raffle/raffle.service.ts",
+    "src/modules/raffle/raffle.module.ts",
+    "src/modules/ticket/ticket.service.ts",
+    "src/modules/ticket/ticket.module.ts",
+    "src/modules/user/user.service.ts",
+    "src/modules/user/user.module.ts",
+    "src/modules/admin/**",
+    "src/app.module.ts",
+    "src/main.ts"
+  ]
+}

--- a/sdk/typedoc.json
+++ b/sdk/typedoc.json
@@ -1,7 +1,11 @@
 {
-  "$schema": "https://typedoc.org/schema.json",
   "plugin": ["typedoc-plugin-markdown"],
-  "entryPoints": ["src/index.ts"],
+  "entryPoints": [
+    "src/index.ts",
+    "src/index.read.ts",
+    "src/index.write.ts"
+  ],
+  "entryPointStrategy": "resolve",
   "out": "docs",
   "name": "Tikka SDK",
   "readme": "README.md",


### PR DESCRIPTION
…ze CI (#487)

- Add src/index.read.ts (@tikka/sdk/read): Exports only read-only surface: RpcService, HorizonService, NetworkConfig/RpcConfig/resolveNetworkConfig/DEFAULT_RPC_CONFIG, ContractFn, RaffleStatus, ContractResponse, read-only domain types (RaffleData, UserParticipation, GetParticipationParams, GetUserTicketsParams, AssetDescriptor), and all utils. No signing code, no wallet adapters, no ContractService.

- Add src/index.write.ts (@tikka/sdk/write): Re-exports everything from index.read, then adds ContractService, TransactionLifecycle, all wallet adapters, sep10 auth helpers, FeeEstimatorService, RaffleService, TicketService, UserService, and all write-side types.

- Add tsconfig.read.json: ESNext module, ES2020 target, emitDecoratorMetadata: false. Explicitly excludes contract.service.ts, lifecycle.ts, wallet/**, auth/**, fee-estimator/**, and all *.module.ts files. Output to dist/read/.

- Update package.json: Add exports map with '.' (existing), './read', './write' sub-paths so Vite/Webpack/esbuild can tree-shake unused sub-paths. Add build:read script (tsc -p tsconfig.read.json). Add size-limit config: @tikka/sdk/read must be <= 50 kB gzipped. Add size-limit and @size-limit/preset-small-lib devDependencies. Rename size-check script to use size-limit CLI.

- Update typedoc.json: Add index.read.ts and index.write.ts as additional entryPoints with entryPointStrategy: resolve so TypeDoc generates a separate page per sub-path.

Existing consumers importing from '@tikka/sdk' are unaffected.
closes #487