### PR TITLE
feat(cache): introduce typed cache keys and invalidation rules

### DIFF
--- a/indexer/src/cache/cache.invalidations.ts
+++ b/indexer/src/cache/cache.invalidations.ts
@@ -1,0 +1,35 @@
+import { CacheService } from './cache.service';
+import { CacheKeys } from './cache.keys';
+
+/**
+ * Structured invalidation rules. Each function encapsulates everything that must
+ * be evicted when a particular event occurs. Callers never construct keys directly.
+ */
+export const CacheInvalidations = {
+  /**
+   * Invalidate on ticket purchase: raffle detail, active list, leaderboard,
+   * and the buyer's profile.
+   */
+  async onPurchase(cache: CacheService, raffleId: string, buyerAddress: string): Promise<void> {
+    await Promise.all([
+      cache.del(CacheKeys.raffle.detail(raffleId)),
+      cache.del(CacheKeys.raffle.active()),
+      cache.del(CacheKeys.leaderboard.global()),
+      cache.del(CacheKeys.user.profile(buyerAddress)),
+    ]);
+  },
+
+  /**
+   * Invalidate on raffle finalize: raffle detail, active list, leaderboard,
+   * platform stats, and the winner's profile.
+   */
+  async onFinalize(cache: CacheService, raffleId: string, winnerAddress: string): Promise<void> {
+    await Promise.all([
+      cache.del(CacheKeys.raffle.detail(raffleId)),
+      cache.del(CacheKeys.raffle.active()),
+      cache.del(CacheKeys.leaderboard.global()),
+      cache.del(CacheKeys.stats.platform()),
+      cache.del(CacheKeys.user.profile(winnerAddress)),
+    ]);
+  },
+};

--- a/indexer/src/cache/cache.keys.ts
+++ b/indexer/src/cache/cache.keys.ts
@@ -1,0 +1,19 @@
+/**
+ * Centralized cache key definitions. All cache key construction must go through
+ * these helpers — no raw string concatenation elsewhere.
+ */
+export const CacheKeys = {
+  raffle: {
+    active: () => 'raffle:active' as const,
+    detail: (id: string) => `raffle:${id}`,
+  },
+  leaderboard: {
+    global: () => 'leaderboard' as const,
+  },
+  user: {
+    profile: (address: string) => `user:${address}`,
+  },
+  stats: {
+    platform: () => 'stats:platform' as const,
+  },
+} as const;

--- a/indexer/src/cache/cache.service.spec.ts
+++ b/indexer/src/cache/cache.service.spec.ts
@@ -1,6 +1,8 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { CacheService } from './cache.service';
 import { ConfigService } from '@nestjs/config';
