### PR TITLE
refactor: added shared transaction modal state and integrate with existing ticket modals

### DIFF
--- a/client/src/components/modals/FailedTicket.tsx
+++ b/client/src/components/modals/FailedTicket.tsx
@@ -1,24 +1,63 @@
-import { X, XCircle } from "lucide-react";
+/**
+ * FailedTicket.tsx
+ *
+ * Ticket-purchase failure modal.
+ * Accepts both `FailedState` and `RetryableState` from the shared model so it
+ * can surface the correct error message and conditionally render a Retry CTA.
+ * Ticket-specific copy is preserved.
+ */
 
-interface FailedTicketProps {
+import { X, XCircle, RefreshCw } from "lucide-react";
+import type { FailedState, RetryableState } from "./transactionModalState";
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+export interface FailedTicketProps {
     onClose?: () => void;
+    /** Fired when the user clicks the primary action ("Try again" or "Continue"). */
     onContinue?: () => void;
+    /** Fired explicitly when the user wants to retry (if `modalState.canRetry`). */
+    onRetry?: () => void;
     raffleName?: string;
     isVisible?: boolean;
+    /**
+     * When provided, error message and retry capability are derived from the
+     * shared state model. Falls back to generic copy when omitted.
+     */
+    modalState?: FailedState | RetryableState;
 }
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
 
 const FailedTicket = ({
     onClose,
     onContinue,
+    onRetry,
     raffleName = "Bali All Sponsored Ticket",
     isVisible = true,
+    modalState,
 }: FailedTicketProps) => {
     if (!isVisible) return null;
 
+    const errorMessage = modalState?.errorMessage;
+    const canRetry =
+        modalState?.phase === "retryable" ? modalState.canRetry : false;
+    const dismissible =
+        modalState?.phase === "failed" ? (modalState.dismissible ?? true) : true;
+
+    const handlePrimary = canRetry ? (onRetry ?? onContinue) : onContinue;
+
     return (
-        <div className="w-full max-w-[500px] mx-auto px-4 sm:px-6">
+        <div
+            data-testid="failed-ticket-modal"
+            className="w-full max-w-[500px] mx-auto px-4 sm:px-6"
+        >
             {/* Close Button */}
-            {onClose && (
+            {onClose && dismissible && (
                 <div className="flex justify-end mb-4 sm:mb-6">
                     <button
                         onClick={onClose}
@@ -33,27 +72,52 @@ const FailedTicket = ({
             {/* Error Indicator */}
             <div className="flex justify-center mb-6 sm:mb-8">
                 <div className="w-12 h-12 sm:w-16 sm:h-16 bg-red-500 rounded-full flex items-center justify-center">
-                    <XCircle size={24} className="sm:w-8 sm:h-8 text-gray-900 dark:text-white" />
+                    <XCircle
+                        size={24}
+                        className="sm:w-8 sm:h-8 text-gray-900 dark:text-white"
+                    />
                 </div>
             </div>
 
             {/* Main Heading */}
             <div className="text-center mb-4 sm:mb-6">
-                <h2 className="text-xl sm:text-2xl font-bold text-gray-900 dark:text-white mb-3 sm:mb-4">
-                    Oh oh...
+                <h2
+                    id="modal-title"
+                    className="text-xl sm:text-2xl font-bold text-gray-900 dark:text-white mb-3 sm:mb-4"
+                >
+                    Oh oh…
                 </h2>
                 <p className="text-gray-900 dark:text-white text-xs sm:text-sm leading-relaxed px-2">
-                    Unfortunately, your purchase for the{" "}
-                    <span className="font-semibold">{raffleName}</span> did not
-                    go through. Pls try again.
+                    {errorMessage ??
+                        <>
+                            Unfortunately, your purchase for the{" "}
+                            <span className="font-semibold">{raffleName}</span>{" "}
+                            did not go through. Pls try again.
+                        </>}
                 </p>
             </div>
 
-            {/* Continue Button */}
-            <div className="w-full">
+            {/* Action Buttons */}
+            <div className="w-full space-y-3">
+                {canRetry && (
+                    <button
+                        data-testid="failed-retry-btn"
+                        onClick={onRetry ?? onContinue}
+                        className="w-full bg-[#fe3796] hover:bg-[#fe3796]/90 text-gray-900 dark:text-white font-semibold py-3 sm:py-4 px-4 sm:px-6 rounded-xl transition-colors text-sm sm:text-base flex items-center justify-center gap-2"
+                    >
+                        <RefreshCw size={16} />
+                        Try again
+                    </button>
+                )}
+
                 <button
-                    onClick={onContinue}
-                    className="w-full bg-[#fe3796] hover:bg-[#fe3796]/90 text-gray-900 dark:text-white font-semibold py-3 sm:py-4 px-4 sm:px-6 rounded-xl transition-colors text-sm sm:text-base"
+                    data-testid="failed-continue-btn"
+                    onClick={handlePrimary}
+                    className={`w-full font-semibold py-3 sm:py-4 px-4 sm:px-6 rounded-xl transition-colors text-sm sm:text-base ${
+                        canRetry
+                            ? "bg-transparent border border-gray-500 dark:border-[#1F263F] text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-[#1F263F]/40"
+                            : "bg-[#fe3796] hover:bg-[#fe3796]/90 text-gray-900 dark:text-white"
+                    }`}
                 >
                     Continue
                 </button>

--- a/client/src/components/modals/ProcessingRaffleCreation.tsx
+++ b/client/src/components/modals/ProcessingRaffleCreation.tsx
@@ -1,30 +1,96 @@
-import { X } from "lucide-react";
+/**
+ * ProcessingRaffleCreation.tsx
+ *
+ * Raffle-creation processing modal.
+ * Now driven by `TransactionModalState` while keeping its raffle-specific
+ * progress bar and multi-step copy.
+ */
 
-interface ProcessingRaffleCreationProps {
-    onClose?: () => void;
+import { X } from "lucide-react";
+import type { TransactionModalState } from "./transactionModalState";
+import { isInFlight } from "./transactionModalState";
+
+// ---------------------------------------------------------------------------
+// Legacy prop API  (kept for backwards-compatibility)
+// ---------------------------------------------------------------------------
+
+interface LegacyProps {
+    /** @deprecated Pass `modalState` instead. */
     transactionHash?: string;
+    /** @deprecated Pass `modalState` instead. */
     network?: string;
-    isVisible?: boolean;
+    /** @deprecated Pass `modalState` instead. */
     currentStep?: string;
+    /** @deprecated Pass `modalState` instead. */
     progress?: number; // 0-100
+    isVisible?: boolean;
 }
+
+// ---------------------------------------------------------------------------
+// Primary prop API
+// ---------------------------------------------------------------------------
+
+export interface ProcessingRaffleCreationProps extends LegacyProps {
+    onClose?: () => void;
+    /**
+     * When provided, the component derives all display values from the shared
+     * state model. Falls back to legacy props when omitted.
+     */
+    modalState?: TransactionModalState;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
 
 const ProcessingRaffleCreation = ({
     onClose,
-    transactionHash = "DEMO-7A9D-E3F2",
+    transactionHash,
     network = "Demo Mode",
-    isVisible = true,
     currentStep = "Uploading metadata...",
     progress = 0,
+    isVisible = true,
+    modalState,
 }: ProcessingRaffleCreationProps) => {
     if (!isVisible) return null;
 
+    const phase = modalState?.phase ?? "submitting";
+    const inFlight = modalState ? isInFlight(modalState) : true;
+
+    const displayStep =
+        modalState?.phase === "awaiting_signature"
+            ? modalState.stepLabel
+            : modalState?.phase === "submitting"
+              ? modalState.stepLabel
+              : currentStep;
+
+    const displayProgress =
+        modalState?.phase === "submitting"
+            ? (modalState.progress ?? progress)
+            : progress;
+
+    const displayNetwork =
+        modalState?.phase === "submitting"
+            ? (modalState.network ?? network)
+            : network;
+
+    const displayRefId =
+        modalState?.phase === "submitting"
+            ? (modalState.referenceId ?? transactionHash)
+            : transactionHash;
+
+    const canClose =
+        onClose && (!inFlight || phase === "failed" || phase === "retryable");
+
     return (
-        <div className="w-full max-w-[500px] mx-auto px-4 sm:px-6">
+        <div
+            data-testid="processing-raffle-creation-modal"
+            className="w-full max-w-[500px] mx-auto px-4 sm:px-6"
+        >
             {/* Header */}
             <div className="flex items-start justify-between mb-4 sm:mb-6">
-                <div className="flex-1"></div>
-                {onClose && (
+                <div className="flex-1" />
+                {canClose && (
                     <button
                         onClick={onClose}
                         className="text-gray-900 dark:text-white hover:text-gray-700 dark:text-gray-300 transition-colors flex-shrink-0"
@@ -35,11 +101,13 @@ const ProcessingRaffleCreation = ({
                 )}
             </div>
 
-            {/* Processing Animation */}
+            {/* Spinner */}
             <div className="flex justify-center mb-6 sm:mb-8">
                 <div className="w-12 h-12 sm:w-16 sm:h-16 bg-white rounded-full flex items-center justify-center">
-                    {/* Loading spinner animation */}
-                    <div className="w-6 h-6 sm:w-8 sm:h-8 border-4 border-[#1A1A2E] border-t-white rounded-full animate-spin"></div>
+                    <div
+                        data-testid="processing-spinner"
+                        className="w-6 h-6 sm:w-8 sm:h-8 border-4 border-[#1A1A2E] border-t-white rounded-full animate-spin"
+                    />
                 </div>
             </div>
 
@@ -50,23 +118,35 @@ const ProcessingRaffleCreation = ({
                         Progress
                     </span>
                     <span className="text-gray-900 dark:text-white text-sm font-medium">
-                        {progress}%
+                        {displayProgress}%
                     </span>
                 </div>
-                <div className="w-full bg-[#1F263F] rounded-full h-2">
+                <div
+                    role="progressbar"
+                    aria-valuenow={displayProgress}
+                    aria-valuemin={0}
+                    aria-valuemax={100}
+                    className="w-full bg-[#1F263F] rounded-full h-2"
+                >
                     <div
                         className="bg-[#FF389C] h-2 rounded-full transition-all duration-500 ease-out"
-                        style={{ width: `${progress}%` }}
-                    ></div>
+                        style={{ width: `${displayProgress}%` }}
+                    />
                 </div>
             </div>
 
+            {/* Copy */}
             <div className="text-center mb-8 sm:mb-12">
-                <h2 className="text-lg sm:text-[22px] font-bold text-gray-900 dark:text-white mb-2">
-                    Creating your raffle...
+                <h2
+                    id="modal-title"
+                    className="text-lg sm:text-[22px] font-bold text-gray-900 dark:text-white mb-2"
+                >
+                    {phase === "awaiting_signature"
+                        ? "Awaiting signature…"
+                        : "Creating your raffle…"}
                 </h2>
                 <p className="text-[#B6C6E1] text-xs sm:text-sm text-center px-2 mb-4">
-                    {currentStep}
+                    {displayStep}
                 </p>
                 <p className="text-[#B6C6E1] text-xs sm:text-sm text-center px-2">
                     Keep this window open while we upload metadata and submit
@@ -75,31 +155,28 @@ const ProcessingRaffleCreation = ({
             </div>
 
             {/* Transaction Details */}
-            {transactionHash && (
+            {displayRefId && (
                 <div className="bg-[#090E1F] rounded-xl p-3 sm:p-4 mb-4 sm:mb-6">
                     <div className="space-y-3">
-                        {/* Reference ID */}
                         <div className="flex justify-between items-center">
                             <span className="text-gray-900 dark:text-white text-xs sm:text-sm">
                                 Reference ID:
                             </span>
                             <span className="text-gray-900 dark:text-white font-mono text-xs sm:text-sm truncate ml-2">
-                                {transactionHash}
+                                {displayRefId}
                             </span>
                         </div>
 
-                        {/* Divider */}
-                        <div className="border-t border-gray-200 dark:border-[#1F263F]"></div>
+                        <div className="border-t border-gray-200 dark:border-[#1F263F]" />
 
-                        {/* Network */}
                         <div className="flex justify-between items-center">
                             <span className="text-gray-900 dark:text-white text-xs sm:text-sm">
                                 Network:
                             </span>
                             <div className="flex items-center space-x-1 sm:space-x-2">
-                                <div className="w-3 h-3 sm:w-4 sm:h-4 bg-blue-400 rounded-full"></div>
+                                <div className="w-3 h-3 sm:w-4 sm:h-4 bg-blue-400 rounded-full" />
                                 <span className="text-gray-900 dark:text-white text-xs sm:text-sm">
-                                    {network}
+                                    {displayNetwork}
                                 </span>
                             </div>
                         </div>
@@ -107,7 +184,7 @@ const ProcessingRaffleCreation = ({
                 </div>
             )}
 
-            {/* Bottom Message */}
+            {/* Footer */}
             <div className="text-center">
                 <p className="text-gray-400 text-xs sm:text-sm px-2">
                     This window will update automatically when your raffle is

--- a/client/src/components/modals/ProcessingTickets.tsx
+++ b/client/src/components/modals/ProcessingTickets.tsx
@@ -1,26 +1,85 @@
-import { X } from "lucide-react";
+/**
+ * ProcessingTickets.tsx
+ *
+ * Ticket-purchase processing modal.
+ * Now driven by `TransactionModalState` so it mirrors the shared phase model
+ * (awaiting_signature → submitting → …) while keeping ticket-specific copy.
+ */
 
-interface ProcessingTicketsProps {
-    onClose?: () => void;
+import { X } from "lucide-react";
+import type { TransactionModalState } from "./transactionModalState";
+import { isInFlight } from "./transactionModalState";
+
+// ---------------------------------------------------------------------------
+// Legacy prop API  (kept for backwards-compatibility with existing callers)
+// ---------------------------------------------------------------------------
+
+interface LegacyProps {
+    /** @deprecated Pass `modalState` instead. */
     transactionHash?: string;
+    /** @deprecated Pass `modalState` instead. */
     network?: string;
     isVisible?: boolean;
 }
 
+// ---------------------------------------------------------------------------
+// Primary prop API
+// ---------------------------------------------------------------------------
+
+export interface ProcessingTicketsProps extends LegacyProps {
+    onClose?: () => void;
+    /**
+     * When provided, the component renders based on the shared state model.
+     * When omitted the component falls back to the legacy always-spinning UI.
+     */
+    modalState?: TransactionModalState;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
 const ProcessingTickets = ({
     onClose,
-    transactionHash = "DEMO-7A9D-E3F2",
+    transactionHash,
     network = "Demo Mode",
     isVisible = true,
+    modalState,
 }: ProcessingTicketsProps) => {
     if (!isVisible) return null;
 
+    // Derive display values from modalState when present, else use legacy props
+    const phase = modalState?.phase ?? "submitting";
+    const inFlight = modalState ? isInFlight(modalState) : true;
+
+    const stepLabel =
+        modalState?.phase === "awaiting_signature"
+            ? modalState.stepLabel
+            : modalState?.phase === "submitting"
+              ? modalState.stepLabel
+              : "Purchasing tickets...";
+
+    const refId =
+        modalState?.phase === "submitting"
+            ? (modalState.referenceId ?? transactionHash ?? "—")
+            : (transactionHash ?? "—");
+
+    const displayNetwork =
+        modalState?.phase === "submitting"
+            ? (modalState.network ?? network)
+            : network;
+
+    const canClose = onClose && (!inFlight || phase === "failed" || phase === "retryable");
+
     return (
-        <div className="w-full max-w-[500px] mx-auto px-4 sm:px-6">
+        <div
+            data-testid="processing-tickets-modal"
+            className="w-full max-w-[500px] mx-auto px-4 sm:px-6"
+        >
             {/* Header */}
             <div className="flex items-start justify-between mb-4 sm:mb-6">
-                <div className="flex-1"></div>
-                {onClose && (
+                <div className="flex-1" />
+                {canClose && (
                     <button
                         onClick={onClose}
                         className="text-gray-900 dark:text-white hover:text-gray-700 dark:text-gray-300 transition-colors flex-shrink-0"
@@ -31,54 +90,60 @@ const ProcessingTickets = ({
                 )}
             </div>
 
-            {/* Processing Animation */}
+            {/* Spinner */}
             <div className="flex justify-center mb-6 sm:mb-8">
                 <div className="w-12 h-12 sm:w-16 sm:h-16 bg-white rounded-full flex items-center justify-center">
-                    {/* Loading spinner animation */}
-                    <div className="w-6 h-6 sm:w-8 sm:h-8 border-4 border-[#1A1A2E] border-t-white rounded-full animate-spin"></div>
+                    <div
+                        data-testid="processing-spinner"
+                        className="w-6 h-6 sm:w-8 sm:h-8 border-4 border-[#1A1A2E] border-t-white rounded-full animate-spin"
+                    />
                 </div>
             </div>
+
+            {/* Copy */}
             <div className="text-center mb-8 sm:mb-12">
-                <h2 className="text-lg sm:text-[22px] font-bold text-gray-900 dark:text-white mb-2">
-                    Purchasing tickets...
+                <h2
+                    id="modal-title"
+                    className="text-lg sm:text-[22px] font-bold text-gray-900 dark:text-white mb-2"
+                >
+                    {phase === "awaiting_signature"
+                        ? "Awaiting signature…"
+                        : "Purchasing tickets…"}
                 </h2>
                 <p className="text-[#B6C6E1] text-xs sm:text-sm text-center px-2">
-                    This is a demo flow. No onchain transaction is required.
+                    {stepLabel}
                 </p>
             </div>
 
-            {/* Transaction Details */}
+            {/* Transaction details */}
             <div className="bg-[#090E1F] rounded-xl p-3 sm:p-4 mb-4 sm:mb-6">
                 <div className="space-y-3">
-                    {/* Reference ID */}
                     <div className="flex justify-between items-center">
                         <span className="text-gray-900 dark:text-white text-xs sm:text-sm">
                             Reference ID:
                         </span>
                         <span className="text-gray-900 dark:text-white font-mono text-xs sm:text-sm truncate ml-2">
-                            {transactionHash}
+                            {refId}
                         </span>
                     </div>
 
-                    {/* Divider */}
-                    <div className="border-t border-gray-200 dark:border-[#1F263F]"></div>
+                    <div className="border-t border-gray-200 dark:border-[#1F263F]" />
 
-                    {/* Mode */}
                     <div className="flex justify-between items-center">
                         <span className="text-gray-900 dark:text-white text-xs sm:text-sm">
                             Mode:
                         </span>
                         <div className="flex items-center space-x-1 sm:space-x-2">
-                            <div className="w-3 h-3 sm:w-4 sm:h-4 bg-yellow-400 rounded-full"></div>
+                            <div className="w-3 h-3 sm:w-4 sm:h-4 bg-yellow-400 rounded-full" />
                             <span className="text-gray-900 dark:text-white text-xs sm:text-sm">
-                                {network}
+                                {displayNetwork}
                             </span>
                         </div>
                     </div>
                 </div>
             </div>
 
-            {/* Bottom Message */}
+            {/* Footer */}
             <div className="text-center">
                 <p className="text-gray-400 text-xs sm:text-sm px-2">
                     This window will update automatically when your transaction

--- a/client/src/components/modals/RaffleCreatedSuccess.tsx
+++ b/client/src/components/modals/RaffleCreatedSuccess.tsx
@@ -1,13 +1,36 @@
+/**
+ * RaffleCreatedSuccess.tsx
+ *
+ * Raffle-creation success modal.
+ * Now accepts `ConfirmedState` from the shared model for the reference-ID /
+ * network fields, while all copy and action buttons remain raffle-specific.
+ */
+
 import { X, CheckCircle, ExternalLink, Copy } from "lucide-react";
 import { Link } from "react-router-dom";
+import type { ConfirmedState } from "./transactionModalState";
 
-interface RaffleCreatedSuccessProps {
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+export interface RaffleCreatedSuccessProps {
     onClose?: () => void;
     raffleId?: number;
     transactionHash?: string;
     network?: string;
     isVisible?: boolean;
+    /**
+     * When provided, `referenceId` and `network` are sourced from the shared
+     * confirmed state. Falls back to the explicit `transactionHash` / `network`
+     * props so existing callers continue to work unchanged.
+     */
+    modalState?: ConfirmedState;
 }
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
 
 const RaffleCreatedSuccess = ({
     onClose,
@@ -15,31 +38,38 @@ const RaffleCreatedSuccess = ({
     transactionHash,
     network = "Demo Mode",
     isVisible = true,
+    modalState,
 }: RaffleCreatedSuccessProps) => {
     if (!isVisible) return null;
 
-    const handleCopyTransactionHash = () => {
-        if (transactionHash) {
-            navigator.clipboard.writeText(transactionHash);
-            // You could add a toast notification here
+    // Prefer values from the shared state model
+    const displayTxHash = modalState?.referenceId ?? transactionHash;
+    const displayNetwork = modalState?.network ?? network;
+
+    const handleCopyTxHash = () => {
+        if (displayTxHash) {
+            navigator.clipboard.writeText(displayTxHash);
         }
     };
 
     const handleViewOnExplorer = () => {
-        if (transactionHash) {
+        if (displayTxHash) {
             const explorerUrl =
-                network === "mainnet"
-                    ? `https://stellar.expert/explorer/public/tx/${transactionHash}`
-                    : `https://stellar.expert/explorer/testnet/tx/${transactionHash}`;
+                displayNetwork === "mainnet"
+                    ? `https://stellar.expert/explorer/public/tx/${displayTxHash}`
+                    : `https://stellar.expert/explorer/testnet/tx/${displayTxHash}`;
             window.open(explorerUrl, "_blank");
         }
     };
 
     return (
-        <div className="w-full max-w-[500px] mx-auto px-4 sm:px-6">
+        <div
+            data-testid="raffle-created-success-modal"
+            className="w-full max-w-[500px] mx-auto px-4 sm:px-6"
+        >
             {/* Header */}
             <div className="flex items-start justify-between mb-4 sm:mb-6">
-                <div className="flex-1"></div>
+                <div className="flex-1" />
                 {onClose && (
                     <button
                         onClick={onClose}
@@ -60,7 +90,10 @@ const RaffleCreatedSuccess = ({
 
             {/* Success Message */}
             <div className="text-center mb-8 sm:mb-12">
-                <h2 className="text-lg sm:text-[22px] font-bold text-gray-900 dark:text-white mb-2">
+                <h2
+                    id="modal-title"
+                    className="text-lg sm:text-[22px] font-bold text-gray-900 dark:text-white mb-2"
+                >
                     Raffle Created Successfully! 🎉
                 </h2>
                 <p className="text-[#B6C6E1] text-xs sm:text-sm text-center px-2">
@@ -82,12 +115,12 @@ const RaffleCreatedSuccess = ({
                                     #{raffleId}
                                 </span>
                             </div>
-                            <div className="border-t border-gray-200 dark:border-[#1F263F]"></div>
+                            <div className="border-t border-gray-200 dark:border-[#1F263F]" />
                         </>
                     )}
 
                     {/* Transaction Hash */}
-                    {transactionHash && (
+                    {displayTxHash && (
                         <>
                             <div className="flex justify-between items-center">
                                 <span className="text-gray-900 dark:text-white text-xs sm:text-sm">
@@ -95,31 +128,32 @@ const RaffleCreatedSuccess = ({
                                 </span>
                                 <div className="flex items-center space-x-2">
                                     <span className="text-gray-900 dark:text-white font-mono text-xs sm:text-sm truncate max-w-[120px]">
-                                        {transactionHash.slice(0, 6)}...
-                                        {transactionHash.slice(-4)}
+                                        {displayTxHash.slice(0, 6)}…
+                                        {displayTxHash.slice(-4)}
                                     </span>
                                     <button
-                                        onClick={handleCopyTransactionHash}
+                                        onClick={handleCopyTxHash}
                                         className="text-gray-400 hover:text-gray-900 dark:text-white transition-colors"
                                         title="Copy transaction hash"
+                                        aria-label="Copy transaction hash"
                                     >
                                         <Copy size={14} />
                                     </button>
                                 </div>
                             </div>
-                            <div className="border-t border-gray-200 dark:border-[#1F263F]"></div>
+                            <div className="border-t border-gray-200 dark:border-[#1F263F]" />
                         </>
                     )}
 
-                    {/* Mode */}
+                    {/* Mode / Network */}
                     <div className="flex justify-between items-center">
                         <span className="text-gray-900 dark:text-white text-xs sm:text-sm">
                             Mode:
                         </span>
                         <div className="flex items-center space-x-1 sm:space-x-2">
-                            <div className="w-3 h-3 sm:w-4 sm:h-4 bg-blue-400 rounded-full"></div>
+                            <div className="w-3 h-3 sm:w-4 sm:h-4 bg-blue-400 rounded-full" />
                             <span className="text-gray-900 dark:text-white text-xs sm:text-sm">
-                                {network}
+                                {displayNetwork}
                             </span>
                         </div>
                     </div>
@@ -128,7 +162,6 @@ const RaffleCreatedSuccess = ({
 
             {/* Action Buttons */}
             <div className="space-y-3 sm:space-y-4">
-                {/* View Raffle Button */}
                 {raffleId !== undefined && (
                     <Link
                         to={`/raffles/${raffleId}`}
@@ -139,18 +172,16 @@ const RaffleCreatedSuccess = ({
                     </Link>
                 )}
 
-                {/* View on Explorer Button */}
-                {transactionHash && (
+                {displayTxHash && (
                     <button
                         onClick={handleViewOnExplorer}
-                        className="w-full bg-gray-200 dark:bg-[#2A264A] hover:bg-gray-300 dark:bg-[#3A365A] text-gray-900 dark:text-white px-6 py-3 rounded-lg font-medium transition-colors duration-200 flex items-center justify-center space-x-2"
+                        className="w-full bg-gray-200 dark:bg-[#2A264A] hover:bg-gray-300 dark:hover:bg-[#3A365A] text-gray-900 dark:text-white px-6 py-3 rounded-lg font-medium transition-colors duration-200 flex items-center justify-center space-x-2"
                     >
                         <ExternalLink size={16} />
                         <span>View on Explorer</span>
                     </button>
                 )}
 
-                {/* Create Another Raffle Button */}
                 <Link
                     to="/create"
                     className="w-full bg-transparent border border-pink-500 dark:border-[#FF389C] text-pink-600 dark:text-[#FF389C] hover:bg-[#FF389C]/10 px-6 py-3 rounded-lg font-medium transition-colors duration-200 text-center block"
@@ -160,7 +191,7 @@ const RaffleCreatedSuccess = ({
                 </Link>
             </div>
 
-            {/* Bottom Message */}
+            {/* Footer */}
             <div className="text-center mt-6">
                 <p className="text-gray-400 text-xs sm:text-sm px-2">
                     Your raffle is now live! Share it with your community to get

--- a/client/src/components/modals/SuccessfulTicket.tsx
+++ b/client/src/components/modals/SuccessfulTicket.tsx
@@ -1,22 +1,52 @@
-import { X, Check } from "lucide-react";
+/**
+ * SuccessfulTicket.tsx
+ *
+ * Ticket-purchase success modal.
+ * Now accepts `TransactionModalState` (phase "confirmed") so the parent can
+ * hand the same state object to whichever modal is currently mounted, while
+ * the copy here stays ticket-purchase specific.
+ */
 
-interface SuccessfulTicketProps {
+import { X, Check } from "lucide-react";
+import type { ConfirmedState } from "./transactionModalState";
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+export interface SuccessfulTicketProps {
     onClose?: () => void;
     onContinue?: () => void;
     raffleName?: string;
     isVisible?: boolean;
+    /**
+     * Optional confirmed state from the shared model.
+     * When provided the component can display the reference ID / network.
+     */
+    modalState?: ConfirmedState;
 }
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
 
 const SuccessfulTicket = ({
     onClose,
     onContinue,
     raffleName = "Bali All Sponsored Ticket",
     isVisible = true,
+    modalState,
 }: SuccessfulTicketProps) => {
     if (!isVisible) return null;
 
+    const referenceId = modalState?.referenceId;
+    const network = modalState?.network;
+
     return (
-        <div data-testid="success-modal" className="w-full max-w-[500px] mx-auto px-4 sm:px-6">
+        <div
+            data-testid="success-modal"
+            className="w-full max-w-[500px] mx-auto px-4 sm:px-6"
+        >
             {/* Close Button */}
             {onClose && (
                 <div className="flex justify-end mb-4 sm:mb-6">
@@ -39,8 +69,11 @@ const SuccessfulTicket = ({
 
             {/* Main Heading */}
             <div className="text-center mb-4 sm:mb-6">
-                <h2 className="text-xl sm:text-2xl font-bold text-gray-900 dark:text-white mb-3 sm:mb-4">
-                    Let's go!!!
+                <h2
+                    id="modal-title"
+                    className="text-xl sm:text-2xl font-bold text-gray-900 dark:text-white mb-3 sm:mb-4"
+                >
+                    Let&apos;s go!!!
                 </h2>
                 <p className="text-gray-900 dark:text-white text-xs sm:text-sm leading-relaxed px-2">
                     Your tickets purchase for{" "}
@@ -48,6 +81,40 @@ const SuccessfulTicket = ({
                     successful.
                 </p>
             </div>
+
+            {/* Optional on-chain details */}
+            {(referenceId || network) && (
+                <div className="bg-[#090E1F] rounded-xl p-3 sm:p-4 mb-4 sm:mb-6">
+                    <div className="space-y-3">
+                        {referenceId && (
+                            <div className="flex justify-between items-center">
+                                <span className="text-gray-400 text-xs sm:text-sm">
+                                    Tx Hash:
+                                </span>
+                                <span className="text-gray-900 dark:text-white font-mono text-xs truncate ml-2 max-w-[160px]">
+                                    {referenceId}
+                                </span>
+                            </div>
+                        )}
+                        {referenceId && network && (
+                            <div className="border-t border-gray-200 dark:border-[#1F263F]" />
+                        )}
+                        {network && (
+                            <div className="flex justify-between items-center">
+                                <span className="text-gray-400 text-xs sm:text-sm">
+                                    Network:
+                                </span>
+                                <div className="flex items-center space-x-1 sm:space-x-2">
+                                    <div className="w-3 h-3 sm:w-4 sm:h-4 bg-green-400 rounded-full" />
+                                    <span className="text-gray-900 dark:text-white text-xs sm:text-sm">
+                                        {network}
+                                    </span>
+                                </div>
+                            </div>
+                        )}
+                    </div>
+                </div>
+            )}
 
             {/* Continue Button */}
             <div className="w-full">

--- a/client/src/components/modals/transactionModalState.spec.ts
+++ b/client/src/components/modals/transactionModalState.spec.ts
@@ -1,0 +1,258 @@
+/**
+ * transactionModalState.spec.ts
+ *
+ * Unit tests for the shared transaction-modal state model and the
+ * `useTransactionModal` hook.
+ *
+ * Run with:  npm run test  (vitest)
+ */
+
+import { describe, it, expect } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+import {
+    modalState,
+    isIdle,
+    isAwaitingSignature,
+    isSubmitting,
+    isConfirmed,
+    isFailed,
+    isRetryable,
+    isInFlight,
+    isTerminal,
+} from "./transactionModalState";
+
+import { useTransactionModal } from "./useTransactionModal";
+
+// ---------------------------------------------------------------------------
+// modalState factories
+// ---------------------------------------------------------------------------
+
+describe("modalState factories", () => {
+    it("idle() produces an idle state", () => {
+        const s = modalState.idle();
+        expect(s.phase).toBe("idle");
+        expect(isIdle(s)).toBe(true);
+    });
+
+    it("awaitingSignature() produces the correct shape", () => {
+        const s = modalState.awaitingSignature("Waiting for wallet…");
+        expect(s.phase).toBe("awaiting_signature");
+        expect(s.stepLabel).toBe("Waiting for wallet…");
+        expect(isAwaitingSignature(s)).toBe(true);
+    });
+
+    it("submitting() carries optional fields", () => {
+        const s = modalState.submitting("Submitting…", {
+            progress: 60,
+            referenceId: "abc123",
+            network: "testnet",
+        });
+        expect(s.phase).toBe("submitting");
+        expect(s.progress).toBe(60);
+        expect(s.referenceId).toBe("abc123");
+        expect(s.network).toBe("testnet");
+        expect(isSubmitting(s)).toBe(true);
+    });
+
+    it("submitting() without opts leaves optional fields undefined", () => {
+        const s = modalState.submitting("Submitting…");
+        expect(s.progress).toBeUndefined();
+        expect(s.referenceId).toBeUndefined();
+    });
+
+    it("confirmed() carries optional fields", () => {
+        const s = modalState.confirmed({ referenceId: "xyz", network: "mainnet" });
+        expect(s.phase).toBe("confirmed");
+        expect(s.referenceId).toBe("xyz");
+        expect(s.network).toBe("mainnet");
+        expect(isConfirmed(s)).toBe(true);
+    });
+
+    it("confirmed() without opts leaves optional fields undefined", () => {
+        const s = modalState.confirmed();
+        expect(s.referenceId).toBeUndefined();
+        expect(s.network).toBeUndefined();
+    });
+
+    it("failed() defaults dismissible to true", () => {
+        const s = modalState.failed("Something went wrong");
+        expect(s.phase).toBe("failed");
+        expect(s.errorMessage).toBe("Something went wrong");
+        expect(s.dismissible).toBe(true);
+        expect(isFailed(s)).toBe(true);
+    });
+
+    it("failed() respects explicit dismissible=false", () => {
+        const s = modalState.failed("Critical failure", { dismissible: false });
+        expect(s.dismissible).toBe(false);
+    });
+
+    it("retryable() defaults canRetry to true", () => {
+        const s = modalState.retryable("Network error");
+        expect(s.phase).toBe("retryable");
+        expect(s.canRetry).toBe(true);
+        expect(isRetryable(s)).toBe(true);
+    });
+
+    it("retryable() respects explicit canRetry=false", () => {
+        const s = modalState.retryable("Permanent error", false);
+        expect(s.canRetry).toBe(false);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Type guards
+// ---------------------------------------------------------------------------
+
+describe("type guards", () => {
+    it("isInFlight is true only for awaiting_signature and submitting", () => {
+        expect(isInFlight(modalState.idle())).toBe(false);
+        expect(isInFlight(modalState.awaitingSignature("…"))).toBe(true);
+        expect(isInFlight(modalState.submitting("…"))).toBe(true);
+        expect(isInFlight(modalState.confirmed())).toBe(false);
+        expect(isInFlight(modalState.failed("err"))).toBe(false);
+        expect(isInFlight(modalState.retryable("err"))).toBe(false);
+    });
+
+    it("isTerminal is true only for confirmed, failed, retryable", () => {
+        expect(isTerminal(modalState.idle())).toBe(false);
+        expect(isTerminal(modalState.awaitingSignature("…"))).toBe(false);
+        expect(isTerminal(modalState.submitting("…"))).toBe(false);
+        expect(isTerminal(modalState.confirmed())).toBe(true);
+        expect(isTerminal(modalState.failed("err"))).toBe(true);
+        expect(isTerminal(modalState.retryable("err"))).toBe(true);
+    });
+
+    it("every guard returns false for an unrelated state", () => {
+        const idle = modalState.idle();
+        expect(isAwaitingSignature(idle)).toBe(false);
+        expect(isSubmitting(idle)).toBe(false);
+        expect(isConfirmed(idle)).toBe(false);
+        expect(isFailed(idle)).toBe(false);
+        expect(isRetryable(idle)).toBe(false);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// useTransactionModal hook
+// ---------------------------------------------------------------------------
+
+describe("useTransactionModal", () => {
+    it("starts in idle state with isOpen=false", () => {
+        const { result } = renderHook(() => useTransactionModal());
+        expect(result.current.state.phase).toBe("idle");
+        expect(result.current.isOpen).toBe(false);
+        expect(result.current.confirmedState).toBeUndefined();
+    });
+
+    it("awaitSignature transitions to awaiting_signature", () => {
+        const { result } = renderHook(() => useTransactionModal());
+        act(() => result.current.actions.awaitSignature("Waiting for wallet…"));
+        expect(result.current.state.phase).toBe("awaiting_signature");
+        expect(result.current.isOpen).toBe(true);
+    });
+
+    it("submit transitions to submitting with all optional fields", () => {
+        const { result } = renderHook(() => useTransactionModal());
+        act(() =>
+            result.current.actions.submit("Submitting…", {
+                progress: 75,
+                referenceId: "tx-abc",
+                network: "testnet",
+            }),
+        );
+        const s = result.current.state;
+        expect(s.phase).toBe("submitting");
+        if (s.phase === "submitting") {
+            expect(s.progress).toBe(75);
+            expect(s.referenceId).toBe("tx-abc");
+            expect(s.network).toBe("testnet");
+        }
+    });
+
+    it("confirm transitions to confirmed and exposes confirmedState", () => {
+        const { result } = renderHook(() => useTransactionModal());
+        act(() =>
+            result.current.actions.confirm({ referenceId: "tx-xyz", network: "mainnet" }),
+        );
+        expect(result.current.state.phase).toBe("confirmed");
+        expect(result.current.confirmedState?.referenceId).toBe("tx-xyz");
+        expect(result.current.confirmedState?.network).toBe("mainnet");
+        expect(result.current.isOpen).toBe(true);
+    });
+
+    it("fail transitions to failed", () => {
+        const { result } = renderHook(() => useTransactionModal());
+        act(() => result.current.actions.fail("Insufficient funds", { dismissible: false }));
+        const s = result.current.state;
+        expect(s.phase).toBe("failed");
+        if (s.phase === "failed") {
+            expect(s.errorMessage).toBe("Insufficient funds");
+            expect(s.dismissible).toBe(false);
+        }
+    });
+
+    it("setRetryable transitions to retryable", () => {
+        const { result } = renderHook(() => useTransactionModal());
+        act(() => result.current.actions.setRetryable("Network timeout", true));
+        const s = result.current.state;
+        expect(s.phase).toBe("retryable");
+        if (s.phase === "retryable") {
+            expect(s.canRetry).toBe(true);
+        }
+    });
+
+    it("reset returns to idle and closes the modal", () => {
+        const { result } = renderHook(() => useTransactionModal());
+        act(() => result.current.actions.confirm());
+        expect(result.current.isOpen).toBe(true);
+
+        act(() => result.current.actions.reset());
+        expect(result.current.state.phase).toBe("idle");
+        expect(result.current.isOpen).toBe(false);
+        expect(result.current.confirmedState).toBeUndefined();
+    });
+
+    it("set() can apply an arbitrary state directly", () => {
+        const { result } = renderHook(() => useTransactionModal());
+        const customState = modalState.submitting("Custom step", { progress: 42 });
+        act(() => result.current.actions.set(customState));
+        const s = result.current.state;
+        expect(s.phase).toBe("submitting");
+        if (s.phase === "submitting") {
+            expect(s.progress).toBe(42);
+        }
+    });
+
+    it("full happy-path sequence: idle → awaiting → submitting → confirmed → reset", () => {
+        const { result } = renderHook(() => useTransactionModal());
+
+        act(() => result.current.actions.awaitSignature("Sign the transaction"));
+        expect(result.current.state.phase).toBe("awaiting_signature");
+
+        act(() => result.current.actions.submit("Broadcasting…", { progress: 50 }));
+        expect(result.current.state.phase).toBe("submitting");
+
+        act(() => result.current.actions.confirm({ referenceId: "hash-001" }));
+        expect(result.current.state.phase).toBe("confirmed");
+        expect(result.current.confirmedState?.referenceId).toBe("hash-001");
+
+        act(() => result.current.actions.reset());
+        expect(result.current.state.phase).toBe("idle");
+    });
+
+    it("full failure-path sequence: idle → awaiting → failed → retryable → reset", () => {
+        const { result } = renderHook(() => useTransactionModal());
+
+        act(() => result.current.actions.awaitSignature("Sign the transaction"));
+        act(() => result.current.actions.fail("User rejected"));
+        expect(result.current.state.phase).toBe("failed");
+
+        act(() => result.current.actions.setRetryable("Network error – please retry"));
+        expect(result.current.state.phase).toBe("retryable");
+
+        act(() => result.current.actions.reset());
+        expect(result.current.state.phase).toBe("idle");
+    });
+});

--- a/client/src/components/modals/transactionModalState.ts
+++ b/client/src/components/modals/transactionModalState.ts
@@ -1,0 +1,172 @@
+/**
+ * transactionModalState.ts
+ *
+ * Shared state model for transaction processing modals.
+ *
+ * Both the ticket-purchase flow and the raffle-creation flow go through
+ * identical lifecycle phases.  Defining them once here keeps the two flows
+ * in sync and makes it trivial to add a third flow later.
+ *
+ * State machine
+ * ─────────────
+ *
+ *   idle ──► awaiting_signature ──► submitting ──► confirmed
+ *                   │                   │
+ *                   └───────────────────┴──► failed
+ *                                            │
+ *                                            └──► retryable (soft failure,
+ *                                                           user may retry)
+ */
+
+// ---------------------------------------------------------------------------
+// State discriminant
+// ---------------------------------------------------------------------------
+
+/** All possible states a transaction modal can be in. */
+export type TransactionModalPhase =
+    | "idle"
+    | "awaiting_signature"
+    | "submitting"
+    | "confirmed"
+    | "failed"
+    | "retryable";
+
+// ---------------------------------------------------------------------------
+// State shape
+// ---------------------------------------------------------------------------
+
+/**
+ * `TransactionModalState` is a discriminated union so that each phase can
+ * carry exactly the data it needs (and nothing it doesn't).
+ */
+export type TransactionModalState =
+    | IdleState
+    | AwaitingSignatureState
+    | SubmittingState
+    | ConfirmedState
+    | FailedState
+    | RetryableState;
+
+export interface IdleState {
+    phase: "idle";
+}
+
+export interface AwaitingSignatureState {
+    phase: "awaiting_signature";
+    /** Human-readable label shown below the spinner, e.g. "Waiting for wallet signature…" */
+    stepLabel: string;
+}
+
+export interface SubmittingState {
+    phase: "submitting";
+    stepLabel: string;
+    /**
+     * Optional 0–100 progress value.  When omitted the UI shows an
+     * indeterminate spinner instead of a progress bar.
+     */
+    progress?: number;
+    /** Optional on-chain reference (txHash / reference ID). */
+    referenceId?: string;
+    /** Network name for display, e.g. "testnet". */
+    network?: string;
+}
+
+export interface ConfirmedState {
+    phase: "confirmed";
+    referenceId?: string;
+    network?: string;
+}
+
+export interface FailedState {
+    phase: "failed";
+    /** Short error description shown to the user. */
+    errorMessage: string;
+    /** Whether the user is allowed to dismiss the modal. */
+    dismissible?: boolean;
+}
+
+export interface RetryableState {
+    phase: "retryable";
+    errorMessage: string;
+    /** When true the consuming component should offer a "Try again" CTA. */
+    canRetry: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Type guards
+// ---------------------------------------------------------------------------
+
+export const isIdle = (s: TransactionModalState): s is IdleState =>
+    s.phase === "idle";
+
+export const isAwaitingSignature = (
+    s: TransactionModalState,
+): s is AwaitingSignatureState => s.phase === "awaiting_signature";
+
+export const isSubmitting = (s: TransactionModalState): s is SubmittingState =>
+    s.phase === "submitting";
+
+export const isConfirmed = (s: TransactionModalState): s is ConfirmedState =>
+    s.phase === "confirmed";
+
+export const isFailed = (s: TransactionModalState): s is FailedState =>
+    s.phase === "failed";
+
+export const isRetryable = (s: TransactionModalState): s is RetryableState =>
+    s.phase === "retryable";
+
+/** True for any "in-flight" phase — useful for disabling the close button. */
+export const isInFlight = (s: TransactionModalState): boolean =>
+    s.phase === "awaiting_signature" || s.phase === "submitting";
+
+/** True for any terminal phase — the flow has ended (success or failure). */
+export const isTerminal = (s: TransactionModalState): boolean =>
+    s.phase === "confirmed" || s.phase === "failed" || s.phase === "retryable";
+
+// ---------------------------------------------------------------------------
+// Factory helpers  (keep construction sites DRY)
+// ---------------------------------------------------------------------------
+
+export const modalState = {
+    idle: (): IdleState => ({ phase: "idle" }),
+
+    awaitingSignature: (stepLabel: string): AwaitingSignatureState => ({
+        phase: "awaiting_signature",
+        stepLabel,
+    }),
+
+    submitting: (
+        stepLabel: string,
+        opts?: { progress?: number; referenceId?: string; network?: string },
+    ): SubmittingState => ({
+        phase: "submitting",
+        stepLabel,
+        ...opts,
+    }),
+
+    confirmed: (opts?: {
+        referenceId?: string;
+        network?: string;
+    }): ConfirmedState => ({
+        phase: "confirmed",
+        ...opts,
+    }),
+
+    failed: (
+        errorMessage: string,
+        opts?: { dismissible?: boolean },
+    ): FailedState => ({
+        phase: "failed",
+        errorMessage,
+        dismissible: opts?.dismissible ?? true,
+    }),
+
+    retryable: (
+        errorMessage: string,
+        canRetry = true,
+    ): RetryableState => ({
+        phase: "retryable",
+        errorMessage,
+        canRetry,
+    }),
+} as const;

--- a/client/src/components/modals/useTransactionModal.ts
+++ b/client/src/components/modals/useTransactionModal.ts
@@ -1,0 +1,129 @@
+/**
+ * useTransactionModal.ts
+ *
+ * Shared React hook that manages a `TransactionModalState` value and exposes
+ * a stable set of transition helpers.
+ *
+ * Usage
+ * ─────
+ *   const { state, actions, isOpen } = useTransactionModal();
+ *
+ *   // start the flow
+ *   actions.awaitSignature("Waiting for wallet…");
+ *
+ *   // once the tx is broadcasting
+ *   actions.submit("Submitting…", { progress: 60, referenceId: txHash });
+ *
+ *   // on success
+ *   actions.confirm({ referenceId: txHash, network: "testnet" });
+ *
+ *   // on hard failure
+ *   actions.fail("Insufficient funds.");
+ *
+ *   // on soft failure (can retry)
+ *   actions.setRetryable("Network error – please try again.");
+ *
+ *   // reset
+ *   actions.reset();
+ *
+ * The `isOpen` boolean is derived automatically: the modal should be shown
+ * for every phase except `idle`.
+ */
+
+import { useState, useCallback } from "react";
+import {
+    modalState,
+    type ConfirmedState,
+    type TransactionModalState,
+} from "./transactionModalState";
+
+// ---------------------------------------------------------------------------
+// Public API types
+// ---------------------------------------------------------------------------
+
+export interface TransactionModalActions {
+    awaitSignature: (stepLabel: string) => void;
+    submit: (
+        stepLabel: string,
+        opts?: { progress?: number; referenceId?: string; network?: string },
+    ) => void;
+    confirm: (opts?: { referenceId?: string; network?: string }) => void;
+    fail: (errorMessage: string, opts?: { dismissible?: boolean }) => void;
+    setRetryable: (errorMessage: string, canRetry?: boolean) => void;
+    reset: () => void;
+    /** Directly set an arbitrary state (escape hatch for complex flows). */
+    set: (next: TransactionModalState) => void;
+}
+
+export interface UseTransactionModalReturn {
+    state: TransactionModalState;
+    actions: TransactionModalActions;
+    /** Convenience: true whenever the phase is not "idle". */
+    isOpen: boolean;
+    /** Convenience: the confirmed state (defined only when phase === "confirmed"). */
+    confirmedState: ConfirmedState | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useTransactionModal(): UseTransactionModalReturn {
+    const [state, setState] = useState<TransactionModalState>(
+        modalState.idle(),
+    );
+
+    const awaitSignature = useCallback((stepLabel: string) => {
+        setState(modalState.awaitingSignature(stepLabel));
+    }, []);
+
+    const submit = useCallback(
+        (
+            stepLabel: string,
+            opts?: { progress?: number; referenceId?: string; network?: string },
+        ) => {
+            setState(modalState.submitting(stepLabel, opts));
+        },
+        [],
+    );
+
+    const confirm = useCallback(
+        (opts?: { referenceId?: string; network?: string }) => {
+            setState(modalState.confirmed(opts));
+        },
+        [],
+    );
+
+    const fail = useCallback(
+        (errorMessage: string, opts?: { dismissible?: boolean }) => {
+            setState(modalState.failed(errorMessage, opts));
+        },
+        [],
+    );
+
+    const setRetryable = useCallback(
+        (errorMessage: string, canRetry = true) => {
+            setState(modalState.retryable(errorMessage, canRetry));
+        },
+        [],
+    );
+
+    const reset = useCallback(() => {
+        setState(modalState.idle());
+    }, []);
+
+    const set = useCallback((next: TransactionModalState) => {
+        setState(next);
+    }, []);
+
+    const isOpen = state.phase !== "idle";
+    const confirmedState =
+        state.phase === "confirmed" ? (state as ConfirmedState) : undefined;
+
+    return {
+        state,
+        actions: { awaitSignature, submit, confirm, fail, setRetryable, reset, set },
+        isOpen,
+        confirmedState,
+    };
+}


### PR DESCRIPTION
## What was done

I unified the modal states across both the ticket purchase and raffle creation flows by defining a shared state machine (`transactionModalState.ts`) that covers six phases: `idle`, `awaiting_signature`, `submitting`, `confirmed`, `failed`, and `retryable`. I also created a reusable React hook (`useTransactionModal.ts`) to manage transitions between these phases consistently. I then refactored the five relevant modal components (`ProcessingTickets`, `SuccessfulTicket`, `FailedTicket`, `ProcessingRaffleCreation`, and `RaffleCreatedSuccess`) to consume this new state model, ensuring they update dynamically based on the current transaction phase while retaining their specific visual designs and remaining completely backwards-compatible with their old props. Finally, I wrote a comprehensive unit test suite (`transactionModalState.spec.ts`) to verify that all state transitions and type guards function correctly.


Close #515