### PR TITLE
feat: add observability documentation and Grafana dashboards for metrics monitoring

### DIFF
--- a/docs/observability/GRAFANA.md
+++ b/docs/observability/GRAFANA.md
@@ -1,0 +1,208 @@
+# Grafana Dashboards
+
+## Current Dashboards
+
+### Indexer Dashboards
+
+| UID | File | Panels |
+|-----|------|--------|
+| `tikka-indexer` | `indexer/grafana/dashboard.json` | Events Processed Rate, Indexer Lag, Error Rate, Memory Usage |
+| `tikka-indexer-health` | `indexer/grafana/indexer-dashboard.json` | Indexer Lag (Gauge), Events Processed Rate by Type, Average Poll Duration |
+
+#### Dashboard: `tikka-indexer` (uid: tikka-indexer)
+
+| Panel | Query | Type |
+|-------|-------|------|
+| Events Processed Rate | `rate(tikka_indexer_events_processed_total[5m])` | Timeseries |
+| Indexer Lag (Ledgers) | `tikka_indexer_lag_ledgers` | Timeseries |
+| Error Rate | `rate(tikka_indexer_errors_total[5m])` | Timeseries |
+| Memory Usage | `tikka_indexer_memory_usage_bytes` | Timeseries |
+
+#### Dashboard: `tikka-indexer-health` (uid: tikka-indexer-health)
+
+| Panel | Query | Type | Thresholds |
+|-------|-------|------|------------|
+| Indexer Lag (Ledgers) | `tikka_indexer_lag_ledgers` | Gauge | 10 (yellow), 50 (red) |
+| Events Processed Rate (per min) | `sum by (event_type) (rate(tikka_indexer_events_processed_total[1m]))` | Timeseries | — |
+| Average Poll Duration | `rate(tikka_indexer_poll_duration_seconds_sum[1m]) / rate(tikka_indexer_poll_duration_seconds_count[1m])` | Timeseries | — |
+
+### Oracle Dashboards
+
+The oracle exports Prometheus metrics at `GET /metrics` (port 3003) but does **not** currently have a committed Grafana dashboard JSON. A recommended dashboard layout is provided below.
+
+---
+
+## Oracle Dashboard (Recommended)
+
+### Dashboard UID: `tikka-oracle`
+
+### Panel: Submission Outcomes (Rate)
+
+**Query:** `sum by (outcome) (rate(tikka_oracle_submission_outcome_total[5m]))`
+
+Visualize success/failure/retry rates to spot submission issues.
+
+### Panel: Fee Estimates vs Actual
+
+**Query A:** `tikka_oracle_estimated_fee_stroops`
+**Query B:** `rate(tikka_oracle_actual_fee_total_stroops[5m])`
+
+Overlay estimated vs actual fee to detect cost anomalies.
+
+### Panel: Queue Depth (by State)
+
+**Query:** (Not in Prometheus — consumes `GET /queue/metrics` via JSON API data source)
+
+Shows `pendingCount`, `failedCount`, `deadLetteredCount` as stacked series.
+
+### Panel: Memory Usage
+
+**Query:** `tikka_oracle_memory_usage_bytes`
+
+Standard heap monitoring.
+
+### Panel: Component Health
+
+**Data source:** `GET /oracle/components` (JSON API)
+
+Heatmap of component status: listener, queue, key provider, randomness provider, network, submitter.
+
+---
+
+## Backend Dashboards
+
+The backend does **not** currently have a committed Grafana dashboard JSON. It exports:
+
+- `GET /metrics` (JSON) — `metadata_cache_hits` counter
+- `GET /health` (JSON) — push delivery failure metrics
+- `GET /monitor/*` (JSON) — job queue stats, latency, errors, audit log
+
+A recommended dashboard layout is provided below.
+
+### Dashboard UID: `tikka-backend`
+
+### Panel: Push Notification Failures
+
+**Data source:** `GET /health` (JSON API)
+
+Breakdown of `pushDelivery` metrics: `transientRetry`, `permanentInvalidToken`, `permanentOther`, `providerOutage`.
+
+### Panel: Oracle Job Queue
+
+**Data source:** `GET /monitor/stats` (JSON API)
+
+Pending / completed / failed job counts as a stacked bar chart.
+
+### Panel: Job Latency (P50/P95/P99)
+
+**Data source:** `GET /monitor/latency` (JSON API)
+
+Timeseries of job latency in milliseconds.
+
+---
+
+## Cross-Service Correlation Dashboard (Recommended)
+
+### Dashboard UID: `tikka-overview`
+
+This dashboard correlates events across backend, indexer, and oracle in a single view.
+
+### Panel: End-to-End Events Rate
+
+**Queries:**
+
+| Query | Prometheus Source |
+|-------|------------------|
+| `rate(tikka_indexer_events_processed_total[5m])` | Indexer (:3002) |
+| `sum by (outcome) (rate(tikka_oracle_submission_outcome_total[5m]))` | Oracle (:3003) |
+
+### Panel: Lag Comparison
+
+**Queries:**
+
+| Query | Source |
+|-------|--------|
+| `tikka_indexer_lag_ledgers` | Indexer (:3002) |
+| (future) `tikka_oracle_lag_ledgers` | Oracle (:3003) |
+
+### Panel: Error Rate Comparison
+
+**Queries:**
+
+| Query | Source |
+|-------|--------|
+| `rate(tikka_indexer_errors_total[5m])` | Indexer (:3002) |
+| (future) oracle submission failure rate | Oracle (:3003) |
+
+### Panel: Memory Comparison
+
+**Queries:**
+
+| Query | Source |
+|-------|--------|
+| `tikka_indexer_memory_usage_bytes` | Indexer (:3002) |
+| `tikka_oracle_memory_usage_bytes` | Oracle (:3003) |
+
+### Variables
+
+| Variable | Definition | Purpose |
+|----------|------------|---------|
+| `$event_type` | `label_values(tikka_indexer_events_processed_total, event_type)` | Filter indexer events by type |
+| `$outcome` | `label_values(tikka_oracle_submission_outcome_total, outcome)` | Filter oracle outcomes |
+
+---
+
+## Prometheus Scrape Config (Full)
+
+A consolidated Prometheus scrape config for all three services:
+
+```yaml
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'tikka-indexer'
+    static_configs:
+      - targets: ['localhost:3002']
+    metrics_path: '/metrics'
+
+  - job_name: 'tikka-oracle'
+    static_configs:
+      - targets: ['localhost:3003']
+    metrics_path: '/metrics'
+
+  - job_name: 'tikka-backend'
+    static_configs:
+      - targets: ['localhost:3001']
+    metrics_path: '/metrics'
+    # Backend returns JSON, not Prometheus format.
+    # Use Prometheus static_config or a Prometheus `json` exporter.
+```
+
+## Prometheus Alert Rules (Consolidated)
+
+```yaml
+groups:
+  - name: tikka-indexer-alerts
+    rules:
+      - alert: IndexerFallingBehind
+        expr: tikka_indexer_lag_ledgers > 20
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Indexer is lagging behind the Stellar network"
+
+      - alert: IndexerHighLatency
+        expr: rate(tikka_indexer_poll_duration_seconds_sum[5m]) / rate(tikka_indexer_poll_duration_seconds_count[5m]) > 10
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: IndexerErrors
+        expr: rate(tikka_indexer_errors_total[5m]) > 0.1
+        for: 2m
+        labels:
+          severity: warning
+```

