### PR TITLE
feat: add comprehensive database schema documentation for backend, indexer, and oracle services

### DIFF
--- a/docs/database/README.md
+++ b/docs/database/README.md
@@ -1,0 +1,68 @@
+# Database Schema Ownership
+
+## Database Instances
+
+| Instance | Services | Access Method |
+|---|---|---|
+| **Supabase (shared PostgreSQL)** | `tikka-backend`, `tikka-oracle` | `@supabase/supabase-js` with `service_role_key` |
+| **Indexer PostgreSQL** | `tikka-indexer` | TypeORM (`@nestjs/typeorm`) |
+
+The backend and oracle share a single Supabase PostgreSQL instance. The indexer runs its own separate PostgreSQL database. The backend never queries the indexer's database directly — it reads on-chain data via the indexer's HTTP REST API.
+
+## Service Ownership
+
+| Service | Migration Path | Owns Tables |
+|---|---|---|
+| **tikka-backend** | `backend/database/migrations/` | 9 tables (off-chain metadata, auth, notifications, webhooks) |
+| **tikka-indexer** | `indexer/src/database/migrations/` | 10 tables (on-chain raffle state, events, users) |
+| **tikka-oracle** | `oracle/database/migrations/` | 4 tables (VRF audit, draw idempotency, push failures) |
+
+## Quick Reference
+
+| Table | Owner | DB Instance | Public Read |
+|---|---|---|---|
+| `raffle_metadata` | backend | Supabase | Yes (non-deleted rows) |
+| `notifications` | backend | Supabase | No |
+| `oracle_jobs` | backend | Supabase | No |
+| `push_tokens` | backend | Supabase | No |
+| `refresh_tokens` | backend | Supabase | No |
+| `siws_nonces` | backend | Supabase | No |
+| `webhooks` (public) | backend | Supabase | Self-serve (JWT) |
+| `webhook_deliveries` | backend | Supabase | Self-serve (JWT) |
+| `notification_subscriptions` | backend | Supabase | No |
+| `audit_logs` | backend | Supabase | No |
+| `raffles` | indexer | Indexer PG | Via indexer API |
+| `tickets` | indexer | Indexer PG | Via indexer API |
+| `users` | indexer | Indexer PG | Via indexer API |
+| `raffle_events` | indexer | Indexer PG | No |
+| `platform_stats` | indexer | Indexer PG | Via indexer API |
+| `platform_state` | indexer | Indexer PG | No |
+| `indexer_cursor` | indexer | Indexer PG | No |
+| `webhooks` (internal) | indexer | Indexer PG | No |
+| `dead_letter_events` | indexer | Indexer PG | No |
+| `archive_checkpoints` | indexer | Indexer PG | No |
+| `vrf_audit_log` | oracle | Supabase | Yes |
+| `oracle_draw_requests` | oracle | Supabase | No |
+| `oracle_draw_request_replays` | oracle | Supabase | No |
+| `push_delivery_failures` | oracle* | Supabase | No |
+
+\* `push_delivery_failures` migration lives in `oracle/database/migrations/` but is **written by backend** `PushNotificationService`. Oracle defined the schema; backend is the writer.
+
+## Cross-Service Reads
+
+The following cross-service read patterns exist:
+
+| Table | Written By | Read By | Method |
+|---|---|---|---|
+| `oracle_jobs` | *(no writer found)* | Backend MonitorService | Direct Supabase query |
+| `push_delivery_failures` | Backend PushNotificationService | Operators (manual) | Direct Supabase query |
+| `raffles`, `tickets`, `users`, etc. | Indexer | Backend | HTTP API to indexer (not direct DB) |
+
+## Adding New Columns
+
+1. **Identify which service owns the table** from the tables above.
+2. **Add a migration** in the owner's migration directory:
+   - Backend: `backend/database/migrations/<NNN>_<name>.sql`
+   - Indexer: `indexer/src/database/migrations/<timestamp>-<Name>.ts`
+   - Oracle: `oracle/database/migrations/<name>.sql`
+3. **If adding a cross-service read**, document the read pattern here.

