### PR TITLE
feat(infra): add K8s readiness/liveness probes to all deployments (#824)

### DIFF
--- a/backend/k8s/deployment.yaml
+++ b/backend/k8s/deployment.yaml
@@ -10,6 +10,11 @@ spec:
   selector:
     matchLabels:
       app: tikka-backend
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   template:
     metadata:
       labels:
@@ -37,13 +42,22 @@ spec:
             limits:
               cpu: "500m"
               memory: "512Mi"
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 3001
+            initialDelaySeconds: 0
+            periodSeconds: 5
+            failureThreshold: 30
+            timeoutSeconds: 3
           readinessProbe:
             httpGet:
               path: /health
               port: 3001
-            initialDelaySeconds: 5
-            periodSeconds: 10
+            initialDelaySeconds: 10
+            periodSeconds: 5
             failureThreshold: 3
+            timeoutSeconds: 5
           livenessProbe:
             httpGet:
               path: /health
@@ -51,6 +65,7 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 10
             failureThreshold: 3
+            timeoutSeconds: 5
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/indexer/kubernetes/deployment.yaml
+++ b/indexer/kubernetes/deployment.yaml
@@ -10,6 +10,11 @@ spec:
   selector:
     matchLabels:
       app: tikka-indexer
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   template:
     metadata:
       labels:
@@ -50,7 +55,7 @@ spec:
               path: /health
               port: 3002
             initialDelaySeconds: 10
-            periodSeconds: 15
+            periodSeconds: 5
             failureThreshold: 3
             timeoutSeconds: 5
           livenessProbe:
@@ -58,10 +63,9 @@ spec:
               path: /health
               port: 3002
             initialDelaySeconds: 30
-            periodSeconds: 30
+            periodSeconds: 10
             failureThreshold: 3
             timeoutSeconds: 5
-      terminationGracePeriodSeconds: 30
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/oracle/k8s/deployment.yaml
+++ b/oracle/k8s/deployment.yaml
@@ -14,6 +14,11 @@ spec:
   selector:
     matchLabels:
       app: tikka-oracle
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   template:
     metadata:
       labels:
@@ -62,20 +67,30 @@ spec:
             limits:
               cpu: "500m"
               memory: "512Mi"
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 3003
+            initialDelaySeconds: 0
+            periodSeconds: 5
+            failureThreshold: 30
+            timeoutSeconds: 3
           readinessProbe:
             httpGet:
               path: /health
               port: 3003
             initialDelaySeconds: 10
-            periodSeconds: 15
+            periodSeconds: 5
             failureThreshold: 3
+            timeoutSeconds: 5
           livenessProbe:
             httpGet:
               path: /health
               port: 3003
             initialDelaySeconds: 30
-            periodSeconds: 30
-            failureThreshold: 5
+            periodSeconds: 10
+            failureThreshold: 3
+            timeoutSeconds: 5
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true


### PR DESCRIPTION
## Summary

- Fix YAML structural bug in indexer deployment (duplicate `terminationGracePeriodSeconds` broke the container block, leaving `securityContext` orphaned outside the container spec)
- Align readinessProbe (`initialDelaySeconds: 10`, `periodSeconds: 5`) and livenessProbe (`periodSeconds: 10`, `failureThreshold: 3`) values across indexer, backend, and oracle to match the spec
- Add `startupProbe` to backend and oracle (mirrors the indexer pattern)
- Add `timeoutSeconds` to all probes across all three services
- Add explicit `RollingUpdate` strategy (`maxUnavailable: 0`) to all three Deployments so rolling updates wait for new pods to pass readiness before terminating old ones, preventing in-flight request drops

## Test plan

- [ ] Verify `kubectl apply -f` succeeds without YAML parse errors on all three manifests
- [ ] Confirm pods reach `Ready` state before receiving traffic during a rolling deploy (`kubectl rollout status deployment/tikka-indexer`)
- [ ] Confirm no in-flight requests are dropped during rollout (check ingress/service error rates)
- [ ] Verify old pods are only terminated after new pods pass readiness (`kubectl describe pod` events)
- [ ] Confirm `startupProbe` on backend and oracle prevents premature liveness kills on slow starts

## Related

Closes #824

🤖 Generated with [Claude Code](https://claude.com/claude-code)