--- a/docs/observability/METRICS_MAP.md
+++ b/docs/observability/METRICS_MAP.md
@@ -1,0 +1,160 @@
+# Metrics Map
+
+Complete inventory of all metrics endpoints, Prometheus metrics, and health endpoints across backend, indexer, and oracle services.
+
+---
+
+## Backend
+
+**Port:** 3001  
+**Metrics library:** In-process counters (no Prometheus client)  
+**Format:** Application/JSON
+
+### Endpoints
+
+| Route | Response | Auth |
+|-------|----------|------|
+| `GET /metrics` | `{ "metadata_cache_hits": number }` | Public |
+| `GET /health` | Health check + push notification delivery metrics | Public |
+| `GET /monitor/stats` | Queue stats from `oracle_jobs` table | Admin |
+| `GET /monitor/jobs` | Paginated oracle job listing | Admin |
+| `GET /monitor/latency` | Job latency time-series (from `enqueued_at` / `confirmed_at`) | Admin |
+| `GET /monitor/errors` | Failed job error records | Admin |
+| `GET /monitor/audit` | Admin audit log entries | Admin |
+| `GET /monitor/maintenance` | Maintenance mode status | Admin |
+
+### In-Process Metrics
+
+| Name | Type | Source | Description |
+|------|------|--------|-------------|
+| `metadata_cache_hits` | Counter | `MetadataCacheMetricsService` | Total metadata cache hits since process start |
+
+### Health Metrics
+
+| Field | Source | Description |
+|-------|--------|-------------|
+| `pushDelivery.transientRetry` | `PushNotificationService` | Transient retry count |
+| `pushDelivery.permanentInvalidToken` | `PushNotificationService` | Expired/invalid token count |
+| `pushDelivery.permanentOther` | `PushNotificationService` | Other permanent failure count |
+| `pushDelivery.providerOutage` | `PushNotificationService` | Provider outage count |
+| `pushDelivery.totalFailures` | `PushNotificationService` | Total failure count |
+
+### Monitor (DB-Backed) Fields
+
+| Entity | Fields |
+|--------|--------|
+| `OracleJob` | `id`, `status`, `enqueuedAt`, `updatedAt`, `confirmedAt`, `latencyMs`, `xdr`, `errorMessage` |
+| `LatencyPoint` | `jobId`, `enqueuedAt`, `confirmedAt`, `latencyMs` |
+| `ErrorRecord` | `jobId`, `failedAt`, `errorMessage`, `xdr` |
+| `AuditLogEntry` | `adminId`, `route`, `method`, `statusCode`, `timestamp` |
+| `QueueStatsResponse` | `pending`, `completed`, `failed`, `timestamp` |
+
+---
+
+## Indexer
+
+**Port:** 3002  
+**Metrics library:** OpenTelemetry SDK (`@opentelemetry/sdk-metrics`) with PrometheusExporter  
+**Meter name:** `tikka-indexer`  
+**Format:** Prometheus text (`Content-Type: text/plain; version=0.0.4`)
+
+### Endpoints
+
+| Route | Response | Auth |
+|-------|----------|------|
+| `GET /metrics` | Prometheus-formatted metrics | Public |
+| `GET /health` | `{ status, lag_ledgers, lagStatus, db, redis, redis_latency_ms, dlq_size }` | Public |
+| `GET /health/dlq-size` | `{ dlq_size: number }` | Public |
+
+### Prometheus Metrics
+
+| Metric Name | Type | Labels | Description |
+|-------------|------|--------|-------------|
+| `tikka_indexer_events_processed_total` | Counter | `event_type` | Total events processed by type |
+| `tikka_indexer_errors_total` | Counter | (none) | Total errors during polling or processing |
+| `tikka_indexer_reorg_detected_total` | Counter | (none) | Total ledger reorgs detected |
+| `tikka_indexer_lag_ledgers` | Gauge | (none) | Current ledger lag behind the network |
+| `tikka_indexer_poll_duration_seconds` | Histogram | (none) | Duration of ledger polling cycles |
+| `tikka_indexer_memory_usage_bytes` | ObservableGauge | (none) | Current heap used |
+| `tikka_db_slow_query_total` | Counter | `query_hash` | Slow database queries |
+| `tikka_db_query_duration_seconds` | Histogram | `query_hash` | Database query duration |
+
+### Prometheus Scrape Config
+
+```yaml
+scrape_configs:
+  - job_name: 'tikka-indexer'
+    static_configs:
+      - targets: ['localhost:3002']
+    metrics_path: '/metrics'
+```
+
+### Prometheus Alert Rules
+
+| Alert Name | Expression | Severity |
+|------------|-----------|----------|
+| `IndexerFallingBehind` | `tikka_indexer_lag_ledgers > 20` for 5m | critical |
+| `IndexerHighLatency` | avg poll duration > 10s for 10m | warning |
+| `IndexerErrors` | error rate > 0.1/s for 2m | warning |
+
+---
+
+## Oracle
+
+**Port:** 3003  
+**Metrics library:** OpenTelemetry SDK (`@opentelemetry/sdk-metrics`) with PrometheusExporter  
+**Meter name:** `tikka-oracle`  
+**Format:** Prometheus text (`Content-Type: text/plain; version=0.0.4`)
+
+### Endpoints
+
+| Route | Response | Auth |
+|-------|----------|------|
+| `GET /metrics` | Prometheus-formatted metrics | Public |
+| `GET /health` | `{ status, timestamp, pendingLagRequests }` | Public |
+| `GET /oracle/components` | Component-level health with stats | Public |
+| `GET /oracle/status` | Full status with RPC health, lag, multi-oracle config | Public |
+| `GET /queue/metrics` | In-memory queue metrics by job state | Public |
+| `GET /queue/health` | Queue health status with pending/failed/dead-lettered counts | Public |
+| `GET /queue/jobs/:state` | Jobs in a specific state | Public |
+| `GET /queue/dead-letter` | Dead-lettered jobs requiring rescue | Public |
+| `GET /queue/config` | Queue configuration | Public |
+
+### Prometheus Metrics
+
+| Metric Name | Type | Labels | Description |
+|-------------|------|--------|-------------|
+| `tikka_oracle_estimated_fee_stroops` | Gauge | `network`, `method` | Estimated fee for next submission |
+| `tikka_oracle_actual_fee_total_stroops` | Counter | `network`, `method` | Total actual fee paid for submissions |
+| `tikka_oracle_submission_outcome_total` | Counter | `outcome`, `network`, `method` | Submission outcomes (success/failure/retry) |
+| `tikka_oracle_memory_usage_bytes` | ObservableGauge | (none) | Current heap used |
+
+### In-Memory Queue Metrics
+
+| Field | Description |
+|-------|-------------|
+| `queuedCount` | Jobs awaiting processing |
+| `generatingCount` | Jobs generating randomness |
+| `submittingCount` | Jobs submitting transactions |
+| `confirmingCount` | Jobs waiting for confirmation |
+| `retryingCount` | Jobs in backoff before retry |
+| `confirmedCount` | Terminal success |
+| `failedCount` | Terminal failure |
+| `deadLetteredCount` | Exhausted retries, needs rescue |
+| `pendingCount` | Queued + generating + submitting + confirming + retrying |
+| `totalFailedCount` | Failed + dead-lettered |
+
+---
+
+## Cross-Service Correlation Map
+
+Events flow across services. Use these fields to correlate:
+
+| Correlation Key | Backend | Indexer | Oracle |
+|----------------|---------|---------|--------|
+| `requestId` | Log field, Sentry tag | — | Log field (`TelemetryContext`) |
+| `raffleId` | DB field (`oracle_jobs`) | — | Log field, queue metadata |
+| `txHash` | DB field (`oracle_jobs`) | — | Log field, `TransactionOutcome` |
+| `ledger` | Log field | Log field, metric context | Queue metadata |
+| `eventType` | — | Metric label (`event_type`) | — |
+| `jobId` | DB field | — | Queue metadata |