--- a/docs/database/backend-schema.md
+++ b/docs/database/backend-schema.md
@@ -1,0 +1,196 @@
+# Backend Database Schema
+
+**Service:** `tikka-backend`
+**Database:** Supabase (shared PostgreSQL with oracle)
+**ORM:** Raw SQL via `@supabase/supabase-js`
+**Migration path:** `backend/database/migrations/`
+
+## Tables
+
+### `raffle_metadata`
+
+| Column | Type | Notes |
+|---|---|---|
+| `raffle_id` | `INTEGER PK` | Raffle ID from contract/indexer |
+| `title` | `TEXT` | |
+| `description` | `TEXT` | |
+| `image_url` | `TEXT` | Legacy single image |
+| `image_urls` | `TEXT[]` | Multi-image support (migration 004) |
+| `category` | `TEXT` | |
+| `metadata_cid` | `TEXT` | IPFS CID |
+| `search_vector` | `tsvector` | Generated full-text search (migration 007) |
+| `deleted_at` | `TIMESTAMPTZ` | Soft-delete (migration 009) |
+| `created_at` | `TIMESTAMPTZ` | |
+| `updated_at` | `TIMESTAMPTZ` | |
+
+**Owner:** Backend
+**Migrations:** 001 (create), 004 (add image_urls), 007 (add search_vector), 009 (add deleted_at)
+**Read:** Public (RLS policy excludes soft-deleted rows)
+**Write:** Backend MetadataService
+**RLS:** `Allow public read` (only non-deleted rows)
+
+### `notifications`
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | `UUID PK` | |
+| `raffle_id` | `INTEGER NOT NULL` | |
+| `user_address` | `VARCHAR(56) NOT NULL` | Stellar wallet |
+| `channel` | `VARCHAR(20)` | email / push |
+| `created_at` | `TIMESTAMPTZ` | |
+
+**Owner:** Backend
+**Migrations:** 002
+**Read:** Backend NotificationService
+**Write:** Backend NotificationService
+**RLS:** Enabled, no public policy
+
+### `oracle_jobs`
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | `TEXT PK` | Oracle job ID |
+| `status` | `TEXT` | pending / completed / failed |
+| `enqueued_at` | `TIMESTAMPTZ` | |
+| `updated_at` | `TIMESTAMPTZ` | |
+| `confirmed_at` | `TIMESTAMPTZ` | |
+| `latency_ms` | `INTEGER` | |
+| `xdr` | `TEXT` | Raw XDR for failed jobs |
+| `error_message` | `TEXT` | |
+
+**Owner:** Backend (migration), no active writer found
+**Migrations:** 003
+**Read:** Backend MonitorService
+**Write:** *(no active writer in codebase — likely placeholder for future oracle integration)*
+**RLS:** Enabled, no public policy
+
+### `push_tokens`
+
+| Column | Type | Notes |
+|---|---|---|
+| `user_address` | `TEXT` | Composite PK |
+| `device_token` | `TEXT` | Composite PK |
+| `platform` | `TEXT` | fcm |
+| `created_at` | `TIMESTAMPTZ` | |
+| `updated_at` | `TIMESTAMPTZ` | |
+
+**Owner:** Backend
+**Migrations:** 005
+**Read:** Backend PushNotificationService
+**Write:** Backend PushNotificationService
+**RLS:** Enabled, no public policy
+
+### `refresh_tokens`
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | `BIGINT PK` | Identity |
+| `user_address` | `TEXT NOT NULL` | |
+| `token_hash` | `TEXT NOT NULL UNIQUE` | HMAC-SHA256 hash |
+| `revoked` | `BOOLEAN` | |
+| `created_at` | `TIMESTAMPTZ` | |
+| `updated_at` | `TIMESTAMPTZ` | |
+| `last_used_at` | `TIMESTAMPTZ` | |
+| `expires_at` | `TIMESTAMPTZ` | |
+
+**Owner:** Backend
+**Migrations:** 006
+**Read:** Backend AuthService
+**Write:** Backend AuthService
+**RLS:** Enabled, no public policy
+
+### `siws_nonces`
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | `BIGINT PK` | Identity |
+| `address` | `TEXT NOT NULL` | Stellar wallet |
+| `nonce` | `TEXT NOT NULL` | |
+| `issued_at` | `TIMESTAMPTZ` | |
+| `expires_at` | `TIMESTAMPTZ` | |
+| `consumed` | `BOOLEAN` | |
+| `created_at` | `TIMESTAMPTZ` | |
+
+**Owner:** Backend
+**Migrations:** 008_siws_nonces
+**Read:** Backend AuthService (implicit via insert/update)
+**Write:** Backend AuthService
+**RLS:** Enabled, no public policy
+
+### `webhooks` (public)
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | `UUID PK` | |
+| `owner_address` | `TEXT NOT NULL` | |
+| `target_url` | `TEXT NOT NULL` | |
+| `events` | `TEXT[]` | Event types subscribed |
+| `secret` | `TEXT` | Webhook signing secret |
+| `is_active` | `BOOLEAN` | |
+| `failure_count` | `INTEGER` | |
+| `created_at` | `TIMESTAMPTZ` | |
+
+**Owner:** Backend
+**Migrations:** 008_webhooks
+**Read:** Backend WebhookService, webhook owners (via RLS)
+**Write:** Backend WebhookService, webhook owners (via RLS)
+**RLS:** `Users can manage their own webhooks` (JWT claim match)
+
+### `webhook_deliveries`
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | `UUID PK` | |
+| `webhook_id` | `UUID FK` | References webhooks(id) |
+| `event_type` | `TEXT` | |
+| `payload` | `JSONB` | |
+| `status_code` | `INTEGER` | |
+| `response_body` | `TEXT` | |
+| `error_message` | `TEXT` | |
+| `success` | `BOOLEAN` | |
+| `created_at` | `TIMESTAMPTZ` | |
+
+**Owner:** Backend
+**Migrations:** 008_webhooks
+**Read:** Webhook owners (via RLS, linked to webhooks)
+**Write:** Backend WebhookService
+**RLS:** `Users can view deliveries for their webhooks`
+
+### `notification_subscriptions`
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | `UUID PK` | |
+| `address` | `TEXT NOT NULL` | |
+| `device_token` | `TEXT` | |
+| `channel` | `TEXT` | |
+| `event_preferences` | `JSONB` | |
+| `status` | `TEXT` | active / inactive / revoked |
+| `created_at` | `TIMESTAMPTZ` | |
+| `updated_at` | `TIMESTAMPTZ` | |
+
+**Owner:** Backend
+**Migrations:** 009_notification_subscriptions
+**Read:** Backend
+**Write:** Backend
+**RLS:** Enabled, no public policy
+
+### `audit_logs`
+
+**Note:** No migration file found in `backend/database/migrations/`. Likely created manually via Supabase dashboard.
+
+**Owner:** Backend
+**Read:** Backend MonitorService
+**Write:** Backend MonitorService
+
+## Read/Write Matrix
+
+| Service | Tables Read | Tables Written |
+|---|---|---|
+| MetadataService | `raffle_metadata` | `raffle_metadata` |
+| SearchService | *(via MetadataService + indexer API)* | — |
+| NotificationService | `notifications` | `notifications` |
+| PushNotificationService | `push_tokens` | `push_tokens`, `push_delivery_failures` |
+| AuthService | `refresh_tokens` | `siws_nonces`, `refresh_tokens` |
+| WebhookService | `webhooks`, `webhook_deliveries` | `webhooks`, `webhook_deliveries` |
+| MonitorService | `oracle_jobs`, `audit_logs` | `audit_logs` |