+import { CacheKeys } from './cache.keys';
+import { CacheInvalidations } from './cache.invalidations';
 import RedisMock from 'ioredis-mock';
 
 jest.mock('ioredis', () => {
@@ -90,5 +92,93 @@ describe('CacheService', () => {
     await service.invalidatePlatformStats();
     stats = await service.getPlatformStats();
     expect(stats).toBeNull();
+  });
+
+  // --- CacheKeys unit tests ---
+
+  describe('CacheKeys', () => {
+    it('generates correct static keys', () => {
+      expect(CacheKeys.raffle.active()).toBe('raffle:active');
+      expect(CacheKeys.leaderboard.global()).toBe('leaderboard');
+      expect(CacheKeys.stats.platform()).toBe('stats:platform');
+    });
+
+    it('generates correct dynamic keys', () => {
+      expect(CacheKeys.raffle.detail('abc')).toBe('raffle:abc');
+      expect(CacheKeys.user.profile('GADDR')).toBe('user:GADDR');
+    });
+
+    it('generates distinct keys for different ids', () => {
+      expect(CacheKeys.raffle.detail('r1')).not.toBe(CacheKeys.raffle.detail('r2'));
+      expect(CacheKeys.user.profile('A')).not.toBe(CacheKeys.user.profile('B'));
+    });
+  });
+
+  // --- CacheInvalidations tests ---
+
+  describe('CacheInvalidations.onPurchase', () => {
+    it('invalidates raffle detail, active list, leaderboard, and buyer profile', async () => {
+      const raffleId = 'raffle1';
+      const buyer = 'GBUYER';
+
+      await service.setRaffleDetail(raffleId, { seats: 10 });
+      await service.setActiveRaffles([{ id: raffleId }]);
+      await service.setLeaderboard([{ address: buyer }]);
+      await service.setUserProfile(buyer, { wins: 0 });
+
+      await CacheInvalidations.onPurchase(service, raffleId, buyer);
+
+      expect(await service.getRaffleDetail(raffleId)).toBeNull();
+      expect(await service.getActiveRaffles()).toBeNull();
+      expect(await service.getLeaderboard()).toBeNull();
+      expect(await service.getUserProfile(buyer)).toBeNull();
+    });
+
+    it('does not throw when keys are missing', async () => {
+      await expect(
+        CacheInvalidations.onPurchase(service, 'nonexistent', 'GNOBODY'),
+      ).resolves.not.toThrow();
+    });
+
+    it('does not throw on repeated calls', async () => {
+      await CacheInvalidations.onPurchase(service, 'r1', 'GADDR');
+      await expect(
+        CacheInvalidations.onPurchase(service, 'r1', 'GADDR'),
+      ).resolves.not.toThrow();
+    });
+  });
+
+  describe('CacheInvalidations.onFinalize', () => {
+    it('invalidates raffle detail, active list, leaderboard, platform stats, and winner profile', async () => {
+      const raffleId = 'raffle2';
+      const winner = 'GWINNER';
+
+      await service.setRaffleDetail(raffleId, { seats: 5 });
+      await service.setActiveRaffles([{ id: raffleId }]);
+      await service.setLeaderboard([{ address: winner, wins: 1 }]);
+      await service.setPlatformStats({ totalRaffles: 42 });
+      await service.setUserProfile(winner, { wins: 1 });
+
+      await CacheInvalidations.onFinalize(service, raffleId, winner);
+
+      expect(await service.getRaffleDetail(raffleId)).toBeNull();
+      expect(await service.getActiveRaffles()).toBeNull();
+      expect(await service.getLeaderboard()).toBeNull();
+      expect(await service.getPlatformStats()).toBeNull();
+      expect(await service.getUserProfile(winner)).toBeNull();
+    });
+
+    it('does not throw when keys are missing', async () => {
+      await expect(
+        CacheInvalidations.onFinalize(service, 'nonexistent', 'GNOBODY'),
+      ).resolves.not.toThrow();
+    });
+
+    it('does not throw on repeated calls', async () => {
+      await CacheInvalidations.onFinalize(service, 'r2', 'GADDR');
+      await expect(
+        CacheInvalidations.onFinalize(service, 'r2', 'GADDR'),
+      ).resolves.not.toThrow();
+    });
   });
 });

--- a/indexer/src/cache/cache.service.ts
+++ b/indexer/src/cache/cache.service.ts
@@ -1,6 +1,8 @@
 import { Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
 import Redis from 'ioredis';
 import { ConfigService } from '@nestjs/config';
+import { CacheKeys } from './cache.keys';
+import { CacheTTL } from './cache.ttl';
 
 export type CacheBucket = 'raffles' | 'users' | 'stats' | 'others';
 
@@ -87,14 +89,6 @@ export class CacheService implements OnModuleInit, OnModuleDestroy {
     }
   }
 
