### PR TITLE
feat(auth): implement refresh token family tracking and sign-out

### DIFF
--- a/backend/database/migrations/011_refresh_token_families.sql
+++ b/backend/database/migrations/011_refresh_token_families.sql
@@ -1,0 +1,14 @@
+-- 011_refresh_token_families.sql
+-- Adds token family tracking to refresh_tokens for reuse-detection and family revocation.
+-- Run this in Supabase SQL Editor after 006_refresh_tokens.sql.
+
+-- Add family_id column: groups all tokens issued from the same login session.
+-- On reuse of a superseded token, the entire family is revoked.
+ALTER TABLE refresh_tokens
+  ADD COLUMN IF NOT EXISTS family_id TEXT NOT NULL DEFAULT gen_random_uuid()::TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_refresh_tokens_family_id ON refresh_tokens(family_id);
+
+COMMENT ON COLUMN refresh_tokens.family_id IS
+  'UUID grouping all rotated tokens from a single login session. '
+  'Reuse of a superseded token triggers revocation of the whole family.';

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -17,8 +17,10 @@ import {
   GetNonceQuerySchema,
   VerifyBodySchema,
   RefreshBodySchema,
+  SignOutBodySchema,
   VerifyBodyDto,
   RefreshBodyDto,
+  SignOutBodyDto,
 } from "./auth.schema";
 
 @ApiTags("Authentication")
@@ -90,6 +92,28 @@ export class AuthController {
     } catch (err) {
       throw new BadRequestException(
         err instanceof Error ? err.message : "Refresh failed",
+      );
+    }
+  }
+
+  /**
+   * POST /auth/sign-out — Revoke the current refresh token family (sign out).
+   *
+   * Rate limit: 10 req / 60 s per IP.
+   */
+  @Throttle({ auth: { limit: 10, ttl: 60000 } })
+  @Post("sign-out")
+  @ApiOperation({ summary: "Revoke refresh token family and sign out" })
+  @ApiResponse({ status: 201, description: "Session revoked" })
+  @ApiResponse({ status: 400, description: "Sign-out failed" })
+  @UsePipes(new (createZodPipe(SignOutBodySchema))())
+  async signOut(@Body() body: SignOutBodyDto) {
+    try {
+      await this.authService.signOut(body.refreshToken);
+      return { message: "Signed out" };
+    } catch (err) {
+      throw new BadRequestException(
+        err instanceof Error ? err.message : "Sign-out failed",
       );
     }
   }

--- a/backend/src/auth/auth.schema.ts
+++ b/backend/src/auth/auth.schema.ts
@@ -44,3 +44,14 @@ export class RefreshBodyDto {
   @ApiProperty({ description: "Refresh token previously issued by the server" })
   refreshToken: string;
 }
