### PR TITLE
fix: throw typed PinningError on IPFS pin failure instead of returnin…

### DIFF
--- a/backend/src/services/pinning.service.ts
+++ b/backend/src/services/pinning.service.ts
@@ -1,5 +1,16 @@
 import { Injectable, Logger } from '@nestjs/common';
 
+/** Thrown by PinningService.pin() when pinning is enabled but fails. */
+export class PinningError extends Error {
+  constructor(
+    message: string,
+    public readonly cause?: unknown,
+  ) {
+    super(message);
+    this.name = 'PinningError';
+  }
+}
+
 @Injectable()
 export class PinningService {
   private readonly logger = new Logger(PinningService.name);
@@ -8,11 +19,17 @@ export class PinningService {
    * Pins JSON metadata to IPFS using Pinata API.
    * Requires PINATA_JWT or (PINATA_API_KEY and PINATA_API_SECRET) env vars.
    * Skips if ENABLE_IPFS_PINNING is not 'true'.
+   *
+   * @returns The IPFS CID string on success, or `null` when pinning is
+   *   intentionally disabled (ENABLE_IPFS_PINNING !== 'true').
+   * @throws {PinningError} When pinning is enabled but credentials are missing
+   *   or the Pinata API call fails. Callers can catch this to decide whether
+   *   to abort the request or continue in a degraded state without a CID.
    */
   async pin(payload: any): Promise<string | null> {
     const isEnabled = process.env.ENABLE_IPFS_PINNING === 'true';
     if (!isEnabled) {
-      this.logger.debug('IPFS pinning is disabled');
+      this.logger.debug('IPFS pinning is disabled — skipping pin attempt');
       return null;
     }
 
@@ -21,9 +38,13 @@ export class PinningService {
     const pinataSecret = process.env.PINATA_API_SECRET;
 
     if (!pinataJwt && (!pinataApiKey || !pinataSecret)) {
-      this.logger.warn('IPFS pinning enabled but Pinata credentials are missing');
-      return null;
+      const msg = 'IPFS pinning is enabled but Pinata credentials are not configured';
+      this.logger.error(msg, { hint: 'Set PINATA_JWT or both PINATA_API_KEY and PINATA_API_SECRET' });
+      throw new PinningError(msg);
     }
+
+    const raffleId = payload?.raffle_id ?? 'unknown';
+    this.logger.log(`Pinning metadata to IPFS`, { raffle_id: raffleId });
 
     try {
       const headers: Record<string, string> = {
@@ -50,15 +71,19 @@ export class PinningService {
 
       if (!response.ok) {
         const errorText = await response.text();
-        this.logger.error(`Pinata API error (${response.status}): ${errorText}`);
-        return null;
+        const msg = `Pinata API returned ${response.status}`;
+        this.logger.error(msg, { raffle_id: raffleId, status: response.status, body: errorText });
+        throw new PinningError(`${msg}: ${errorText}`);
       }
 
       const data = (await response.json()) as { IpfsHash: string };
+      this.logger.log(`Successfully pinned metadata`, { raffle_id: raffleId, cid: data.IpfsHash });
       return data.IpfsHash;
     } catch (err) {
-      this.logger.error(`Failed to pin metadata to IPFS: ${err instanceof Error ? err.message : String(err)}`);
-      return null;
+      if (err instanceof PinningError) throw err;
+      const msg = `Failed to pin metadata to IPFS: ${err instanceof Error ? err.message : String(err)}`;
+      this.logger.error(msg, { raffle_id: raffleId, cause: err });
+      throw new PinningError(msg, err);
     }
   }
 }


### PR DESCRIPTION
…g null (#754)

Previously PinningService.pin() returned null for three different conditions, making it impossible for callers to distinguish between them:
  1. Pinning intentionally disabled (ENABLE_IPFS_PINNING != 'true')
  2. Pinata credentials missing/misconfigured
  3. Pinata API call failed at runtime

Cases 2 and 3 were silent: no exception, no structured log context, and metadata was persisted to the DB with no CID, pointing to content that was never actually pinned (orphaned metadata).

Changes:
- Export PinningError class (extends Error) so callers can catch and handle pin failures distinctly from other errors.
- Case 1 (disabled): unchanged — still returns null with a debug log. This is the only legitimate null return path.
- Case 2 (missing credentials): now throws PinningError immediately with an error-level structured log including a configuration hint.
- Case 3 (API failure): non-ok HTTP responses and network errors now throw PinningError with error-level structured logs containing raffle_id, HTTP status, and response body for observability.
- Add a log.log() on successful pin with raffle_id and CID for traceability.
- Re-throw PinningError instances immediately in the catch block to avoid double-wrapping.
closes #754