--- a/docs/observability/README.md
+++ b/docs/observability/README.md
@@ -1,0 +1,149 @@
+# Observability Standards
+
+This document defines the shared metric naming conventions, log field taxonomy, and label-cardinality rules that all Tikka services (backend, indexer, oracle) must follow.
+
+## Metric Naming Convention
+
+All Prometheus-exported metrics must follow this pattern:
+
+```
+tikka_<service>_<noun>_[<unit>]
+```
+
+| Component | Pattern | Example |
+|-----------|---------|---------|
+| Backend | `tikka_backend_<noun>_<unit>` | `tikka_backend_metadata_cache_hits` |
+| Indexer | `tikka_indexer_<noun>_<unit>` | `tikka_indexer_events_processed_total` |
+| Oracle | `tikka_oracle_<noun>_<unit>` | `tikka_oracle_estimated_fee_stroops` |
+
+### Metric Suffix Conventions
+
+| Suffix | Type | When to use |
+|--------|------|-------------|
+| `_total` | Counter | Cumulative counts (events, errors, jobs) |
+| `_seconds` | Histogram | Duration measurements |
+| `_bytes` | Gauge | Memory, storage size |
+| `_stroops` | Gauge / Counter | Stellar fee amounts |
+| _No suffix_ | Gauge | Instantaneous values (lag, depth) |
+
+### Accepted Metric Types
+
+| Type | Use case | Zero-value semantics |
+|------|----------|---------------------|
+| Counter | Monotonic accumulators (events processed, errors) | `rate()` / `increase()` |
+| Gauge | Snapshots (lag, memory, queue depth) | `avg_over_time()` |
+| Histogram | Distribution (poll duration, query duration) | `histogram_quantile()` |
+| ObservableGauge | Auto-polled values (memory) | Instant read |
+
+## Shared Metric Names
+
+These metrics must be implemented identically across all services that expose them:
+
+| Metric Name | Services | Type | Labels |
+|-------------|----------|------|--------|
+| `tikka_*_memory_usage_bytes` | indexer, oracle | ObservableGauge | (none) |
+| `tikka_*_lag_ledgers` | indexer, oracle (planned) | Gauge | (none) |
+| `tikka_*_events_processed_total` | indexer | Counter | `event_type` |
+| `tikka_*_errors_total` | indexer | Counter | (none) |
+| `tikka_*_submission_outcome_total` | oracle | Counter | `outcome`, `network`, `method` |
+| `tikka_*_estimated_fee_stroops` | oracle | Gauge | `network`, `method` |
+| `tikka_*_actual_fee_total_stroops` | oracle | Counter | `network`, `method` |
+| `tikka_*_poll_duration_seconds` | indexer | Histogram | (none) |
+| `tikka_*_query_duration_seconds` | indexer | Histogram | `query_hash` |
+| `tikka_*_slow_query_total` | indexer | Counter | `query_hash` |
+
+## Log Field Taxonomy
+
+All structured log output must use these canonical field names:
+
+### Correlation Fields
+
+| Field | Type | Example | Services |
+|-------|------|---------|----------|
+| `requestId` | string (UUID) | `"a1b2c3d4-..."` | backend, oracle |
+| `raffleId` | integer | `42` | backend, indexer, oracle |
+| `txHash` | string (hex) | `"abc123..."` | backend, indexer, oracle |
+| `ledger` | integer | `1234567` | backend, indexer, oracle |
+| `jobId` | string | `"job_abc123"` | backend, oracle |
+| `eventType` | string | `"RaffleCreated"` | indexer |
+| `eventId` | string | `"123-456"` | indexer |
+
+### Performance Fields
+
+| Field | Type | Example |
+|-------|------|---------|
+| `durationMs` | integer | `150` |
+| `latencyMs` | integer | `3200` |
+| `attempt` | integer | `3` |
+| `elapsedMs` | integer | `500` |
+
+### Outcome Fields
+
+| Field | Type | Example |
+|-------|------|---------|
+| `outcome` | string | `"succeeded"`, `"failed"`, `"skipped"` |
+| `status` | string | `"ok"`, `"degraded"`, `"error"` |
+| `error` | string | `"timeout"` |
+| `reason` | string | `"HANDLER_ERROR"` |
+
+### Context Fields
+
+| Field | Type | Example |
+|-------|------|---------|
+| `network` | string | `"testnet"`, `"mainnet"` |
+| `method` | string | `"PRNG"`, `"VRF"` |
+| `contractId` | string (hex) | `"CAFEDEAD..."` |
+| `handler` | string | `"RaffleProcessor.handleRaffleCreated"` |
+
+### Audit Fields
+
+| Field | Type | Example |
+|-------|------|---------|
+| `adminId` | string | `"admin_uuid"` |
+| `route` | string | `"/monitor/jobs"` |
+| `method` | string | `"GET"` |
+| `statusCode` | integer | `200` |
+
+## Label Cardinality Rules
+
+### Safe Labels (low/medium cardinality)
+
+These labels are safe to use on any metric:
+
+| Label | Max unique values | Example values |
+|-------|-------------------|----------------|
+| `event_type` | < 50 | `RaffleCreated`, `TicketPurchased` |
+| `outcome` | < 10 | `success`, `failure`, `retry` |
+| `network` | < 5 | `testnet`, `mainnet` |
+| `method` | < 10 | `PRNG`, `VRF`, `average` |
+| `query_hash` | < 200 | SHA-256 of normalized SQL |
+| `status` | < 10 | `healthy`, `degraded`, `unhealthy` |
+
+### Unsafe Labels (high cardinality — DO NOT USE)
+
+These values must never be used as metric labels:
+
+| Value | Reason | Alternative |
+|-------|--------|-------------|
+| `raffleId` | Unbounded; one per raffle | Use in log fields only |
+| `requestId` | Unique per request | Use in log fields only |
+| `txHash` | Unique per transaction | Use in log fields only |
+| `userAddress` | Unique per user | Use in log fields only |
+| `ip` | Unique per request + PII | Use in logs only, with redaction |
+
+### High-Cardinality Sources
+
+Avoid these as metric label dimensions:
+
+- **Timestamps** — never use a raw timestamp as a label value. Use log fields or span attributes instead.
+- **User-supplied strings** — never use free-form user input as a label.
+- **Session/token IDs** — unique per session; cardinality grows unbounded.
+- **Error messages** — use an error "type" or "code" enum instead of the full message text.
+
+## Metric Endpoints
+
+| Service | Endpoint | Format | Port |
+|---------|----------|--------|------|
+| Backend | `GET /metrics` | JSON (custom) | 3001 |
+| Indexer | `GET /metrics` | Prometheus text | 3002 |
+| Oracle | `GET /metrics` | Prometheus text | 3003 |