+
+export const SignOutBodySchema = z.object({
+  refreshToken: z
+    .string({ required_error: "refreshToken is required" })
+    .min(1, "refreshToken cannot be empty"),
+});
+
+export class SignOutBodyDto {
+  @ApiProperty({ description: "Refresh token to revoke (signs out the session)" })
+  refreshToken: string;
+}

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -5,11 +5,58 @@ import { SiwsService } from './siws.service';
 import { SUPABASE_CLIENT } from '../services/supabase.provider';
 import { env } from '../config/env.config';
 
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const ADDRESS = 'GABC123';
+const FAMILY_ID = 'test-family-id';
+const RAW_TOKEN = 'raw-refresh-token';
+const TOKEN_HASH = 'hashed-token';
+
+function makeTokenRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 1,
+    user_address: ADDRESS,
+    token_hash: TOKEN_HASH,
+    revoked: false,
+    family_id: FAMILY_ID,
+    expires_at: new Date(Date.now() + 86_400_000).toISOString(),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
 describe('AuthService', () => {
   let service: AuthService;
   let jwtService: jest.Mocked<JwtService>;
   let siwsService: jest.Mocked<SiwsService>;
-  let supabaseClient: any;
+  let supabase: any;
+
+  // Chainable Supabase query builder mock
+  function makeQueryBuilder(terminal: () => Promise<any>) {
+    const builder: any = {
+      select: jest.fn().mockReturnThis(),
+      insert: jest.fn().mockReturnThis(),
+      update: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      maybeSingle: jest.fn().mockImplementation(terminal),
+      // update().eq().eq() chains resolve via the last eq
+    };
+    // Make update chains resolve via a then-able
+    builder.update.mockImplementation(() => {
+      const updateChain: any = {
+        eq: jest.fn().mockReturnThis(),
+        then: (resolve: any) => resolve({ error: null }),
+      };
+      return updateChain;
+    });
+    return builder;
+  }
 
   beforeEach(async () => {
     jwtService = {
@@ -22,14 +69,15 @@ describe('AuthService', () => {
       verify: jest.fn().mockReturnValue(true),
     } as any;
 
-    supabaseClient = {
+    // Default supabase mock — individual tests override as needed.
+    supabase = {
       from: jest.fn().mockReturnThis(),
-      insert: jest.fn().mockResolvedValue({ error: null }),
       select: jest.fn().mockReturnThis(),
+      insert: jest.fn().mockResolvedValue({ error: null }),
+      update: jest.fn().mockReturnThis(),
       eq: jest.fn().mockReturnThis(),
       limit: jest.fn().mockReturnThis(),
-      maybeSingle: jest.fn(),
-      update: jest.fn().mockReturnThis(),
+      maybeSingle: jest.fn().mockResolvedValue({ data: null, error: null }),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -37,85 +85,304 @@ describe('AuthService', () => {
         AuthService,
         { provide: JwtService, useValue: jwtService },
         { provide: SiwsService, useValue: siwsService },
-        { provide: SUPABASE_CLIENT, useValue: supabaseClient },
+        { provide: SUPABASE_CLIENT, useValue: supabase },
       ],
     }).compile();
 
     service = module.get<AuthService>(AuthService);
+
+    // Spy on private hashToken to return a predictable value.
+    jest.spyOn(service as any, 'hashToken').mockReturnValue(TOKEN_HASH);
   });
 
+  afterEach(() => jest.clearAllMocks());
+
+  // -------------------------------------------------------------------------
+  // getNonce
+  // -------------------------------------------------------------------------
+
   describe('getNonce', () => {
-    it('should generate and store a nonce', async () => {
-      const address = 'GABC123';
-      const result = await service.getNonce(address);
+    it('generates and stores a nonce', async () => {
+      const result = await service.getNonce(ADDRESS);
 
       expect(result).toHaveProperty('nonce');
       expect(result).toHaveProperty('expiresAt');
       expect(result).toHaveProperty('issuedAt');
-      expect(supabaseClient.from).toHaveBeenCalledWith('siws_nonces');
-      expect(supabaseClient.insert).toHaveBeenCalled();
+      expect(result).toHaveProperty('message');
+      expect(supabase.from).toHaveBeenCalledWith('siws_nonces');
+      expect(supabase.insert).toHaveBeenCalled();
+    });
+
+    it('throws when DB insert fails', async () => {
+      supabase.insert.mockResolvedValueOnce({ error: new Error('db error') });
+      await expect(service.getNonce(ADDRESS)).rejects.toThrow('Failed to store nonce');
     });
   });
 
-  describe('verify', () => {
-    const address = 'GABC123';
-    const nonce = 'mock-nonce';
-    const signature = 'mock-signature';
-    const issuedAt = new Date().toISOString();
-    const expiresAt = new Date(Date.now() + 300000).toISOString();
+  // -------------------------------------------------------------------------
+  // verify
+  // -------------------------------------------------------------------------
 
-    it('should verify a valid signature and mark nonce as consumed', async () => {
-      supabaseClient.maybeSingle.mockResolvedValue({
-        data: { id: 1, address, nonce, issued_at: issuedAt, expires_at: expiresAt, consumed: false },
+  describe('verify', () => {
+    const nonce = 'mock-nonce';
+    const signature = 'mock-sig';
+    const issuedAt = new Date().toISOString();
+    const expiresAt = new Date(Date.now() + 300_000).toISOString();
+
+    function setupNonce(overrides: Record<string, unknown> = {}) {
+      supabase.maybeSingle.mockResolvedValueOnce({
+        data: { id: 1, address: ADDRESS, nonce, issued_at: issuedAt, expires_at: expiresAt, consumed: false, ...overrides },
         error: null,
       });
-      supabaseClient.update.mockReturnValue({ eq: jest.fn().mockResolvedValue({ error: null }) });
+      // nonce update
+      supabase.update.mockReturnValueOnce({ eq: jest.fn().mockResolvedValue({ error: null }) });
+      // refresh token insert (issueTokens)
+      supabase.insert.mockResolvedValueOnce({ error: null });
+    }
 
-      const result = await service.verify(address, signature, nonce, issuedAt);
-
+    it('verifies a valid signature and issues tokens', async () => {
+      setupNonce();
+      const result = await service.verify(ADDRESS, signature, nonce, issuedAt);
       expect(result).toHaveProperty('accessToken');
-      expect(supabaseClient.update).toHaveBeenCalledWith({ consumed: true });
+      expect(result).toHaveProperty('refreshToken');
     });
 
-    it('should throw error if nonce is already consumed', async () => {
-      // maybeSingle returns null if no match (due to .eq('consumed', false))
-      supabaseClient.maybeSingle.mockResolvedValue({ data: null, error: null });
-
-      await expect(service.verify(address, signature, nonce, issuedAt))
+    it('throws when nonce is not found', async () => {
+      supabase.maybeSingle.mockResolvedValueOnce({ data: null, error: null });
+      await expect(service.verify(ADDRESS, signature, nonce, issuedAt))
         .rejects.toThrow('Invalid or expired nonce');
     });
 
-    it('should throw error if nonce is expired (absolute)', async () => {
-      const pastExpiresAt = new Date(Date.now() - 1000).toISOString();
-      supabaseClient.maybeSingle.mockResolvedValue({
-        data: { id: 1, address, nonce, issued_at: issuedAt, expires_at: pastExpiresAt, consumed: false },
-        error: null,
-      });
-
-      await expect(service.verify(address, signature, nonce, issuedAt))
+    it('throws when nonce is expired (absolute)', async () => {
+      setupNonce({ expires_at: new Date(Date.now() - 1000).toISOString() });
+      await expect(service.verify(ADDRESS, signature, nonce, issuedAt))
         .rejects.toThrow('Nonce expired');
     });
 
-    it('should throw error if nonce is expired (relative TTL)', async () => {
+    it('throws when nonce is expired (relative TTL)', async () => {
       const oldIssuedAt = new Date(Date.now() - (env.siws.nonceTtlSeconds + 10) * 1000).toISOString();
-      supabaseClient.maybeSingle.mockResolvedValue({
-        data: { id: 1, address, nonce, issued_at: oldIssuedAt, expires_at: expiresAt, consumed: false },
-        error: null,
-      });
-
-      await expect(service.verify(address, signature, nonce, oldIssuedAt))
+      setupNonce({ issued_at: oldIssuedAt });
+      await expect(service.verify(ADDRESS, signature, nonce, oldIssuedAt))
         .rejects.toThrow('Nonce expired');
     });
 
-    it('should throw error if signature is invalid', async () => {
-      supabaseClient.maybeSingle.mockResolvedValue({
-        data: { id: 1, address, nonce, issued_at: issuedAt, expires_at: expiresAt, consumed: false },
+    it('throws when signature is invalid', async () => {
+      setupNonce();
+      siwsService.verify.mockReturnValueOnce(false);
+      await expect(service.verify(ADDRESS, signature, nonce, issuedAt))
+        .rejects.toThrow('Invalid signature');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // refresh — normal rotation
+  // -------------------------------------------------------------------------
+
+  describe('refresh — normal rotation', () => {
+    it('issues new tokens and revokes the old token row', async () => {
+      jwtService.verify.mockReturnValue({ address: ADDRESS, type: 'refresh' } as any);
+
+      // First maybeSingle: token lookup
+      supabase.maybeSingle.mockResolvedValueOnce({
+        data: makeTokenRow(),
         error: null,
       });
-      siwsService.verify.mockReturnValue(false);
 
-      await expect(service.verify(address, signature, nonce, issuedAt))
-        .rejects.toThrow('Invalid signature');
+      // update (revoke old token) — chainable
+      const revokeChain = { eq: jest.fn().mockReturnThis(), then: (r: any) => r({ error: null }) };
+      supabase.update.mockReturnValueOnce(revokeChain);
+
+      // insert (store new token)
+      supabase.insert.mockResolvedValueOnce({ error: null });
+
+      const result = await service.refresh(RAW_TOKEN);
+
+      expect(result).toHaveProperty('accessToken');
+      expect(result).toHaveProperty('refreshToken');
+      // Old token should have been marked revoked
+      expect(supabase.update).toHaveBeenCalled();
+    });
+
+    it('preserves the same family_id across rotations', async () => {
+      jwtService.verify.mockReturnValue({ address: ADDRESS, type: 'refresh' } as any);
+
+      supabase.maybeSingle.mockResolvedValueOnce({
+        data: makeTokenRow({ family_id: FAMILY_ID }),
+        error: null,
+      });
+
+      const revokeChain = { eq: jest.fn().mockReturnThis(), then: (r: any) => r({ error: null }) };
+      supabase.update.mockReturnValueOnce(revokeChain);
+
+      let insertedRow: any;
+      supabase.insert.mockImplementationOnce((rows: any[]) => {
+        insertedRow = rows[0];
+        return Promise.resolve({ error: null });
+      });
+
+      await service.refresh(RAW_TOKEN);
+
+      expect(insertedRow?.family_id).toBe(FAMILY_ID);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // refresh — reuse detection
+  // -------------------------------------------------------------------------
+
+  describe('refresh — reuse detection', () => {
+    it('revokes the entire family when a superseded token is reused', async () => {
+      jwtService.verify.mockReturnValue({ address: ADDRESS, type: 'refresh' } as any);
+
+      // Token is already revoked (superseded)
+      supabase.maybeSingle.mockResolvedValueOnce({
+        data: makeTokenRow({ revoked: true }),
+        error: null,
+      });
+
+      // Family revocation update
+      const familyRevokeChain = { eq: jest.fn().mockReturnThis(), then: (r: any) => r({ error: null }) };
+      supabase.update.mockReturnValueOnce(familyRevokeChain);
+
+      await expect(service.refresh(RAW_TOKEN))
+        .rejects.toThrow('Refresh token reuse detected — session revoked');
+
+      // Verify family revocation was attempted
+      expect(supabase.update).toHaveBeenCalled();
+    });
+
+    it('does not leak token values in the reuse error message', async () => {
+      jwtService.verify.mockReturnValue({ address: ADDRESS, type: 'refresh' } as any);
+
+      supabase.maybeSingle.mockResolvedValueOnce({
+        data: makeTokenRow({ revoked: true }),
+        error: null,
+      });
+
+      const familyRevokeChain = { eq: jest.fn().mockReturnThis(), then: (r: any) => r({ error: null }) };
+      supabase.update.mockReturnValueOnce(familyRevokeChain);
+
+      let thrownError: Error | undefined;
+      try {
+        await service.refresh(RAW_TOKEN);
+      } catch (e) {
+        thrownError = e as Error;
+      }
+
+      expect(thrownError).toBeDefined();
+      // Error message must not contain the raw token or its hash
+      expect(thrownError!.message).not.toContain(RAW_TOKEN);
+      expect(thrownError!.message).not.toContain(TOKEN_HASH);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // refresh — revoked / expired / unknown token
+  // -------------------------------------------------------------------------
+
+  describe('refresh — invalid token states', () => {
+    it('throws when token is not found in DB', async () => {
+      jwtService.verify.mockReturnValue({ address: ADDRESS, type: 'refresh' } as any);
+      supabase.maybeSingle.mockResolvedValueOnce({ data: null, error: null });
+
+      await expect(service.refresh(RAW_TOKEN)).rejects.toThrow('Refresh token not found');
+    });
+
+    it('throws when token is expired', async () => {
+      jwtService.verify.mockReturnValue({ address: ADDRESS, type: 'refresh' } as any);
+      supabase.maybeSingle.mockResolvedValueOnce({
+        data: makeTokenRow({ expires_at: new Date(Date.now() - 1000).toISOString() }),
+        error: null,
+      });
+
+      await expect(service.refresh(RAW_TOKEN)).rejects.toThrow('Refresh token expired');
+    });
+
+    it('throws when JWT signature is invalid', async () => {
+      jwtService.verify.mockImplementationOnce(() => { throw new Error('jwt malformed'); });
+
+      await expect(service.refresh(RAW_TOKEN)).rejects.toThrow('Invalid refresh token');
+    });
+
+    it('throws when token payload type is not refresh', async () => {
+      jwtService.verify.mockReturnValue({ address: ADDRESS, type: 'access' } as any);
+
+      await expect(service.refresh(RAW_TOKEN)).rejects.toThrow('Invalid refresh token payload');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // signOut
+  // -------------------------------------------------------------------------
+
+  describe('signOut', () => {
+    it('revokes the token family on sign-out', async () => {
+      jwtService.verify.mockReturnValue({ address: ADDRESS, type: 'refresh' } as any);
+
+      supabase.maybeSingle.mockResolvedValueOnce({
+        data: { family_id: FAMILY_ID },
+        error: null,
+      });
+
+      const familyRevokeChain = { eq: jest.fn().mockReturnThis(), then: (r: any) => r({ error: null }) };
+      supabase.update.mockReturnValueOnce(familyRevokeChain);
+
+      await expect(service.signOut(RAW_TOKEN)).resolves.toBeUndefined();
+      expect(supabase.update).toHaveBeenCalled();
+    });
+
+    it('is idempotent when token is not found', async () => {
+      jwtService.verify.mockReturnValue({ address: ADDRESS, type: 'refresh' } as any);
+      supabase.maybeSingle.mockResolvedValueOnce({ data: null, error: null });
+
+      // Should not throw
+      await expect(service.signOut(RAW_TOKEN)).resolves.toBeUndefined();
+    });
+
+    it('still attempts revocation when JWT is expired', async () => {
+      // JWT verify throws (expired token) but we still look up by hash
+      jwtService.verify.mockImplementationOnce(() => { throw new Error('jwt expired'); });
+
+      supabase.maybeSingle.mockResolvedValueOnce({
+        data: { family_id: FAMILY_ID },
+        error: null,
+      });
+
+      const familyRevokeChain = { eq: jest.fn().mockReturnThis(), then: (r: any) => r({ error: null }) };
+      supabase.update.mockReturnValueOnce(familyRevokeChain);
+
+      await expect(service.signOut(RAW_TOKEN)).resolves.toBeUndefined();
+      expect(supabase.update).toHaveBeenCalled();
+    });
+
+    it('throws when no token is provided', async () => {
+      await expect(service.signOut('')).rejects.toThrow('Refresh token required');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Token value logging safeguard
+  // -------------------------------------------------------------------------
+
+  describe('sensitive value logging', () => {
+    it('does not log raw token values on invalid token error', async () => {
+      const logSpy = jest.spyOn((service as any).logger, 'warn').mockImplementation(() => {});
+
+      jwtService.verify.mockReturnValue({ address: ADDRESS, type: 'refresh' } as any);
+      supabase.maybeSingle.mockResolvedValueOnce({
+        data: makeTokenRow({ revoked: true }),
+        error: null,
+      });
+      const familyRevokeChain = { eq: jest.fn().mockReturnThis(), then: (r: any) => r({ error: null }) };
+      supabase.update.mockReturnValueOnce(familyRevokeChain);
+
+      try { await service.refresh(RAW_TOKEN); } catch { /* expected */ }
+
+      for (const call of logSpy.mock.calls) {
+        const logLine = String(call[0]);
+        expect(logLine).not.toContain(RAW_TOKEN);
+        expect(logLine).not.toContain(TOKEN_HASH);
+      }
     });
   });
 });

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Inject } from '@nestjs/common';
+import { Injectable, Inject, Logger } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { randomBytes, createHmac } from 'crypto';
 import { SiwsService } from './siws.service';
@@ -8,6 +8,7 @@ import { env } from '../config/env.config';
 
 @Injectable()
 export class AuthService {
+  private readonly logger = new Logger(AuthService.name);
   private readonly NONCE_TTL_MS = env.siws.nonceTtlSeconds * 1000;
 
   constructor(
@@ -15,6 +16,10 @@ export class AuthService {
     private readonly siwsService: SiwsService,
     @Inject(SUPABASE_CLIENT) private readonly client: SupabaseClient,
   ) {}
+
+  // ---------------------------------------------------------------------------
+  // Nonce
+  // ---------------------------------------------------------------------------
 
   /**
    * Generate nonce for SIWS.
@@ -45,13 +50,12 @@ export class AuthService {
       throw new Error('Failed to store nonce');
     }
 
-    return {
-      nonce,
-      expiresAt,
-      issuedAt,
-      message,
-    };
+    return { nonce, expiresAt, issuedAt, message };
   }
+
+  // ---------------------------------------------------------------------------
+  // Verify (SIWS sign-in)
+  // ---------------------------------------------------------------------------
 
   /**
    * Verify SIWS signature against the SIWS message and issue JWT.
@@ -88,11 +92,7 @@ export class AuthService {
       throw new Error('Nonce expired');
     }
 
-    const message = this.siwsService.buildMessage(
-      address,
-      nonce,
-      messageIssuedAt,
-    );
+    const message = this.siwsService.buildMessage(address, nonce, messageIssuedAt);
 
     if (!signature || !this.siwsService.verify(address, message, signature)) {
       throw new Error('Invalid signature');
@@ -107,83 +107,55 @@ export class AuthService {
       throw new Error('Failed to invalidate nonce');
     }
 
-    // issue both access + refresh tokens and persist refresh token hash
-    return await this.issueTokens(address);
+    return this.issueTokens(address);
   }
 
-  private signAccessToken(address: string) {
-    const payload = { address };
-    return this.jwtService.sign(payload, { expiresIn: env.jwt.expiresIn });
-  }
+  // ---------------------------------------------------------------------------
+  // Token issuance
+  // ---------------------------------------------------------------------------
 
-  private signRefreshToken(address: string) {
-    const payload = { address, type: 'refresh' };
-    return this.jwtService.sign(payload, {
-      expiresIn: env.jwt.refreshExpiresIn,
-    });
-  }
-
-  private hashToken(token: string) {
-    return createHmac('sha256', env.jwt.secret).update(token).digest('hex');
-  }
-
-  private async storeRefreshHash(
-    userAddress: string,
-    tokenHash: string,
-    expiresAtIso: string,
-  ) {
-    // Upsert a refresh token row: allow multiple active tokens per user if desired.
-    const { error } = await this.client.from('refresh_tokens').insert(
-      [
-        {
-          user_address: userAddress,
-          token_hash: tokenHash,
-          created_at: new Date().toISOString(),
-          last_used_at: new Date().toISOString(),
-          expires_at: expiresAtIso,
-          revoked: false,
-        },
-      ]
-    );
-
-    if (error) {
-      throw new Error('Failed to persist refresh token');
-    }
-  }
-
-  async issueTokens(address: string): Promise<{ accessToken: string; refreshToken: string }> {
+  async issueTokens(
+    address: string,
+    familyId?: string,
+  ): Promise<{ accessToken: string; refreshToken: string }> {
     const accessToken = this.signAccessToken(address);
     const refreshToken = this.signRefreshToken(address);
 
-    // compute expiry for refresh token record
     const now = new Date();
-    // Parse refreshExpiresIn like '30d' or '7d' or seconds; for simplicity support days only
-    const match = String(env.jwt.refreshExpiresIn).match(/(\d+)d$/);
-    let expiresAt = new Date(now.getTime());
+    const match = String(env.jwt.refreshExpiresIn).match(/^(\d+)d$/);
+    const expiresAt = new Date(now);
     if (match) {
       expiresAt.setDate(expiresAt.getDate() + parseInt(match[1], 10));
     } else {
-      // fallback: 30 days
       expiresAt.setDate(expiresAt.getDate() + 30);
     }
 
     const tokenHash = this.hashToken(refreshToken);
-    await this.storeRefreshHash(address, tokenHash, expiresAt.toISOString());
+    // Use provided familyId (rotation) or generate a new one (fresh login).
+    const resolvedFamilyId = familyId ?? randomBytes(16).toString('hex');
+    await this.storeRefreshToken(address, tokenHash, expiresAt.toISOString(), resolvedFamilyId);
 
     return { accessToken, refreshToken };
   }
 
+  // ---------------------------------------------------------------------------
+  // Refresh (rotation with reuse detection)
+  // ---------------------------------------------------------------------------
+
   /**
    * Refresh flow: validate provided refresh token, rotate and issue new tokens.
+   *
+   * Reuse detection: if a superseded (already-rotated) token is presented,
+   * the entire token family is revoked to protect against session hijacking.
    */
   async refresh(refreshToken: string): Promise<{ accessToken: string; refreshToken: string }> {
-    if (!refreshToken) throw new Error('refresh token required');
+    if (!refreshToken) throw new Error('Refresh token required');
 
-    // verify token signature and expiry
-    let payload: any;
+    let payload: { address?: string; type?: string };
     try {
-      payload = this.jwtService.verify(refreshToken);
-    } catch (err) {
+      payload = this.jwtService.verify(refreshToken) as typeof payload;
+    } catch {
+      // Never log the token value itself.
       throw new Error('Invalid refresh token');
     }
 
@@ -192,41 +164,139 @@ export class AuthService {
     }
 
     const tokenHash = this.hashToken(refreshToken);
+    const address = payload.address;
 
-    // lookup token hash in DB
-    const { data, error } = await this.client
+    // Look up the token regardless of revocation status so we can detect reuse.
+    const { data: tokenRow, error } = await this.client
       .from('refresh_tokens')
-      .select('*')
+      .select('id, revoked, expires_at, family_id')
       .eq('token_hash', tokenHash)
-      .eq('revoked', false)
       .limit(1)
       .maybeSingle();
 
-    if (error || !data) {
-      throw new Error('Refresh token not found or revoked');
+    if (error || !tokenRow) {
+      // Token hash not in DB at all — unknown / tampered token.
+      throw new Error('Refresh token not found');
     }
 
-    // optional: check expires_at
-    if (data.expires_at && new Date(data.expires_at) < new Date()) {
+    if (tokenRow.revoked) {
+      // This token was already superseded. Revoke the entire family to
+      // invalidate any tokens the attacker may have obtained.
+      this.logger.warn(
+        `Refresh token reuse detected for address [REDACTED], family ${tokenRow.family_id}. Revoking family.`,
+      );
+      await this.revokeFamilyById(tokenRow.family_id);
+      throw new Error('Refresh token reuse detected — session revoked');
+    }
+
+    if (tokenRow.expires_at && new Date(tokenRow.expires_at) < new Date()) {
       throw new Error('Refresh token expired');
     }
 
-    // rotate: create new refresh token and replace stored hash
-    const address = payload.address as string;
-    const newAccess = this.signAccessToken(address);
-    const newRefresh = this.signRefreshToken(address);
-    const newHash = this.hashToken(newRefresh);
-
+    // Mark the current token as revoked (superseded) before issuing the next one.
     const nowIso = new Date().toISOString();
-    const { error: updateErr } = await this.client
+    const { error: revokeErr } = await this.client
       .from('refresh_tokens')
-      .update({ token_hash: newHash, last_used_at: nowIso, updated_at: nowIso })
-      .eq('token_hash', tokenHash);
+      .update({ revoked: true, updated_at: nowIso })
+      .eq('id', tokenRow.id);
 
-    if (updateErr) {
+    if (revokeErr) {
       throw new Error('Failed to rotate refresh token');
     }
 
-    return { accessToken: newAccess, refreshToken: newRefresh };
+    // Issue new tokens in the same family.
+    return this.issueTokens(address, tokenRow.family_id);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Sign-out
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Revoke all active refresh tokens for the given token's family.
+   * Accepts the raw refresh token so the caller doesn't need to track family IDs.
+   */
+  async signOut(refreshToken: string): Promise<void> {
+    if (!refreshToken) throw new Error('Refresh token required');
+
+    let payload: { address?: string; type?: string };
+    try {
+      payload = this.jwtService.verify(refreshToken) as typeof payload;
+    } catch {
+      // Expired or invalid — still attempt revocation by hash lookup.
+      payload = {};
+    }
+
+    const tokenHash = this.hashToken(refreshToken);
+
+    const { data: tokenRow } = await this.client
+      .from('refresh_tokens')
+      .select('family_id')
+      .eq('token_hash', tokenHash)
+      .limit(1)
+      .maybeSingle();
+
+    if (tokenRow?.family_id) {
+      await this.revokeFamilyById(tokenRow.family_id);
+    }
+    // If the token isn't found we treat sign-out as a no-op (idempotent).
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  private signAccessToken(address: string): string {
+    return this.jwtService.sign({ address }, { expiresIn: env.jwt.expiresIn });
+  }
+
+  private signRefreshToken(address: string): string {
+    return this.jwtService.sign(
+      { address, type: 'refresh' },
+      { expiresIn: env.jwt.refreshExpiresIn },
+    );
+  }
+
+  /** HMAC-SHA256 hash of the raw token. Never log the input. */
+  private hashToken(token: string): string {
+    return createHmac('sha256', env.jwt.secret).update(token).digest('hex');
+  }
+
+  private async storeRefreshToken(
+    userAddress: string,
+    tokenHash: string,
+    expiresAtIso: string,
+    familyId: string,
+  ): Promise<void> {
+    const now = new Date().toISOString();
+    const { error } = await this.client.from('refresh_tokens').insert([
+      {
+        user_address: userAddress,
+        token_hash: tokenHash,
+        created_at: now,
+        last_used_at: now,
+        expires_at: expiresAtIso,
+        revoked: false,
+        family_id: familyId,
+      },
+    ]);
+
+    if (error) {
+      throw new Error('Failed to persist refresh token');
+    }
+  }
+
+  /** Revoke every non-revoked token in a family. */
+  private async revokeFamilyById(familyId: string): Promise<void> {
+    const nowIso = new Date().toISOString();
+    const { error } = await this.client
+      .from('refresh_tokens')
+      .update({ revoked: true, updated_at: nowIso })
+      .eq('family_id', familyId)
+      .eq('revoked', false);
+
+    if (error) {
+      this.logger.error(`Failed to revoke token family ${familyId}: ${error.message}`);
+    }
   }
 }


### PR DESCRIPTION
Refresh Token Rotation Safeguards
What
Adds token family tracking to the refresh token rotation flow so that reuse of a superseded token triggers full session revocation, rather than silently failing.

Why
The previous implementation stored one hash per token and simply replaced it on rotation. If an attacker obtained a superseded token (e.g. via a leaked response), they could attempt to use it — the server would reject it, but the legitimate session would remain active and unaware. This is the standard "silent failure" gap in naïve rotation schemes.

Changes
Database

011_refresh_token_families.sql — adds family_id TEXT NOT NULL to refresh_tokens, indexed for fast family-wide revocation queries.
auth.service.ts

issueTokens accepts an optional familyId; fresh logins generate a new random family, rotations carry the existing one forward.
refresh fetches the token row regardless of revocation status. A revoked row means a superseded token was reused — the entire family is immediately revoked and a safe error is returned. A valid row is marked revoked before the new token is inserted, eliminating any window where two valid tokens in the same family coexist.
signOut revokes all tokens in a family by hash lookup. Idempotent, works even when the JWT is expired.
Raw token values are never passed to the logger or included in error messages.
auth.controller.ts

Adds POST /auth/sign-out (rate-limited, Zod-validated).
auth.schema.ts

Adds SignOutBodySchema and SignOutBodyDto.
auth.service.spec.ts

Full rewrite covering: normal rotation, family_id preservation across rotations, reuse detection + family revocation, revoked / expired / unknown token states, sign-out (normal, idempotent, expired JWT), and a dedicated assertion that raw token values never appear in logs or error messages.
Testing
cd backend && npm run lint && npm run test && npm run build

Closes #536 