### PR TITLE
feat: add local full-stack docker compose profiles (#620)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Shared infrastructure — used by docker-compose.yml
+# Copy to .env and adjust as needed.
+
+POSTGRES_USER=tikka
+POSTGRES_PASSWORD=tikka-pass
+POSTGRES_DB=tikka

--- a/README.md
+++ b/README.md
@@ -12,6 +12,60 @@ This repository is the **Tikka ecosystem**: frontend, SDK, backend, indexer, and
 | [**indexer**](./indexer/) | Blockchain event ingestion — Horizon → decode → PostgreSQL (+ Redis cache). NestJS. |
 | [**oracle**](./oracle/) | Randomness oracle — listens for draw requests, computes VRF/PRNG, submits to contract. NestJS. |
 
+## Local Development
+
+### Prerequisites
+
+Docker and Docker Compose v2.
+
+### Setup
+
+```bash
+cp .env.example .env
+cp backend/.env.example backend/.env.local   # fill in SUPABASE_URL, JWT_SECRET, ADMIN_TOKEN
+cp indexer/.env.example indexer/.env.local   # fill in SOROBAN_RPC_URL, TIKKA_CONTRACT_ID
+cp oracle/.env.example oracle/.env.local
+```
+
+### Profiles
+
+| Profile | What starts |
+|---------|-------------|
+| `deps` | Postgres + Redis only |
+| `backend` | deps + backend API (port 3001) |
+| `indexer` | deps + indexer (port 3002) |
+| `oracle` | deps + oracle (port 3003) |
+| `full` | deps + backend + indexer + oracle |
+| `client` | full + Vite client (port 5173) |
+
+### Full stack (no client)
+
+```bash
+docker compose --profile full up --build
+```
+
+### Individual service + deps
+
+```bash
+docker compose --profile backend up --build
+docker compose --profile indexer up --build
+```
+
+### Frontend dev (Vite locally, backend in Docker)
+
+```bash
+docker compose --profile backend up -d
+cd client && pnpm install && pnpm dev
+```
+
+### Tear down
+
+```bash
+docker compose --profile full down -v
+```
+
+---
+
 ## SDK API Docs
 
 Auto-generated TypeDoc reference for `@tikka/sdk`:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,108 @@
+version: '3.8'
+
+# Profiles:
+#   deps     — postgres + redis only (useful for running services locally)
+#   backend  — deps + backend API
+#   indexer  — deps + indexer
+#   oracle   — deps + oracle
+#   full     — everything except client (backend + indexer + oracle + deps)
+#   client   — adds the Vite dev server (optional; most devs run this locally)
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    profiles: [deps, backend, indexer, oracle, full, client]
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-tikka}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-tikka-pass}
+      POSTGRES_DB: ${POSTGRES_DB:-tikka}
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-tikka}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    image: redis:7-alpine
+    profiles: [deps, backend, indexer, oracle, full, client]
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    profiles: [backend, full, client]
+    ports:
+      - "3001:3001"
+    env_file: ./backend/.env.local
+    environment:
+      NODE_ENV: development
+      PORT: 3001
+      REDIS_URL: redis://redis:6379
+      INDEXER_URL: http://indexer:3002
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+
+  indexer:
+    build:
+      context: ./indexer
+      dockerfile: Dockerfile
+    profiles: [indexer, full, client]
+    ports:
+      - "3002:3002"
+    env_file: ./indexer/.env.local
+    environment:
+      NODE_ENV: development
+      DATABASE_URL: postgres://${POSTGRES_USER:-tikka}:${POSTGRES_PASSWORD:-tikka-pass}@postgres:5432/${POSTGRES_DB:-tikka}
+      REDIS_URL: redis://redis:6379
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+
+  oracle:
+    build:
+      context: ./oracle
+      dockerfile: Dockerfile
+    profiles: [oracle, full, client]
+    ports:
+      - "3003:3003"
+    env_file: ./oracle/.env.local
+    environment:
+      NODE_ENV: development
+      REDIS_URL: redis://redis:6379
+    depends_on:
+      redis:
+        condition: service_healthy
+
+  client:
+    build:
+      context: ./client
+      dockerfile: Dockerfile
+    profiles: [client]
+    ports:
+      - "5173:5173"
+    env_file: ./client/.env.local
+    depends_on:
+      - backend
+
+networks:
+  default:
+    name: tikka-network
+
+volumes:
+  postgres-data:

--- a/indexer/Dockerfile
+++ b/indexer/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:22-alpine AS builder
+WORKDIR /app
+RUN npm install -g pnpm
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+COPY . .
+RUN pnpm run build
+
+FROM node:22-alpine AS runner
+WORKDIR /app
+RUN npm install -g pnpm
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --prod --frozen-lockfile
+COPY --from=builder /app/dist ./dist
+ENV NODE_ENV=production
+EXPOSE 3002
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD wget --quiet --tries=1 http://localhost:3002/health -O /dev/null || exit 1
+CMD ["node", "dist/main.js"]

--- a/oracle/Dockerfile
+++ b/oracle/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:22-alpine AS builder
+WORKDIR /app
+RUN npm install -g pnpm
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+COPY . .
+RUN pnpm run build
+
+FROM node:22-alpine AS runner
+WORKDIR /app
+RUN npm install -g pnpm
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --prod --frozen-lockfile
+COPY --from=builder /app/dist ./dist
+ENV NODE_ENV=production
+EXPOSE 3003
+CMD ["node", "dist/main.js"]


### PR DESCRIPTION
- Add root docker-compose.yml with profiles: deps, backend, indexer, oracle, full, client
- Add .env.example for shared Postgres vars
- Add Dockerfile for indexer (port 3002) and oracle (port 3003)
- Update README with local dev setup and profile usage guide
- Client profile is optional; frontend devs can run Vite locally against dockerized backend
closed #620