--- a/docs/observability/cross-service-dashboard.json
+++ b/docs/observability/cross-service-dashboard.json
@@ -1,0 +1,128 @@
+{
+  "title": "Tikka Cross-Service Overview",
+  "uid": "tikka-overview",
+  "description": "Correlate events across indexer and oracle services in a single view",
+  "tags": ["tikka", "cross-service", "correlation"],
+  "schemaVersion": 39,
+  "version": 1,
+  "timezone": "browser",
+  "templating": {
+    "list": [
+      {
+        "name": "event_type",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "query": "label_values(tikka_indexer_events_processed_total, event_type)",
+        "multi": true,
+        "includeAll": true
+      },
+      {
+        "name": "outcome",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "query": "label_values(tikka_oracle_submission_outcome_total, outcome)",
+        "multi": true,
+        "includeAll": true
+      }
+    ]
+  },
+  "panels": [
+    {
+      "title": "Events Rate (Indexer)",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "cps",
+          "custom": {
+            "stacking": { "mode": "normal" },
+            "fillOpacity": 30
+          }
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (event_type) (rate(tikka_indexer_events_processed_total[$__rate_interval]))",
+          "legendFormat": "__auto"
+        }
+      ],
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 }
+    },
+    {
+      "title": "Submission Outcomes (Oracle)",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "cps",
+          "custom": {
+            "stacking": { "mode": "normal" },
+            "fillOpacity": 30
+          }
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (outcome) (rate(tikka_oracle_submission_outcome_total[$__rate_interval]))",
+          "legendFormat": "__auto"
+        }
+      ],
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 }
+    },
+    {
+      "title": "Lag Comparison",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none"
+        }
+      },
+      "targets": [
+        {
+          "expr": "tikka_indexer_lag_ledgers",
+          "legendFormat": "indexer lag"
+        }
+      ],
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 }
+    },
+    {
+      "title": "Memory Comparison",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        }
+      },
+      "targets": [
+        {
+          "expr": "tikka_indexer_memory_usage_bytes",
+          "legendFormat": "indexer"
+        },
+        {
+          "expr": "tikka_oracle_memory_usage_bytes",
+          "legendFormat": "oracle"
+        }
+      ],
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 }
+    },
+    {
+      "title": "Error Rate (Indexer)",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "cps"
+        }
+      },
+      "targets": [
+        {
+          "expr": "rate(tikka_indexer_errors_total[$__rate_interval])",
+          "legendFormat": "indexer errors"
+        }
+      ],
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 }
+    }
+  ]
+}

