### PR TITLE
feat: [backend] Add support for IPFS metadata pinning via Pinata

### DIFF
--- a/backend/.npmrc
+++ b/backend/.npmrc
@@ -1,0 +1,5 @@
+only-built-dependencies[]=@firebase/util
+only-built-dependencies[]=@nestjs/core
+only-built-dependencies[]=@sentry/node-cpu-profiler
+only-built-dependencies[]=protobufjs
+only-built-dependencies[]=sharp

--- a/backend/pnpm-workspace.yaml
+++ b/backend/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+allowBuilds:
+  '@firebase/util': true
+  '@nestjs/core': true
+  '@sentry/node-cpu-profiler': true
+  protobufjs: true
+  sharp: true

--- a/backend/src/api/rest/raffles/raffles.service.spec.ts
+++ b/backend/src/api/rest/raffles/raffles.service.spec.ts
@@ -3,6 +3,7 @@ import { ConfigService } from '@nestjs/config';
 import { RafflesService } from './raffles.service';
 import { IndexerService, IndexerRaffleData } from '../../../services/indexer.service';
 import { MetadataService, RaffleMetadata } from '../../../services/metadata.service';
+import { PinningService } from '../../../services/pinning.service';
 
 const mockRaffle: IndexerRaffleData = {
   id: 1,
@@ -37,8 +38,9 @@ const mockMetadata: RaffleMetadata = {
 describe('RafflesService', () => {
   let service: RafflesService;
   let indexerService: jest.Mocked<Pick<IndexerService, 'listRaffles' | 'getRaffle'>>;
-  let metadataService: jest.Mocked<Pick<MetadataService, 'getMetadata' | 'getBatchMetadata' | 'upsertMetadata'>>;
+  let metadataService: jest.Mocked<Pick<MetadataService, 'getMetadata' | 'getBatchMetadata' | 'upsertMetadata' | 'updateMetadataCid'>>;
   let configService: jest.Mocked<Pick<ConfigService, 'get'>>;
+  let pinningService: jest.Mocked<Pick<PinningService, 'pin'>>;
 
   beforeEach(() => {
     indexerService = {
@@ -49,15 +51,20 @@ describe('RafflesService', () => {
       getMetadata: jest.fn().mockResolvedValue(null),
       getBatchMetadata: jest.fn().mockResolvedValue(new Map()),
       upsertMetadata: jest.fn(),
+      updateMetadataCid: jest.fn(),
     };
     configService = {
       get: jest.fn().mockReturnValue(false),
+    };
+    pinningService = {
+      pin: jest.fn().mockResolvedValue(null),
     };
 
     service = new RafflesService(
       metadataService as unknown as MetadataService,
       indexerService as unknown as IndexerService,
       configService as unknown as ConfigService,
+      pinningService as unknown as PinningService,
     );
   });
 
@@ -160,14 +167,51 @@ describe('RafflesService', () => {
   });
 
   describe('upsertMetadata', () => {
-    it('delegates to metadataService.upsertMetadata', async () => {
+    it('delegates to metadataService.upsertMetadata, pins, and updates metadata_cid on success', async () => {
       const payload = { title: 'New Title' };
       indexerService.getRaffle.mockResolvedValue(mockRaffle);
       metadataService.upsertMetadata.mockResolvedValue({ ...mockMetadata, title: 'New Title' });
+      pinningService.pin.mockResolvedValue('QmPinnedIpfsHash');
+      metadataService.updateMetadataCid.mockResolvedValue({
+        ...mockMetadata,
+        title: 'New Title',
+        metadata_cid: 'QmPinnedIpfsHash',
+      });
 
-      await service.upsertMetadata(1, payload, 'GABC123');
+      const result = await service.upsertMetadata(1, payload, 'GABC123');
 
       expect(metadataService.upsertMetadata).toHaveBeenCalledWith(1, payload);
+      expect(pinningService.pin).toHaveBeenCalledWith({ ...mockMetadata, title: 'New Title' });
+      expect(metadataService.updateMetadataCid).toHaveBeenCalledWith(1, 'QmPinnedIpfsHash');
+      expect(result.metadata_cid).toBe('QmPinnedIpfsHash');
+    });
+
+    it('continues gracefully if PinningService.pin returns null', async () => {
+      const payload = { title: 'New Title' };
+      indexerService.getRaffle.mockResolvedValue(mockRaffle);
+      metadataService.upsertMetadata.mockResolvedValue({ ...mockMetadata, title: 'New Title', metadata_cid: null });
+      pinningService.pin.mockResolvedValue(null);
+
+      const result = await service.upsertMetadata(1, payload, 'GABC123');
+
+      expect(metadataService.upsertMetadata).toHaveBeenCalledWith(1, payload);
+      expect(pinningService.pin).toHaveBeenCalled();
+      expect(metadataService.updateMetadataCid).not.toHaveBeenCalled();
+      expect(result.metadata_cid).toBeNull();
+    });
+
+    it('continues gracefully if PinningService.pin throws an error', async () => {
+      const payload = { title: 'New Title' };
+      indexerService.getRaffle.mockResolvedValue(mockRaffle);
+      metadataService.upsertMetadata.mockResolvedValue({ ...mockMetadata, title: 'New Title', metadata_cid: null });
+      pinningService.pin.mockRejectedValue(new Error('Pinata API offline'));
+
+      const result = await service.upsertMetadata(1, payload, 'GABC123');
+
+      expect(metadataService.upsertMetadata).toHaveBeenCalledWith(1, payload);
+      expect(pinningService.pin).toHaveBeenCalled();
+      expect(metadataService.updateMetadataCid).not.toHaveBeenCalled();
+      expect(result.metadata_cid).toBeNull();
     });
 
     it('throws NotFoundException when raffle is missing in indexer', async () => {

--- a/backend/src/api/rest/raffles/raffles.service.ts
+++ b/backend/src/api/rest/raffles/raffles.service.ts
@@ -3,6 +3,7 @@ import {
   Injectable,
   NotFoundException,
   NotImplementedException,
+  Logger,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import {
@@ -10,6 +11,7 @@ import {
   RaffleMetadata,
   UpsertMetadataPayload,
 } from '../../../services/metadata.service';
+import { PinningService } from '../../../services/pinning.service';
 import {
   IndexerService,
   IndexerRaffleData,
@@ -45,10 +47,13 @@ export interface RaffleDetailResponse {
 
 @Injectable()
 export class RafflesService {
+  private readonly logger = new Logger(RafflesService.name);
+
   constructor(
     private readonly metadataService: MetadataService,
     private readonly indexerService: IndexerService,
     private readonly config: ConfigService,
+    private readonly pinningService: PinningService,
   ) {}
 
   /**
@@ -86,7 +91,23 @@ export class RafflesService {
       );
     }
 
-    return this.metadataService.upsertMetadata(raffleId, payload);
+    const saved = await this.metadataService.upsertMetadata(raffleId, payload);
+
+    try {
+      const cid = await this.pinningService.pin(saved);
+      if (cid) {
+        const updated = await this.metadataService.updateMetadataCid(raffleId, cid);
+        return updated;
+      }
+    } catch (err) {
+      this.logger.error(
+        `Failed to pin metadata to IPFS for raffle ${raffleId}: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+
+    return saved;
   }
 
   /**

--- a/backend/src/services/metadata.module.ts
+++ b/backend/src/services/metadata.module.ts
@@ -13,6 +13,6 @@ import { PinningService } from './pinning.service';
     PinningService,
     MetadataService,
   ],
-  exports: [MetadataService, MetadataCacheMetricsService],
+  exports: [MetadataService, MetadataCacheMetricsService, PinningService],
 })
 export class MetadataModule {}

--- a/backend/src/services/metadata.service.spec.ts
+++ b/backend/src/services/metadata.service.spec.ts
@@ -24,7 +24,6 @@ describe('MetadataService', () => {
   >;
   let metrics: MetadataCacheMetricsService;
   let config: { get: jest.Mock };
-  let pinningService: { pin: jest.Mock };
 
   beforeEach(() => {
     queryBuilder = {
@@ -51,9 +50,7 @@ describe('MetadataService', () => {
       del: jest.fn().mockResolvedValue(undefined),
     };
 
-    pinningService = {
-      pin: jest.fn().mockResolvedValue(null),
-    };
+
 
     metrics = new MetadataCacheMetricsService();
 
@@ -63,7 +60,6 @@ describe('MetadataService', () => {
 
     service = new MetadataService(
       client as any,
-      pinningService as any,
       config as any,
       redis as unknown as MetadataRedisService,
       metrics,
@@ -195,6 +191,29 @@ describe('MetadataService', () => {
 
     await service.upsertMetadata(9, { title: 'x' });
 
+    expect(redis.del).toHaveBeenCalledWith('tikka:raffle_metadata:9');
+  });
+
+  it('updates metadata_cid and invalidates cache key', async () => {
+    redis.isEnabled.mockReturnValue(true);
+    const selectBuilder = {
+      single: jest.fn().mockResolvedValue({
+        data: { raffle_id: 9, metadata_cid: 'QmNewCid' },
+        error: null,
+      }),
+    };
+    const updateBuilder = {
+      eq: jest.fn().mockReturnThis(),
+      select: jest.fn().mockReturnValue(selectBuilder),
+    };
+    const localQueryBuilder = {
+      update: jest.fn().mockReturnValue(updateBuilder),
+    };
+    jest.spyOn(client, 'from').mockReturnValue(localQueryBuilder as any);
+
+    const result = await service.updateMetadataCid(9, 'QmNewCid');
+
+    expect(result.metadata_cid).toBe('QmNewCid');
     expect(redis.del).toHaveBeenCalledWith('tikka:raffle_metadata:9');
   });
 });

--- a/backend/src/services/metadata.service.ts
+++ b/backend/src/services/metadata.service.ts
@@ -2,7 +2,6 @@ import { Inject, Injectable, BadRequestException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { SupabaseClient } from '@supabase/supabase-js';
 import { SUPABASE_CLIENT } from './supabase.provider';
-import { PinningService } from './pinning.service';
 import { MetadataRedisService } from './metadata-redis.service';
 import { MetadataCacheMetricsService } from './metadata-cache-metrics.service';
 
@@ -52,7 +51,6 @@ function cacheKeyForRaffle(raffleId: number): string {
 export class MetadataService {
   constructor(
     @Inject(SUPABASE_CLIENT) private readonly client: SupabaseClient,
-    private readonly pinningService: PinningService,
     private readonly config: ConfigService,
     private readonly metadataRedis: MetadataRedisService,
     private readonly metadataCacheMetrics: MetadataCacheMetricsService,
@@ -212,21 +210,19 @@ export class MetadataService {
       ?.map((url) => url?.trim())
       .filter((url): url is string => Boolean(url));
 
-
-    const metadataCid = await this.pinningService.pin({
-      raffle_id: raffleId,
-      ...payload,
-    });
+    const existing = await this.getMetadata(raffleId);
 
     const row = {
       raffle_id: raffleId,
-      ...payload,
-      metadata_cid: metadataCid || payload.metadata_cid,
+      title: payload.title !== undefined ? payload.title : (existing?.title ?? ''),
+      description: payload.description !== undefined ? payload.description : (existing?.description ?? ''),
+      image_url: payload.image_url !== undefined ? payload.image_url : (existing?.image_url ?? null),
       image_urls:
-        normalizedImageUrls && normalizedImageUrls.length > 0
-          ? normalizedImageUrls
-          : null,
-      category: payload.category?.trim() || null,
+        payload.image_urls !== undefined
+          ? (normalizedImageUrls && normalizedImageUrls.length > 0 ? normalizedImageUrls : null)
+          : (existing?.image_urls ?? null),
+      category: payload.category !== undefined ? (payload.category?.trim() || null) : (existing?.category ?? null),
+      metadata_cid: payload.metadata_cid !== undefined ? payload.metadata_cid : (existing?.metadata_cid ?? null),
       updated_at: new Date().toISOString(),
     };
 
@@ -246,6 +242,26 @@ export class MetadataService {
     const saved = data as RaffleMetadata;
     await this.metadataRedis.del(cacheKeyForRaffle(raffleId));
 
+    return saved;
+  }
+
+  /**
+   * Update the metadata_cid field for a raffle metadata record and invalidate its cache.
+   */
+  async updateMetadataCid(raffleId: number, metadataCid: string): Promise<RaffleMetadata> {
+    const { data, error } = await this.client
+      .from(TABLE)
+      .update({ metadata_cid: metadataCid, updated_at: new Date().toISOString() })
+      .eq('raffle_id', raffleId)
+      .select()
+      .single();
+
+    if (error) {
+      throw new Error(`Failed to update metadata CID for raffle ${raffleId}: ${error.message}`);
+    }
+
+    const saved = data as RaffleMetadata;
+    await this.metadataRedis.del(cacheKeyForRaffle(raffleId));
     return saved;
   }
 

--- a/backend/src/services/pinning.service.spec.ts
+++ b/backend/src/services/pinning.service.spec.ts
@@ -1,0 +1,142 @@
+import { PinningService } from './pinning.service';
+import { env } from '../config/env.config';
+import { RaffleMetadata } from './metadata.service';
+
+describe('PinningService', () => {
+  let service: PinningService;
+  let fetchSpy: jest.SpyInstance;
+  let storageSpy: jest.SpyInstance;
+
+  const mockMetadata: RaffleMetadata = {
+    raffle_id: 1,
+    title: 'Test Raffle',
+    description: 'A test raffle description',
+    image_url: 'https://example.com/image.png',
+    image_urls: ['https://example.com/image.png'],
+    category: 'Art',
+    metadata_cid: null,
+    created_at: '2026-06-27T08:00:00Z',
+    updated_at: '2026-06-27T08:00:00Z',
+    deleted_at: null,
+  };
+
+  beforeEach(() => {
+    service = new PinningService();
+    fetchSpy = jest.spyOn(global, 'fetch');
+    storageSpy = jest.spyOn(env, 'storage', 'get').mockReturnValue({
+      enableIpfsPinning: true,
+      pinataJwt: 'mock-jwt-token',
+      pinataApiKey: 'mock-api-key',
+      pinataApiSecret: 'mock-api-secret',
+      ipfsGatewayUrl: 'https://ipfs.io/ipfs/',
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should return null if IPFS pinning is disabled', async () => {
+    storageSpy.mockReturnValue({
+      enableIpfsPinning: false,
+      pinataJwt: 'mock-jwt-token',
+      pinataApiKey: 'mock-api-key',
+      pinataSecret: 'mock-api-secret',
+      ipfsGatewayUrl: 'https://ipfs.io/ipfs/',
+    });
+
+    const result = await service.pin(mockMetadata);
+    expect(result).toBeNull();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('should return null if Pinata credentials are missing', async () => {
+    storageSpy.mockReturnValue({
+      enableIpfsPinning: true,
+      pinataJwt: undefined,
+      pinataApiKey: undefined,
+      pinataApiSecret: undefined,
+      ipfsGatewayUrl: 'https://ipfs.io/ipfs/',
+    });
+
+    const result = await service.pin(mockMetadata);
+    expect(result).toBeNull();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('should pin metadata successfully using PINATA_JWT and return the CID', async () => {
+    const mockResponse = {
+      ok: true,
+      json: jest.fn().mockResolvedValue({ IpfsHash: 'QmSuccessCid' }),
+    };
+    fetchSpy.mockResolvedValue(mockResponse as any);
+
+    const result = await service.pin(mockMetadata);
+
+    expect(result).toBe('QmSuccessCid');
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://api.pinata.cloud/pinning/pinJSONToIPFS',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer mock-jwt-token',
+        }),
+      }),
+    );
+  });
+
+  it('should pin metadata successfully using api key and secret when JWT is absent', async () => {
+    storageSpy.mockReturnValue({
+      enableIpfsPinning: true,
+      pinataJwt: undefined,
+      pinataApiKey: 'mock-api-key',
+      pinataApiSecret: 'mock-api-secret',
+      ipfsGatewayUrl: 'https://ipfs.io/ipfs/',
+    });
+
+    const mockResponse = {
+      ok: true,
+      json: jest.fn().mockResolvedValue({ IpfsHash: 'QmSuccessApiKeyCid' }),
+    };
+    fetchSpy.mockResolvedValue(mockResponse as any);
+
+    const result = await service.pin(mockMetadata);
+
+    expect(result).toBe('QmSuccessApiKeyCid');
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://api.pinata.cloud/pinning/pinJSONToIPFS',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          pinata_api_key: 'mock-api-key',
+          pinata_secret_api_key: 'mock-api-secret',
+        }),
+      }),
+    );
+  });
+
+  it('should return null and log error if Pinata API response is not ok', async () => {
+    const mockResponse = {
+      ok: false,
+      status: 401,
+      text: jest.fn().mockResolvedValue('Unauthorized'),
+    };
+    fetchSpy.mockResolvedValue(mockResponse as any);
+
+    const result = await service.pin(mockMetadata);
+
+    expect(result).toBeNull();
+    expect(fetchSpy).toHaveBeenCalled();
+  });
+
+  it('should return null and log error if fetch throws a network error', async () => {
+    fetchSpy.mockRejectedValue(new Error('Network disconnected'));
+
+    const result = await service.pin(mockMetadata);
+
+    expect(result).toBeNull();
+    expect(fetchSpy).toHaveBeenCalled();
+  });
+});

--- a/backend/src/services/pinning.service.ts
+++ b/backend/src/services/pinning.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { env } from '../config/env.config';
+import type { RaffleMetadata } from './metadata.service';
 
 @Injectable()
 export class PinningService {
@@ -10,7 +11,7 @@ export class PinningService {
    * Requires PINATA_JWT or (PINATA_API_KEY and PINATA_API_SECRET) env vars.
    * Skips if ENABLE_IPFS_PINNING is not 'true'.
    */
-  async pin(payload: any): Promise<string | null> {
+  async pin(metadata: RaffleMetadata): Promise<string | null> {
     const isEnabled = env.storage.enableIpfsPinning;
     if (!isEnabled) {
       this.logger.debug('IPFS pinning is disabled');
@@ -42,9 +43,9 @@ export class PinningService {
         method: 'POST',
         headers,
         body: JSON.stringify({
-          pinataContent: payload,
+          pinataContent: metadata,
           pinataMetadata: {
-            name: `raffle-${payload.raffle_id || 'metadata'}-${Date.now()}`,
+            name: `raffle-${metadata.raffle_id || 'metadata'}-${Date.now()}`,
           },
         }),
       });

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,12 +6,26 @@
     "": {
       "name": "tikka",
       "dependencies": {
+        "@pinata/sdk": "^2.1.0",
         "react-router-dom": "^7.13.2"
       },
       "devDependencies": {
         "@types/react": "^18.3.28",
         "@types/react-dom": "^18.3.7",
         "@types/react-router-dom": "^5.3.3"
+      }
+    },
+    "node_modules/@pinata/sdk": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@pinata/sdk/-/sdk-2.1.0.tgz",
+      "integrity": "sha512-hkS0tcKtsjf9xhsEBs2Nbey5s+Db7x5rlOH9TaWHBXkJ7IwwOs2xnEDigNaxAHKjYAwcw+m2hzpO5QgOfeF7Zw==",
+      "deprecated": "Please install the new IPFS SDK at pinata-web3. More information at https://docs.pinata.cloud/web3/sdk",
+      "license": "MIT",
+      "dependencies": {
+        "axios": "^0.21.1",
+        "form-data": "^2.3.3",
+        "is-ipfs": "^0.6.0",
+        "path": "^0.12.7"
       }
     },
     "node_modules/@types/history": {
@@ -72,6 +86,132 @@
         "@types/react-router": "*"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.14.0"
+      }
+    },
+    "node_modules/base-x": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.11.tgz",
+      "integrity": "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^3.0.2"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/cids": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/cids/-/cids-0.7.5.tgz",
+      "integrity": "sha512-zT7mPeghoWAu+ppn8+BS1tQ5qGmbMfB4AregnQjA/qHY3GC1m1ptI9GkWNlgeu38r7CuRdXB47uY2XgAYt6QVA==",
+      "deprecated": "This module has been superseded by the multiformats module",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "class-is": "^1.1.0",
+        "multibase": "~0.6.0",
+        "multicodec": "^1.0.0",
+        "multihashes": "~0.4.15"
+      },
+      "engines": {
+        "node": ">=4.0.0",
+        "npm": ">=3.0.0"
+      }
+    },
+    "node_modules/class-is": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/class-is/-/class-is-1.1.0.tgz",
+      "integrity": "sha512-rhjH9AG1fvabIDoGRVH587413LPjTZgmDF9fOFCbFJQV4yuocX1mHxxvXI4g3cGwbVY9wAYIoKlg1N79frJKQw==",
+      "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/cookie": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
@@ -91,6 +231,460 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.6.tgz",
+      "integrity": "sha512-Ogz/E85h9tlfJzpI6TuFpGcHZFhLrb9Gw8wq9v40CxSCPnv7ahKr6Xgtkn0KYCDQJ8DNn5VoMO8EXr9V5PadyA==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
+      "license": "ISC"
+    },
+    "node_modules/ip-regex": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
+      "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-ip": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-3.1.0.tgz",
+      "integrity": "sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-regex": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-ipfs": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/is-ipfs/-/is-ipfs-0.6.3.tgz",
+      "integrity": "sha512-HyRot1dvLcxImtDqPxAaY1miO6WsiP/z7Yxpg2qpaLWv5UdhAPtLvHJ4kMLM0w8GSl8AFsVF23PHe1LzuWrUlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bs58": "^4.0.1",
+        "cids": "~0.7.0",
+        "mafmt": "^7.0.0",
+        "multiaddr": "^7.2.1",
+        "multibase": "~0.6.0",
+        "multihashes": "~0.4.13"
+      }
+    },
+    "node_modules/mafmt": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/mafmt/-/mafmt-7.1.0.tgz",
+      "integrity": "sha512-vpeo9S+hepT3k2h5iFxzEHvvR0GPBx9uKaErmnRzYNcaKb03DgOArjEMlgG4a9LcuZZ89a3I8xbeto487n26eA==",
+      "license": "MIT",
+      "dependencies": {
+        "multiaddr": "^7.3.0"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/multiaddr": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-7.5.0.tgz",
+      "integrity": "sha512-GvhHsIGDULh06jyb6ev+VfREH9evJCFIRnh3jUt9iEZ6XDbyoisZRFEI9bMvK/AiR6y66y6P+eoBw9mBYMhMvw==",
+      "deprecated": "This module is deprecated, please upgrade to @multiformats/multiaddr",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "cids": "~0.8.0",
+        "class-is": "^1.1.0",
+        "is-ip": "^3.1.0",
+        "multibase": "^0.7.0",
+        "varint": "^5.0.0"
+      }
+    },
+    "node_modules/multiaddr/node_modules/cids": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
+      "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
+      "deprecated": "This module has been superseded by the multiformats module",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.6.0",
+        "class-is": "^1.1.0",
+        "multibase": "^1.0.0",
+        "multicodec": "^1.0.1",
+        "multihashes": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=4.0.0",
+        "npm": ">=3.0.0"
+      }
+    },
+    "node_modules/multiaddr/node_modules/cids/node_modules/multibase": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+      "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+      "deprecated": "This module has been superseded by the multiformats module",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^3.0.8",
+        "buffer": "^5.5.0"
+      },
+      "engines": {
+        "node": ">=10.0.0",
+        "npm": ">=6.0.0"
+      }
+    },
+    "node_modules/multiaddr/node_modules/multibase": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
+      "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
+      "deprecated": "This module has been superseded by the multiformats module",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^3.0.8",
+        "buffer": "^5.5.0"
+      }
+    },
+    "node_modules/multiaddr/node_modules/multihashes": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
+      "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.6.0",
+        "multibase": "^1.0.1",
+        "varint": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10.0.0",
+        "npm": ">=6.0.0"
+      }
+    },
+    "node_modules/multiaddr/node_modules/multihashes/node_modules/multibase": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+      "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+      "deprecated": "This module has been superseded by the multiformats module",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^3.0.8",
+        "buffer": "^5.5.0"
+      },
+      "engines": {
+        "node": ">=10.0.0",
+        "npm": ">=6.0.0"
+      }
+    },
+    "node_modules/multibase": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.6.1.tgz",
+      "integrity": "sha512-pFfAwyTjbbQgNc3G7D48JkJxWtoJoBMaR4xQUOuB8RnCgRqaYmWNFeJTTvrJ2w51bjLq2zTby6Rqj9TQ9elSUw==",
+      "deprecated": "This module has been superseded by the multiformats module",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^3.0.8",
+        "buffer": "^5.5.0"
+      }
+    },
+    "node_modules/multicodec": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
+      "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
+      "deprecated": "This module has been superseded by the multiformats module",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.6.0",
+        "varint": "^5.0.0"
+      }
+    },
+    "node_modules/multihashes": {
+      "version": "0.4.21",
+      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.21.tgz",
+      "integrity": "sha512-uVSvmeCWf36pU2nB4/1kzYZjsXD9vofZKpgudqkceYY5g2aZZXJ5r9lxuzoRLl1OAp28XljXsEJ/X/85ZsKmKw==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "multibase": "^0.7.0",
+        "varint": "^5.0.0"
+      }
+    },
+    "node_modules/multihashes/node_modules/multibase": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
+      "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
+      "deprecated": "This module has been superseded by the multiformats module",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^3.0.8",
+        "buffer": "^5.5.0"
+      }
+    },
+    "node_modules/path": {
+      "version": "0.12.7",
+      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
+      "integrity": "sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "process": "^0.11.1",
+        "util": "^0.10.3"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
     },
     "node_modules/react": {
       "version": "19.2.4",
@@ -153,6 +747,26 @@
         "react-dom": ">=18"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -164,6 +778,21 @@
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
+    },
+    "node_modules/util": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "2.0.3"
+      }
+    },
+    "node_modules/varint": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
+      "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow==",
       "license": "MIT"
     }
   }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@types/react-router-dom": "^5.3.3"
   },
   "dependencies": {
+    "@pinata/sdk": "^2.1.0",
     "react-router-dom": "^7.13.2"
   }
 }


### PR DESCRIPTION
Closes #844 
- Implemented direct Pinata IPFS JSON pinning API
- Moved pinning orchestration to RafflesService post-upsert (best-effort)
- Enhanced MetadataService to prevent partial update overwrites
- Wrote mock-based unit tests for PinningService and RafflesService