--- a/docs/database/indexer-schema.md
+++ b/docs/database/indexer-schema.md
@@ -1,0 +1,227 @@
+# Indexer Database Schema
+
+**Service:** `tikka-indexer`
+**Database:** Separate PostgreSQL (not shared with backend/oracle)
+**ORM:** TypeORM 0.3.x via `@nestjs/typeorm`
+**Migration path:** `indexer/src/database/migrations/`
+**Entities:** `indexer/src/database/entities/`
+
+## Tables
+
+### `raffles`
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | `INTEGER PK` | Raffle ID from contract |
+| `status` | `TEXT` | open / drawing / finalized / cancelled |
+| `creator` | `VARCHAR(56)` | Stellar address |
+| `price` | `BIGINT` | Ticket price in stroops |
+| `asset` | `VARCHAR(100)` | Stellar asset code |
+| `asset_issuer` | `VARCHAR(56)` | Asset issuer (native = null) |
+| `max_tickets` | `INTEGER` | |
+| `max_entries_per_user` | `INTEGER` | |
+| `start_time` | `TIMESTAMP` | Ledger close time |
+| `end_time` | `TIMESTAMP` | |
+| `winner` | `VARCHAR(56)` | Winner address (nullable) |
+| `winning_ticket_id` | `INTEGER` | Added in migration 1720000000002 |
+| `prize_xlm` | `BIGINT` | |
+| `total_tickets_sold` | `INTEGER` | |
+| `ledger` | `INTEGER` | Creation ledger sequence |
+| `tx_hash` | `VARCHAR(64)` | Creation tx hash |
+| `created_at` | `TIMESTAMP` | |
+| `updated_at` | `TIMESTAMP` | |
+
+**Owner:** Indexer
+**Migrations:** 1700000000000 (create), 1720000000002 (add winning_ticket_id)
+**Read:** Indexer API controllers
+**Write:** Indexer RaffleProcessor
+**Cross-service:** Backend reads via HTTP API (not direct DB)
+
+### `tickets`
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | `INTEGER PK` | |
+| `raffle_id` | `INTEGER FK` | References raffles(id) |
+| `owner` | `VARCHAR(56)` | Stellar address |
+| `purchase_tx_hash` | `VARCHAR(64) UNIQUE` | For idempotency |
+| `refunded` | `BOOLEAN` | |
+| `purchased_at` | `TIMESTAMP` | |
+| `created_at` | `TIMESTAMP` | |
+
+**Owner:** Indexer
+**Migrations:** 1700000000001
+**Read:** Indexer API controllers
+**Write:** Indexer TicketProcessor
+**Cross-service:** Backend reads via HTTP API (not direct DB)
+
+### `users`
+
+| Column | Type | Notes |
+|---|---|---|
+| `address` | `VARCHAR(56) PK` | Stellar wallet (natural key) |
+| `total_tickets_bought` | `INTEGER` | |
+| `total_raffles_won` | `INTEGER` | |
+| `total_raffles_participated` | `INTEGER` | |
+| `total_prize_xlm` | `BIGINT` | |
+| `total_spent_xlm` | `BIGINT` | |
+| `last_tx_hash` | `VARCHAR(64)` | Added in migration 1720000000001 |
+| `first_seen_at` | `TIMESTAMP` | |
+| `last_active_at` | `TIMESTAMP` | |
+| `created_at` | `TIMESTAMP` | |
+| `updated_at` | `TIMESTAMP` | |
+
+**Owner:** Indexer
+**Migrations:** 1700000000002 (create), 1720000000001 (add last_tx_hash)
+**Read:** Indexer API controllers (including leaderboard)
+**Write:** Indexer UserProcessor
+**Cross-service:** Backend reads via HTTP API (not direct DB)
+
+### `raffle_events`
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | `INTEGER PK` | |
+| `raffle_id` | `INTEGER` | |
+| `event_type` | `TEXT` | |
+| `tx_hash` | `VARCHAR(64) UNIQUE` | Idempotency |
+| `ledger` | `INTEGER` | |
+| `data` | `JSONB` | Event payload |
+| `schema_version` | `INTEGER` | Added in migration 1720000000003 |
+| `processed` | `BOOLEAN` | |
+| `created_at` | `TIMESTAMP` | |
+
+**Owner:** Indexer
+**Migrations:** 1700000000003 (create), 1720000000003 (add schema_version)
+**Read:** Indexer internal
+**Write:** Indexer EventParser / IngestionDispatcher
+
+### `platform_stats`
+
+| Column | Type | Notes |
+|---|---|---|
+| `date` | `DATE PK` | Natural key |
+| `total_active_raffles` | `INTEGER` | |
+| `total_tickets_sold` | `INTEGER` | |
+| `total_volume_xlm` | `BIGINT` | |
+| `total_users` | `INTEGER` | |
+| `total_raffles_created` | `INTEGER` | |
+| `total_raffles_completed` | `INTEGER` | |
+| `created_at` | `TIMESTAMP` | |
+| `updated_at` | `TIMESTAMP` | |
+
+**Owner:** Indexer
+**Migrations:** 1700000000004
+**Read:** Indexer stats controller
+**Write:** Indexer StatsProcessor (cron)
+**Cross-service:** Backend reads via HTTP API
+
+### `platform_state`
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | `TEXT PK` | Singleton ('global') |
+| `platform_paused` | `BOOLEAN` | |
+| `admin_address` | `VARCHAR(56)` | |
+| `created_at` | `TIMESTAMP` | |
+| `updated_at` | `TIMESTAMP` | |
+
+**Owner:** Indexer
+**Migrations:** 1700000000006
+**Read:** Indexer AdminProcessor
+**Write:** Indexer AdminProcessor
+
+### `indexer_cursor`
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | `INTEGER PK` | Singleton (1) |
+| `last_ledger` | `INTEGER` | |
+| `paging_token` | `TEXT` | |
+| `ledger_hashes` | `JSONB` | Added in migration 1730000000001 |
+| `updated_at` | `TIMESTAMP` | |
+
+**Owner:** Indexer
+**Migrations:** 1700000000005 (create), 1730000000001 (add ledger_hashes)
+**Read:** Indexer CursorManagerService
+**Write:** Indexer CursorManagerService
+
+### `webhooks` (internal)
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | `INTEGER PK` | |
+| `url` | `TEXT NOT NULL` | |
+| `events` | `TEXT[]` | Event types |
+| `failure_count` | `INTEGER` | |
+| `is_active` | `BOOLEAN` | |
+| `created_at` | `TIMESTAMP` | |
+| `updated_at` | `TIMESTAMP` | |
+
+**Owner:** Indexer
+**Migrations:** 1720000000000
+**Read:** Indexer WebhookService
+**Write:** Indexer WebhookService
+**Note:** This is a separate `webhooks` table from the backend's. Backend webhooks are user-facing (Supabase); indexer webhooks are for internal event dispatch.
+
+### `dead_letter_events`
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | `INTEGER PK` | |
+| `event_type` | `TEXT` | |
+| `payload` | `JSONB` | |
+| `reason` | `TEXT` | Failure reason |
+| `ledger` | `INTEGER` | |
+| `retry_count` | `INTEGER` | |
+| `replayed_at` | `TIMESTAMPTZ` | |
+| `created_at` | `TIMESTAMP` | |
+
+**Owner:** Indexer
+**Migrations:** 1730000000000
+**Read:** Indexer DeadLetterQueueService
+**Write:** Indexer DeadLetterQueueService
+
+### `archive_checkpoints`
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | `INTEGER PK` | |
+| `job_type` | `TEXT` | Type of archiving job |
+| `last_archived_id` | `INTEGER` | |
+| `last_archived_at` | `TIMESTAMP` | |
+| `status` | `TEXT` | |
+| `created_at` | `TIMESTAMP` | |
+| `updated_at` | `TIMESTAMP` | |
+
+**Owner:** Indexer
+**Migrations:** 1748589373000
+**Read:** Indexer ArchiveService
+**Write:** Indexer ArchiveService
+
+## Read/Write Matrix
+
+| Service | Tables Read | Tables Written |
+|---|---|---|
+| RaffleProcessor | `raffles` | `raffles` |
+| TicketProcessor | `tickets` | `tickets` |
+| UserProcessor | `users` | `users` |
+| StatsProcessor | `platform_stats` | `platform_stats` |
+| EventParser | `raffle_events` | `raffle_events` |
+| CursorManagerService | `indexer_cursor` | `indexer_cursor` |
+| AdminProcessor | `platform_state` | `platform_state` |
+| WebhookService | `webhooks` | `webhooks` |
+| DeadLetterQueueService | `dead_letter_events` | `dead_letter_events` |
+| ArchiveService | `archive_checkpoints` | `archive_checkpoints` |
+
+## Cross-Service Access
+
+The backend reads indexer data exclusively via the indexer's HTTP REST API — never via direct database connection. Endpoints used:
+
+| Backend Service | Indexer API Endpoint |
+|---|---|
+| IndexerService | `GET /raffles`, `GET /raffles/:id` |
+| UsersService | `GET /users/:address` |
+| LeaderboardService | `GET /leaderboard` |
+| StatsService | `GET /stats/platform` |
+| SearchService | *(combines metadata + indexer raffle data)* |