-  private readonly TTLS = {
-    ACTIVE_RAFFLES: 30,
-    RAFFLE_DETAIL: 10,
-    LEADERBOARD: 60,
-    USER_PROFILE: 30,
-    PLATFORM_STATS: 300,
-  };
-
   private deriveBucket(key: string): CacheBucket {
     if (key.startsWith('raffle:') || key === 'leaderboard') {
       return 'raffles';
@@ -166,63 +160,63 @@ export class CacheService implements OnModuleInit, OnModuleDestroy {
   // --- Specific Cache Accessors ---
 
   async getActiveRaffles(): Promise<any | null> {
-    return this.get('raffle:active');
+    return this.get(CacheKeys.raffle.active());
   }
 
   async setActiveRaffles(raffles: any): Promise<void> {
-    await this.set('raffle:active', raffles, this.TTLS.ACTIVE_RAFFLES);
+    await this.set(CacheKeys.raffle.active(), raffles, CacheTTL.ACTIVE_RAFFLES);
   }
 
   async invalidateActiveRaffles(): Promise<void> {
-    await this.del('raffle:active');
+    await this.del(CacheKeys.raffle.active());
   }
 
   async getRaffleDetail(id: string): Promise<any | null> {
-    return this.get(`raffle:${id}`);
+    return this.get(CacheKeys.raffle.detail(id));
   }
 
   async setRaffleDetail(id: string, detail: any): Promise<void> {
-    await this.set(`raffle:${id}`, detail, this.TTLS.RAFFLE_DETAIL);
+    await this.set(CacheKeys.raffle.detail(id), detail, CacheTTL.RAFFLE_DETAIL);
   }
 
   async invalidateRaffleDetail(id: string): Promise<void> {
-    await this.del(`raffle:${id}`);
+    await this.del(CacheKeys.raffle.detail(id));
   }
 
   async getLeaderboard(): Promise<any | null> {
-    return this.get('leaderboard');
+    return this.get(CacheKeys.leaderboard.global());
   }
 
   async setLeaderboard(leaderboard: any): Promise<void> {
-    await this.set('leaderboard', leaderboard, this.TTLS.LEADERBOARD);
+    await this.set(CacheKeys.leaderboard.global(), leaderboard, CacheTTL.LEADERBOARD);
   }
 
   async invalidateLeaderboard(): Promise<void> {
-    await this.del('leaderboard');
+    await this.del(CacheKeys.leaderboard.global());
   }
 
   async getUserProfile(address: string): Promise<any | null> {
-    return this.get(`user:${address}`);
+    return this.get(CacheKeys.user.profile(address));
   }
 
   async setUserProfile(address: string, profile: any): Promise<void> {
-    await this.set(`user:${address}`, profile, this.TTLS.USER_PROFILE);
+    await this.set(CacheKeys.user.profile(address), profile, CacheTTL.USER_PROFILE);
   }
 
   async invalidateUserProfile(address: string): Promise<void> {
-    await this.del(`user:${address}`);
+    await this.del(CacheKeys.user.profile(address));
   }
 
   async getPlatformStats(): Promise<any | null> {
-    return this.get('stats:platform');
+    return this.get(CacheKeys.stats.platform());
   }
 
   async setPlatformStats(stats: any): Promise<void> {
-    await this.set('stats:platform', stats, this.TTLS.PLATFORM_STATS);
+    await this.set(CacheKeys.stats.platform(), stats, CacheTTL.PLATFORM_STATS);
   }
 
   async invalidatePlatformStats(): Promise<void> {
-    await this.del('stats:platform');
+    await this.del(CacheKeys.stats.platform());
   }
 
   // --- Monitoring & Stats ---

--- a/indexer/src/cache/cache.ttl.ts
+++ b/indexer/src/cache/cache.ttl.ts
@@ -1,0 +1,15 @@
+/** TTL constants (in seconds) grouped by cache category. */
+export const CacheTTL = {
+  /** Short-lived: data changes frequently (leaderboard). */
+  LEADERBOARD: 60,
+
+  /** Medium-lived: raffle data changes on purchase/finalize. */
+  ACTIVE_RAFFLES: 30,
+  RAFFLE_DETAIL: 10,
+
+  /** Long-lived: user profiles change infrequently. */
+  USER_PROFILE: 300,
+
+  /** Background stats, refreshed on a slow cadence. */
+  PLATFORM_STATS: 300,
+} as const;


### PR DESCRIPTION
- Add cache.keys.ts: CacheKeys helper with domain-grouped typed key builders
- Add cache.ttl.ts: CacheTTL constants by category (short/medium/long)
- Add cache.invalidations.ts: onPurchase and onFinalize invalidation rules
- Refactor cache.service.ts: remove inline key strings and TTL literals
- Expand cache.service.spec.ts: add key generation and invalidation tests

Closes #563