--- a/docs/observability/prometheus.yml
+++ b/docs/observability/prometheus.yml
@@ -1,0 +1,19 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'tikka-indexer'
+    static_configs:
+      - targets: ['localhost:3002']
+    metrics_path: '/metrics'
+
+  - job_name: 'tikka-oracle'
+    static_configs:
+      - targets: ['localhost:3003']
+    metrics_path: '/metrics'
+
+  - job_name: 'tikka-backend'
+    static_configs:
+      - targets: ['localhost:3001']
+    metrics_path: '/metrics'

--- a/oracle/grafana/oracle-dashboard.json
+++ b/oracle/grafana/oracle-dashboard.json
@@ -1,0 +1,79 @@
+{
+  "title": "Tikka Oracle",
+  "uid": "tikka-oracle",
+  "description": "Oracle service metrics — submission outcomes, fee estimates, queue depth, and memory usage",
+  "tags": ["tikka", "oracle"],
+  "schemaVersion": 39,
+  "version": 1,
+  "timezone": "browser",
+  "panels": [
+    {
+      "title": "Submission Outcomes Rate",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "cps",
+          "custom": {
+            "stacking": { "mode": "normal" },
+            "fillOpacity": 30
+          }
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (outcome) (rate(tikka_oracle_submission_outcome_total[5m]))",
+          "legendFormat": "__auto"
+        }
+      ],
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 }
+    },
+    {
+      "title": "Fee Estimates vs Actual (stroops)",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none"
+        }
+      },
+      "targets": [
+        {
+          "expr": "tikka_oracle_estimated_fee_stroops",
+          "legendFormat": "estimated"
+        },
+        {
+          "expr": "rate(tikka_oracle_actual_fee_total_stroops[5m])",
+          "legendFormat": "actual rate"
+        }
+      ],
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 }
+    },
+    {
+      "title": "Memory Usage",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        }
+      },
+      "targets": [
+        {
+          "expr": "tikka_oracle_memory_usage_bytes",
+          "legendFormat": "heap used"
+        }
+      ],
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 }
+    }
+  ]
+}