--- a/docs/database/oracle-schema.md
+++ b/docs/database/oracle-schema.md
@@ -1,0 +1,101 @@
+# Oracle Database Schema
+
+**Service:** `tikka-oracle`
+**Database:** Supabase (shared PostgreSQL with backend)
+**ORM:** Raw SQL via `@supabase/supabase-js`
+**Migration path:** `oracle/database/migrations/`
+
+## Tables
+
+### `vrf_audit_log`
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | `BIGSERIAL PK` | |
+| `raffle_id` | `INTEGER UNIQUE NOT NULL` | One audit record per raffle |
+| `request_id` | `TEXT` | |
+| `commitment_hash` | `TEXT NOT NULL` | |
+| `reveal_hash` | `TEXT` | |
+| `proof` | `TEXT` | |
+| `seed` | `TEXT` | |
+| `oracle_public_key` | `TEXT NOT NULL` | |
+| `status` | `TEXT` | committed / revealed / abandoned |
+| `committed_at` | `TIMESTAMPTZ NOT NULL` | |
+| `revealed_at` | `TIMESTAMPTZ` | |
+| `ledger_sequence` | `INTEGER` | |
+| `chain_hash` | `TEXT NOT NULL` | |
+
+**Owner:** Oracle
+**Migrations:** 008_vrf_audit_log
+**Read:** Public (RLS: `public_select`), Oracle AuditLogService
+**Write:** Oracle AuditLogService (createCommitRecord, updateRevealRecord, markAbandoned)
+**RLS:** Public SELECT allowed
+
+### `oracle_draw_requests`
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | `BIGSERIAL PK` | |
+| `request_identity` | `TEXT UNIQUE NOT NULL` | Idempotency key |
+| `ledger_sequence` | `INTEGER NOT NULL` | |
+| `tx_hash` | `TEXT NOT NULL` | |
+| `event_index` | `INTEGER NOT NULL` | |
+| `raffle_id` | `INTEGER NOT NULL` | |
+| `contract_request_id` | `TEXT NOT NULL` | |
+| `replayed` | `BOOLEAN` | |
+| `first_seen_at` | `TIMESTAMPTZ` | |
+
+**Owner:** Oracle
+**Migrations:** 009_oracle_draw_request_idempotency
+**Read:** Oracle DrawRequestLedgerService (via UNIQUE violation detection)
+**Write:** Oracle DrawRequestLedgerService
+
+### `oracle_draw_request_replays`
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | `BIGSERIAL PK` | |
+| `request_identity` | `TEXT NOT NULL` | Non-unique (multiple replays tracked) |
+| `ledger_sequence` | `INTEGER NOT NULL` | |
+| `tx_hash` | `TEXT NOT NULL` | |
+| `event_index` | `INTEGER NOT NULL` | |
+| `raffle_id` | `INTEGER NOT NULL` | |
+| `contract_request_id` | `TEXT NOT NULL` | |
+| `replayed_at` | `TIMESTAMPTZ` | |
+
+**Owner:** Oracle
+**Migrations:** 009_oracle_draw_request_idempotency
+**Read:** Oracle internal
+**Write:** Oracle DrawRequestLedgerService
+
+### `push_delivery_failures`
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | `BIGSERIAL PK` | |
+| `user_address` | `TEXT NOT NULL` | |
+| `device_token` | `TEXT` | |
+| `error_code` | `TEXT NOT NULL` | |
+| `classification` | `TEXT` | transient_retry / permanent_invalid_token / permanent_other / provider_outage |
+| `next_action` | `TEXT` | retry / remove_token / drop |
+| `created_at` | `TIMESTAMPTZ` | |
+
+**Owner:** Oracle (migration), Backend (writer)
+**Migrations:** push_delivery_failures
+**Read:** Operators (manual), no service reader found
+**Write:** Backend PushNotificationService
+**Note:** Schema defined by oracle migration; runtime writes come from backend. This is a shared concern.
+
+## Read/Write Matrix
+
+| Service | Tables Read | Tables Written |
+|---|---|---|
+| AuditLogService | `vrf_audit_log` | `vrf_audit_log` |
+| DrawRequestLedgerService | `oracle_draw_requests` | `oracle_draw_requests`, `oracle_draw_request_replays` |
+| Backend PushNotificationService | — | `push_delivery_failures` |
+
+## Cross-Service Notes
+
+- The oracle shares the Supabase instance with the backend. Both use `service_role_key` for writes.
+- `oracle_jobs` (migration `003_oracle_jobs.sql` in backend) is a backend-owned table for oracle observability. No active writer exists in the codebase — it is read by backend's MonitorService for admin dashboards.
+- `push_delivery_failures` is a cross-service table: oracle defined the schema, backend writes the records. Be cautious when modifying this table — coordinate with both teams.


### PR DESCRIPTION
## Summary

Creates database schema ownership documentation for all three services, reducing ambiguity about table ownership and migration paths.

## Changes

### New files

```
docs/database/
├── README.md                # Overview, DB instances, quick-reference ownership table, cross-service reads
├── backend-schema.md        # 10 tables, migration paths, column details, service read/write matrix
├── indexer-schema.md        # 10 tables, TypeORM migration paths, entities, cross-service API access
└── oracle-schema.md         # 4 tables, SQL migration paths, cross-service notes
```

### Key details documented

- **2 database instances**: shared Supabase (backend + oracle), separate PostgreSQL (indexer)
- **23 tables** across all services with owner, DB instance, and public read status
- **Cross-service read patterns**: `push_delivery_failures` (oracle schema, backend writer), `oracle_jobs` (backend migration, no active writer), indexer data read via HTTP API (not direct DB)
- **Migration directories** for each service with naming conventions for new migrations
- **Service-to-table read/write matrices** for backend and indexer

Closes #630
