### PR TITLE
feat: add Zod validation and recovery schemas to MetadataService

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -35,7 +35,8 @@
         "recharts": "^3.8.1",
         "sonner": "^2.0.7",
         "swiper": "^11.2.10",
-        "tailwindcss": "^4.1.13"
+        "tailwindcss": "^4.1.13",
+        "zod": "^4.4.3"
     },
     "devDependencies": {
         "@eslint/js": "^9.33.0",

--- a/client/src/services/metadataService.spec.ts
+++ b/client/src/services/metadataService.spec.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MetadataService, RaffleMetadataSchema, SafeRaffleMetadataSchema } from './metadataService';
+import { supabase } from '../config/supabase';
+import type { RaffleMetadata } from '../types/types';
+
+vi.mock('../config/supabase', () => ({
+  supabase: {
+    from: vi.fn().mockReturnThis(),
+    insert: vi.fn().mockReturnThis(),
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    single: vi.fn().mockReturnThis(),
+    update: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+  },
+  RAFFLE_METADATA_TABLE: 'raffle_metadata',
+}));
+
+describe('MetadataService', () => {
+  const validMetadata: RaffleMetadata = {
+    title: 'Test Raffle',
+    description: 'Test Description',
+    image: 'https://example.com/image.png',
+    prizeName: '100 XLM',
+    prizeValue: '100',
+    prizeCurrency: 'XLM',
+    category: 'Crypto',
+    tags: ['test'],
+    createdBy: 'GDTEST...',
+    createdAt: 1234567890,
+    updatedAt: 1234567890,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Validation', () => {
+    it('validates correct metadata', () => {
+      expect(() => RaffleMetadataSchema.parse(validMetadata)).not.toThrow();
+    });
+
+    it('throws on invalid metadata for upload', () => {
+      const invalidMetadata = { ...validMetadata, title: '' }; // Title is required
+      expect(() => RaffleMetadataSchema.parse(invalidMetadata)).toThrow();
+    });
+
+    it('provides safe fallbacks for invalid remote metadata', () => {
+      const invalidRemoteData = {
+        title: 123, // Invalid type
+        // missing description
+        image: 'not-a-url-but-string-is-ok', 
+      };
+
+      const parsed = SafeRaffleMetadataSchema.parse(invalidRemoteData);
+      expect(parsed.title).toBe('Unknown Raffle');
+      expect(parsed.description).toBe('Metadata could not be loaded');
+      expect(parsed.image).toBe('not-a-url-but-string-is-ok');
+      expect(parsed.prizeName).toBe('Unknown Prize');
+      expect(parsed.prizeCurrency).toBe('XLM');
+    });
+  });
+
+  describe('uploadRaffleMetadata', () => {
+    it('validates and uploads valid metadata', async () => {
+      const mockInsert = vi.fn().mockReturnThis();
+      const mockSelect = vi.fn().mockReturnThis();
+      const mockSingle = vi.fn().mockResolvedValue({ data: { id: 'test-id' }, error: null });
+
+      (supabase.from as any).mockReturnValue({
+        insert: mockInsert,
+      });
+      mockInsert.mockReturnValue({ select: mockSelect });
+      mockSelect.mockReturnValue({ single: mockSingle });
+
+      const id = await MetadataService.uploadRaffleMetadata(validMetadata);
+      expect(id).toBe('test-id');
+      expect(mockInsert).toHaveBeenCalledWith([
+        expect.objectContaining({
+          metadata: validMetadata,
+        }),
+      ]);
+    });
+
+    it('throws error if metadata is invalid before calling supabase', async () => {
+      const invalidMetadata = { ...validMetadata, title: '' } as RaffleMetadata;
+      const mockInsert = vi.fn();
+      (supabase.from as any).mockReturnValue({ insert: mockInsert });
+
+      await expect(MetadataService.uploadRaffleMetadata(invalidMetadata)).rejects.toThrow();
+      expect(mockInsert).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/client/src/services/metadataService.ts
+++ b/client/src/services/metadataService.ts
@@ -1,7 +1,38 @@
+import { z } from "zod";
 import { supabase, RAFFLE_METADATA_TABLE } from "../config/supabase";
 import { api } from "./apiClient";
 import { API_CONFIG } from "../config/api";
 import type { RaffleMetadata, SupabaseRaffleRecord } from "../types/types";
+
+export const RaffleMetadataSchema = z.object({
+  title: z.string().min(1, "Title is required"),
+  description: z.string().min(1, "Description is required"),
+  image: z.string(),
+  images: z.array(z.string()).optional(),
+  prizeName: z.string(),
+  prizeValue: z.string(),
+  prizeCurrency: z.string(),
+  category: z.string(),
+  tags: z.array(z.string()),
+  createdBy: z.string(),
+  createdAt: z.number(),
+  updatedAt: z.number(),
+});
+
+export const SafeRaffleMetadataSchema = z.object({
+  title: z.string().catch("Unknown Raffle"),
+  description: z.string().catch("Metadata could not be loaded"),
+  image: z.string().catch(""),
+  images: z.array(z.string()).optional().catch(undefined),
+  prizeName: z.string().catch("Unknown Prize"),
+  prizeValue: z.string().catch("0"),
+  prizeCurrency: z.string().catch("XLM"),
+  category: z.string().catch("Other"),
+  tags: z.array(z.string()).catch([]),
+  createdBy: z.string().catch(""),
+  createdAt: z.number().catch(0),
+  updatedAt: z.number().catch(0),
+});
 
 export class MetadataService {
   /**
@@ -9,12 +40,13 @@ export class MetadataService {
    */
   static async uploadRaffleMetadata(metadata: RaffleMetadata): Promise<string> {
     try {
-      console.log("📤 MetadataService: Uploading metadata:", metadata);
+      const validatedMetadata = RaffleMetadataSchema.parse(metadata);
+      console.log("📤 MetadataService: Uploading metadata:", validatedMetadata);
       const { data, error } = await supabase
         .from(RAFFLE_METADATA_TABLE)
         .insert([
           {
-            metadata,
+            metadata: validatedMetadata,
             created_at: new Date().toISOString(),
             updated_at: new Date().toISOString(),
           },
@@ -53,7 +85,7 @@ export class MetadataService {
         return null;
       }
 
-      return data.metadata;
+      return SafeRaffleMetadataSchema.parse(data.metadata) as RaffleMetadata;
     } catch (error) {
       console.error("Error fetching raffle metadata:", error);
       return null;
@@ -78,7 +110,7 @@ export class MetadataService {
         return null;
       }
 
-      return data.metadata;
+      return SafeRaffleMetadataSchema.parse(data.metadata) as RaffleMetadata;
     } catch (error) {
       console.error("Error fetching raffle metadata by contract ID:", error);
       return null;
@@ -93,11 +125,14 @@ export class MetadataService {
     metadata: Partial<RaffleMetadata>,
   ): Promise<boolean> {
     try {
+      const partialSchema = RaffleMetadataSchema.partial();
+      const validatedMetadata = partialSchema.parse(metadata);
+
       const { error } = await supabase
         .from(RAFFLE_METADATA_TABLE)
         .update({
           metadata: {
-            ...metadata,
+            ...validatedMetadata,
             updatedAt: Date.now(),
           },
           updated_at: new Date().toISOString(),
@@ -159,7 +194,10 @@ export class MetadataService {
         throw new Error(`Failed to fetch raffles by creator: ${error.message}`);
       }
 
-      return data || [];
+      return (data || []).map((record) => ({
+        ...record,
+        metadata: SafeRaffleMetadataSchema.parse(record.metadata) as RaffleMetadata,
+      }));
     } catch (error) {
       console.error("Error fetching raffles by creator:", error);
       return [];


### PR DESCRIPTION
## What was done 

I've successfully implemented a robust validation layer for raffle metadata using Zod. I started by installing the `zod` package and defining two schemas in `metadataService.ts`: a strict `RaffleMetadataSchema` used to validate data before it's uploaded or updated, and a `SafeRaffleMetadataSchema` that leverages Zod's `.catch()` feature to provide safe fallback values for missing or invalid fields when reading from the database. I then integrated these schemas into the `MetadataService` methods, ensuring that any new or updated metadata is strictly checked, while fetching methods like `getRaffleMetadata` and `getRafflesByCreator` safely parse the remote data without crashing the app. Finally, I created a comprehensive test suite in `metadataService.spec.ts` that validates both the strict and fallback behaviors, and all tests are passing successfully.|


Close #519