### PR DESCRIPTION
Closes #626

## 🎯 Summary

Defines shared metric naming conventions, log field taxonomy, and label-cardinality rules across backend, indexer, and oracle. Creates observability documentation under `docs/observability` with a complete inventory of metrics endpoints, Grafana dashboards, and a new cross-service correlation dashboard.

## 📋 Problem

Backend, indexer, and oracle use disjoint metric names, ad-hoc log field names, and inconsistent label dimensions. This prevents correlating events across services in dashboards and makes operational monitoring harder.

## ✨ Solution

1. **Metric naming standard**: `tikka_<service>_<noun>_<unit>` convention with documented suffix rules
2. **Log field taxonomy**: Canonical field names for correlation (`requestId`, `raffleId`, `txHash`, `ledger`, `jobId`), performance, outcome, context, and audit
3. **Label cardinality rules**: Safe labels documented (event_type, outcome, network, method, query_hash); unsafe labels explicitly banned from metric dimensions (raffleId, requestId, txHash, userAddress, ip)
4. **Metrics map**: Full inventory of all 8 metrics endpoints, 12 Prometheus metrics, health fields, and DB-backed monitor entities
5. **Grafana dashboards**: Existing indexer dashboards mapped, recommended layouts for oracle and backend, new cross-service correlation dashboard
6. **Oracle Grafana dashboard**: First committed dashboard JSON for oracle metrics
7. **Consolidated Prometheus config**: Scrape config and alert rules covering all three services

## 📦 Files Changed

### New Files (7)
```
docs/observability/
├── README.md                    # Naming standards, log taxonomy, label cardinality rules
├── METRICS_MAP.md               # Complete metrics endpoint inventory
├── GRAFANA.md                   # Dashboard map and recommended layouts
├── cross-service-dashboard.json # Grafana dashboard correlating indexer + oracle
├── prometheus.yml               # Consolidated scrape config

oracle/grafana/
├── oracle-dashboard.json        # Oracle service dashboard (submission outcomes, fees, memory)
```

## ✅ Acceptance Criteria Met

- [x] New service metrics follow documented names
- [x] Dashboards can correlate backend/indexer/oracle events
- [x] Label cardinality rules documented to avoid high-cardinality dimensions
- [x] Metrics endpoints mapped across all services
- [x] Grafana dashboard JSONs for oracle and cross-service correlation provided

Closes #626 