### PR TITLE
Read-only SDK entry,dependabot,vercel.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,57 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /client
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+      - client
+
+  - package-ecosystem: npm
+    directory: /sdk
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+      - sdk
+
+  - package-ecosystem: npm
+    directory: /backend
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+      - backend
+
+  - package-ecosystem: npm
+    directory: /indexer
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+      - indexer
+
+  - package-ecosystem: npm
+    directory: /oracle
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+      - oracle
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+      - docker
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+      - github-actions

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -65,7 +65,7 @@ jobs:
       run: npx playwright install --with-deps
     - name: Run Playwright tests
       run: npx playwright test
-   - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v4
       if: always()
       with:
         name: playwright-report

--- a/client/docs/PERFORMANCE.md
+++ b/client/docs/PERFORMANCE.md
@@ -1,0 +1,73 @@
+# Core Web Vitals & Performance Targets
+
+Tikka client targets Google's "Good" thresholds for all Core Web Vitals as measured at the 75th percentile (p75) for production traffic.
+
+## Targets
+
+| Metric | Target | Description |
+|--------|--------|-------------|
+| **LCP** (Largest Contentful Paint) | < 2.5 s | Time until the largest image or text block is visible |
+| **CLS** (Cumulative Layout Shift) | < 0.1 | Visual stability — unexpected layout movement score |
+| **INP** (Interaction to Next Paint) | < 200 ms | Responsiveness to user interactions |
+| **FCP** (First Contentful Paint) | < 1.8 s | Time until first content is rendered |
+| **TTFB** (Time to First Byte) | < 800 ms | Network and server responsiveness |
+
+## Monitoring
+
+Metrics are collected automatically via `@vercel/analytics` and `@vercel/speed-insights`, which are injected into the production build by `client/src/main.tsx`.
+
+- **Vercel Analytics**: Real-user monitoring (RUM) visible in the Vercel dashboard under _Analytics_.
+- **Speed Insights**: CWV per-page breakdown with p75 scoring visible under _Speed Insights_.
+
+Both are loaded with dynamic `import()` gated on `import.meta.env.PROD && MODE !== 'test'`, so they are:
+- **Not** included in `vite dev` (development)
+- **Not** included during Vitest runs
+- **Included** only in `vite build` production output
+
+## Improving CWV
+
+### LCP
+
+- Preload hero images with `<link rel="preload" as="image">` in `index.html`.
+- Serve images from Vercel's Edge CDN (automatic for assets in `public/`).
+- Use `loading="eager"` on above-the-fold images and `loading="lazy"` elsewhere.
+
+### CLS
+
+- Always specify `width` and `height` on `<img>` tags to reserve layout space.
+- Avoid injecting content above existing content after page load.
+- Use CSS `min-height` on skeleton loaders that get replaced with real content.
+
+### INP
+
+- Defer non-critical work (analytics, third-party scripts) with `requestIdleCallback`.
+- Avoid long tasks (> 50 ms) on the main thread — profile with Lighthouse.
+- Use React's `useTransition` / `startTransition` for non-urgent state updates.
+
+## Running Lighthouse Locally
+
+```bash
+# Requires: npm i -g lighthouse
+pnpm run build && pnpm run preview &
+lighthouse http://localhost:4173 --output html --output-path ./lighthouse-report.html
+open ./lighthouse-report.html
+```
+
+## CI Integration (optional)
+
+To enforce CWV budgets in CI, add `@lhci/cli` and a `lighthouserc.json`:
+
+```json
+{
+  "ci": {
+    "assert": {
+      "assertions": {
+        "categories:performance": ["error", { "minScore": 0.9 }],
+        "largest-contentful-paint": ["error", { "maxNumericValue": 2500 }],
+        "cumulative-layout-shift": ["error", { "maxNumericValue": 0.1 }],
+        "experimental-interaction-to-next-paint": ["warn", { "maxNumericValue": 200 }]
+      }
+    }
+  }
+}
+```

--- a/client/package.json
+++ b/client/package.json
@@ -23,6 +23,8 @@
         "@creit.tech/stellar-wallets-kit": "^1.7.3",
         "@stellar/stellar-sdk": "^14.4.3",
         "@supabase/supabase-js": "^2.76.1",
+        "@vercel/analytics": "^1.5.0",
+        "@vercel/speed-insights": "^1.2.0",
         "@tailwindcss/vite": "^4.1.13",
         "canvas-confetti": "^1.9.4",
         "i18next": "^26.0.7",

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -21,10 +21,21 @@ if (
   document.documentElement.classList.remove("dark");
 }
 
+// Load Vercel observability only in production builds, not in test or dev.
+// import.meta.env.PROD is false during `vite dev` and vitest runs.
+const isProd = import.meta.env.PROD && import.meta.env.MODE !== 'test';
+
+const analyticsModule = isProd ? await import('@vercel/analytics/react') : null;
+const speedInsightsModule = isProd ? await import('@vercel/speed-insights/react') : null;
+const Analytics = analyticsModule?.Analytics ?? null;
+const SpeedInsights = speedInsightsModule?.SpeedInsights ?? null;
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <ErrorBoundary>
       <App />
+      {Analytics && <Analytics />}
+      {SpeedInsights && <SpeedInsights />}
     </ErrorBoundary>
   </StrictMode>,
 )

--- a/indexer/package.json
+++ b/indexer/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "scripts": {
     "build": "nest build",
+    "openapi:generate": "ts-node --transpile-only scripts/generate-openapi.ts",
     "start": "nest start",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
@@ -52,6 +53,7 @@
     "@nestjs/config": "^4.0.3",
     "@nestjs/core": "^10.4.0",
     "@nestjs/platform-express": "^10.4.22",
+    "@nestjs/swagger": "^8.1.1",
     "@nestjs/typeorm": "^10.0.2",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/exporter-prometheus": "^0.215.0",

--- a/indexer/scripts/generate-openapi.ts
+++ b/indexer/scripts/generate-openapi.ts
@@ -1,0 +1,32 @@
+/**
+ * Generates a static openapi.json at the project root.
+ * Run: pnpm run openapi:generate
+ */
+import { NestFactory } from '@nestjs/core';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import { writeFileSync } from 'fs';
+import { join } from 'path';
+import { AppModule } from '../src/app.module';
+
+async function generate() {
+  const app = await NestFactory.create(AppModule, { logger: false });
+
+  const config = new DocumentBuilder()
+    .setTitle('Tikka Indexer API')
+    .setDescription('Internal REST API for raffles, users, leaderboard, stats, and snapshots')
+    .setVersion('1.0')
+    .addApiKey({ type: 'apiKey', in: 'header', name: 'x-api-key' }, 'api-key')
+    .build();
+
+  const document = SwaggerModule.createDocument(app, config);
+  const outPath = join(__dirname, '..', 'openapi.json');
+  writeFileSync(outPath, JSON.stringify(document, null, 2), 'utf8');
+  console.log(`OpenAPI spec written to ${outPath}`);
+
+  await app.close();
+}
+
+generate().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/indexer/src/api/controllers/dto/leaderboard.dto.ts
+++ b/indexer/src/api/controllers/dto/leaderboard.dto.ts
@@ -1,24 +1,20 @@
-/**
- * Leaderboard DTOs — cursor-based pagination with mode-based ranking.
- * Hide internal fields like firstSeenLedger (storage-only).
- * Hide raw cursor implementation - nextCursor is opaque to clients.
- */
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
-export type LeaderboardMode = "wins" | "volume" | "tickets";
+export type LeaderboardMode = 'wins' | 'volume' | 'tickets';
 
-export interface LeaderboardEntryDto {
-  rank: number | null;
-  address: string;
-  totalTicketsBought: number;
-  totalRafflesWon: number;
-  totalPrizeXlm: string;
+export class LeaderboardEntryDto {
+  @ApiPropertyOptional({ nullable: true }) rank: number | null;
+  @ApiProperty() address: string;
+  @ApiProperty() totalTicketsBought: number;
+  @ApiProperty() totalRafflesWon: number;
+  @ApiProperty() totalPrizeXlm: string;
 }
 
-export interface LeaderboardResponseDto {
-  by: LeaderboardMode;
-  limit: number;
-  offset: number | null;
-  ranking: string[];
-  entries: LeaderboardEntryDto[];
-  nextCursor: string | null;
+export class LeaderboardResponseDto {
+  @ApiProperty({ enum: ['wins', 'volume', 'tickets'] }) by: LeaderboardMode;
+  @ApiProperty() limit: number;
+  @ApiPropertyOptional({ nullable: true }) offset: number | null;
+  @ApiProperty({ type: [String] }) ranking: string[];
+  @ApiProperty({ type: [LeaderboardEntryDto] }) entries: LeaderboardEntryDto[];
+  @ApiPropertyOptional({ nullable: true }) nextCursor: string | null;
 }

--- a/indexer/src/api/controllers/dto/raffle.dto.ts
+++ b/indexer/src/api/controllers/dto/raffle.dto.ts
@@ -1,43 +1,40 @@
-/**
- * Raffle DTOs — stable contracts for API responses.
- * Hide internal fields like createdLedger, finalizedLedger, lastTxHash.
- */
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
-export interface RaffleListItemDto {
-  id: number;
-  creator: string;
-  status: "open" | "drawing" | "finalized" | "cancelled";
-  ticket_price: string;
-  asset: string;
-  max_tickets: number;
-  tickets_sold: number;
-  end_time: string;
-  winner: string | null;
-  prize_amount: string | null;
-  metadata_cid: string | null;
-  created_at: string; // ISO date string
+export class RaffleListItemDto {
+  @ApiProperty() id: number;
+  @ApiProperty() creator: string;
+  @ApiProperty({ enum: ['open', 'drawing', 'finalized', 'cancelled'] }) status: 'open' | 'drawing' | 'finalized' | 'cancelled';
+  @ApiProperty() ticket_price: string;
+  @ApiProperty() asset: string;
+  @ApiProperty() max_tickets: number;
+  @ApiProperty() tickets_sold: number;
+  @ApiProperty() end_time: string;
+  @ApiPropertyOptional({ nullable: true }) winner: string | null;
+  @ApiPropertyOptional({ nullable: true }) prize_amount: string | null;
+  @ApiPropertyOptional({ nullable: true }) metadata_cid: string | null;
+  @ApiProperty() created_at: string;
 }
 
-export interface RaffleDetailDto extends RaffleListItemDto {
-  winning_ticket_id: number | null;
-  ticket_count: number;
+export class RaffleDetailDto extends RaffleListItemDto {
+  @ApiPropertyOptional({ nullable: true }) winning_ticket_id: number | null;
+  @ApiProperty() ticket_count: number;
 }
 
-export interface UserRaffleHistoryItemDto extends RaffleListItemDto {
-  user_tickets: number;
-  won: boolean;
+export class UserRaffleHistoryItemDto extends RaffleListItemDto {
+  @ApiProperty() user_tickets: number;
+  @ApiProperty() won: boolean;
 }
 
-export interface RaffleListResponseDto {
-  data: RaffleListItemDto[];
-  total: number;
-  limit: number;
-  offset: number;
+export class RaffleListResponseDto {
+  @ApiProperty({ type: [RaffleListItemDto] }) data: RaffleListItemDto[];
+  @ApiProperty() total: number;
+  @ApiProperty() limit: number;
+  @ApiProperty() offset: number;
 }
 
-export interface UserRaffleHistoryResponseDto {
-  data: UserRaffleHistoryItemDto[];
-  total: number;
-  limit: number;
-  offset: number;
+export class UserRaffleHistoryResponseDto {
+  @ApiProperty({ type: [UserRaffleHistoryItemDto] }) data: UserRaffleHistoryItemDto[];
+  @ApiProperty() total: number;
+  @ApiProperty() limit: number;
+  @ApiProperty() offset: number;
 }

--- a/indexer/src/api/controllers/dto/snapshot.dto.ts
+++ b/indexer/src/api/controllers/dto/snapshot.dto.ts
@@ -1,13 +1,10 @@
-/**
- * Snapshot DTOs — admin snapshot export/import responses.
- * Hide implementation details of storage, processing, or file handling.
- */
+import { ApiProperty } from '@nestjs/swagger';
 
-export interface SnapshotExportResponseDto {
-  message: string;
-  filename: string;
+export class SnapshotExportResponseDto {
+  @ApiProperty() message: string;
+  @ApiProperty() filename: string;
 }
 
-export interface SnapshotImportResponseDto {
-  message: string;
+export class SnapshotImportResponseDto {
+  @ApiProperty() message: string;
 }

--- a/indexer/src/api/controllers/dto/stats.dto.ts
+++ b/indexer/src/api/controllers/dto/stats.dto.ts
@@ -1,15 +1,12 @@
-/**
- * Platform Statistics DTOs — aggregated, cache-friendly responses.
- * Hide internal fields like storage date, raw aggregation details.
- */
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
-export interface PlatformStatDto {
-  date: string | null; // ISO date string or null
-  total_raffles: number;
-  total_tickets: number;
-  total_volume_xlm: string;
-  unique_participants: number;
-  prizes_distributed_xlm: string;
-  active_raffles: number;
-  total_users: number;
+export class PlatformStatDto {
+  @ApiPropertyOptional({ nullable: true }) date: string | null;
+  @ApiProperty() total_raffles: number;
+  @ApiProperty() total_tickets: number;
+  @ApiProperty() total_volume_xlm: string;
+  @ApiProperty() unique_participants: number;
+  @ApiProperty() prizes_distributed_xlm: string;
+  @ApiProperty() active_raffles: number;
+  @ApiProperty() total_users: number;
 }

--- a/indexer/src/api/controllers/dto/user.dto.ts
+++ b/indexer/src/api/controllers/dto/user.dto.ts
@@ -1,34 +1,33 @@
-/**
- * User DTOs — stable contracts for API responses.
- * Hide internal fields like lastTxHash (removed from all responses).
- */
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
-export interface UserProfileDto {
-  address: string;
-  total_tickets_bought: number;
-  total_raffles_entered: number;
-  total_raffles_won: number;
-  total_prize_xlm: string;
-  creator_stats?: {
-    raffles_created: number;
-    total_tickets_sold: number;
-    total_xlm_raised: string;
-    participant_win_rate: number;
-  };
+export class CreatorStatsDto {
+  @ApiProperty() raffles_created: number;
+  @ApiProperty() total_tickets_sold: number;
+  @ApiProperty() total_xlm_raised: string;
+  @ApiProperty() participant_win_rate: number;
 }
 
-export interface UserLeaderboardEntryDto {
-  rank: number;
-  address: string;
-  total_tickets_bought: number;
-  total_raffles_won: number;
-  total_prize_xlm: string;
-  total_raffles_entered: number;
+export class UserProfileDto {
+  @ApiProperty() address: string;
+  @ApiProperty() total_tickets_bought: number;
+  @ApiProperty() total_raffles_entered: number;
+  @ApiProperty() total_raffles_won: number;
+  @ApiProperty() total_prize_xlm: string;
+  @ApiPropertyOptional({ type: CreatorStatsDto }) creator_stats?: CreatorStatsDto;
 }
 
-export interface UserLeaderboardResponseDto {
-  data: UserLeaderboardEntryDto[];
-  total: number;
-  limit: number;
-  offset: number;
+export class UserLeaderboardEntryDto {
+  @ApiProperty() rank: number;
+  @ApiProperty() address: string;
+  @ApiProperty() total_tickets_bought: number;
+  @ApiProperty() total_raffles_won: number;
+  @ApiProperty() total_prize_xlm: string;
+  @ApiProperty() total_raffles_entered: number;
+}
+
+export class UserLeaderboardResponseDto {
+  @ApiProperty({ type: [UserLeaderboardEntryDto] }) data: UserLeaderboardEntryDto[];
+  @ApiProperty() total: number;
+  @ApiProperty() limit: number;
+  @ApiProperty() offset: number;
 }

--- a/indexer/src/api/controllers/leaderboard.controller.ts
+++ b/indexer/src/api/controllers/leaderboard.controller.ts
@@ -1,6 +1,7 @@
 import { Controller, Get, Query } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+import { ApiTags, ApiOperation, ApiResponse, ApiQuery } from '@nestjs/swagger';
 import { UserEntity } from '../../database/entities/user.entity';
 import { CacheService } from '../../cache/cache.service';
 import {
@@ -9,6 +10,7 @@ import {
   LeaderboardEntryDto,
 } from './dto/leaderboard.dto';
 
+@ApiTags('leaderboard')
 @Controller('leaderboard')
 export class LeaderboardController {
   constructor(
@@ -17,6 +19,12 @@ export class LeaderboardController {
     private readonly cacheService: CacheService,
   ) {}
 
+  @ApiOperation({ summary: 'Cursor-paginated leaderboard', description: 'Returns users ranked by wins, volume, or ticket count.' })
+  @ApiQuery({ name: 'by', required: false, enum: ['wins', 'volume', 'tickets'] })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiQuery({ name: 'cursor', required: false })
+  @ApiQuery({ name: 'offset', required: false, type: Number })
+  @ApiResponse({ status: 200, type: LeaderboardResponseDto })
   @Get()
   async getLeaderboard(
     @Query('by') by: LeaderboardMode = 'wins',

--- a/indexer/src/api/controllers/raffles.controller.ts
+++ b/indexer/src/api/controllers/raffles.controller.ts
@@ -7,12 +7,13 @@ import {
   ParseIntPipe,
   UseGuards,
 } from "@nestjs/common";
+import { ApiKeyGuard } from "../api-key.guard";
 import { InjectRepository } from "@nestjs/typeorm";
 import { Repository } from "typeorm";
+import { ApiTags, ApiOperation, ApiResponse, ApiQuery, ApiParam, ApiSecurity } from "@nestjs/swagger";
 import { CacheService } from "../../cache/cache.service";
 import { RaffleEntity } from "../../database/entities/raffle.entity";
 import { TicketEntity } from "../../database/entities/ticket.entity";
-import { ApiKeyGuard } from "../api-key.guard";
 import {
   RaffleListItemDto,
   RaffleDetailDto,
@@ -28,6 +29,8 @@ export interface RaffleListQuery {
   offset?: string;
 }
 
+@ApiTags('raffles')
+@ApiSecurity('api-key')
 @UseGuards(ApiKeyGuard)
 @Controller("raffles")
 export class RafflesController {
@@ -44,6 +47,13 @@ export class RafflesController {
    * List raffles with optional filters and pagination.
    * Uses cache for the active-raffle list; falls back to PostgreSQL.
    */
+  @ApiOperation({ summary: 'List raffles', description: 'Returns a paginated list of raffles with optional filters.' })
+  @ApiQuery({ name: 'status', required: false, enum: ['open', 'drawing', 'finalized', 'cancelled'] })
+  @ApiQuery({ name: 'creator', required: false })
+  @ApiQuery({ name: 'asset', required: false })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiQuery({ name: 'offset', required: false, type: Number })
+  @ApiResponse({ status: 200, type: RaffleListResponseDto })
   @Get()
   async list(@Query() query: RaffleListQuery): Promise<RaffleListResponseDto> {
     const limit = Math.min(parseInt(query.limit ?? "20", 10), 100);
@@ -93,6 +103,10 @@ export class RafflesController {
    * GET /raffles/:id
    * Raffle detail — cache-first, PostgreSQL fallback.
    */
+  @ApiOperation({ summary: 'Get raffle by ID' })
+  @ApiParam({ name: 'id', type: Number })
+  @ApiResponse({ status: 200, type: RaffleDetailDto })
+  @ApiResponse({ status: 404, description: 'Raffle not found' })
   @Get(":id")
   async detail(@Param("id", ParseIntPipe) id: number): Promise<RaffleDetailDto> {
     const cached = await this.cacheService.getRaffleDetail(String(id));

--- a/indexer/src/api/controllers/snapshot.controller.ts
+++ b/indexer/src/api/controllers/snapshot.controller.ts
@@ -1,4 +1,5 @@
 import { Controller, Post, Body, UseGuards, Logger, HttpException, HttpStatus } from "@nestjs/common";
+import { ApiTags, ApiOperation, ApiResponse, ApiBody, ApiSecurity } from "@nestjs/swagger";
 import { SnapshotService } from "../../maintenance/snapshot.service";
 import { ApiKeyGuard } from "../api-key.guard";
 import {
@@ -6,6 +7,8 @@ import {
   SnapshotImportResponseDto,
 } from "./dto/snapshot.dto";
 
+@ApiTags('admin')
+@ApiSecurity('api-key')
 @Controller("admin/snapshot")
 @UseGuards(ApiKeyGuard)
 export class SnapshotController {
@@ -13,6 +16,8 @@ export class SnapshotController {
 
   constructor(private readonly snapshotService: SnapshotService) {}
 
+  @ApiOperation({ summary: 'Export snapshot' })
+  @ApiResponse({ status: 201, type: SnapshotExportResponseDto })
   @Post("export")
   async export(): Promise<SnapshotExportResponseDto> {
     try {
@@ -30,6 +35,9 @@ export class SnapshotController {
     }
   }
 
+  @ApiOperation({ summary: 'Import snapshot' })
+  @ApiBody({ schema: { properties: { filename: { type: 'string' } } } })
+  @ApiResponse({ status: 201, type: SnapshotImportResponseDto })
   @Post("import")
   async import(@Body("filename") filename: string): Promise<SnapshotImportResponseDto> {
     if (!filename) {

--- a/indexer/src/api/controllers/stats.controller.ts
+++ b/indexer/src/api/controllers/stats.controller.ts
@@ -1,6 +1,7 @@
 import { Controller, Get, UseGuards } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { Repository } from "typeorm";
+import { ApiTags, ApiOperation, ApiResponse, ApiSecurity } from "@nestjs/swagger";
 import { CacheService } from "../../cache/cache.service";
 import { PlatformStatEntity } from "../../database/entities/platform-stat.entity";
 import { RaffleEntity, RaffleStatus } from "../../database/entities/raffle.entity";
@@ -8,6 +9,8 @@ import { UserEntity } from "../../database/entities/user.entity";
 import { ApiKeyGuard } from "../api-key.guard";
 import { PlatformStatDto } from "./dto/stats.dto";
 
+@ApiTags('stats')
+@ApiSecurity('api-key')
 @UseGuards(ApiKeyGuard)
 @Controller("stats")
 export class StatsController {
@@ -26,6 +29,8 @@ export class StatsController {
    * Aggregated platform-wide stats — cache-first (5 min TTL), PostgreSQL fallback.
    * Merges the latest daily roll-up row with live counts for active raffles.
    */
+  @ApiOperation({ summary: 'Platform statistics', description: 'Aggregated platform-wide stats (cached, 5 min TTL).' })
+  @ApiResponse({ status: 200, type: PlatformStatDto })
   @Get("platform")
   async platform(): Promise<PlatformStatDto> {
     const cached = await this.cacheService.getPlatformStats();

--- a/indexer/src/api/controllers/users.controller.ts
+++ b/indexer/src/api/controllers/users.controller.ts
@@ -8,6 +8,7 @@ import {
 } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { Repository } from "typeorm";
+import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiQuery, ApiSecurity } from "@nestjs/swagger";
 import { CacheService } from "../../cache/cache.service";
 import { UserEntity } from "../../database/entities/user.entity";
 import { TicketEntity } from "../../database/entities/ticket.entity";
@@ -29,6 +30,8 @@ export interface PaginationQuery {
   offset?: string;
 }
 
+@ApiTags('users')
+@ApiSecurity('api-key')
 @UseGuards(ApiKeyGuard)
 @Controller()
 export class UsersController {
@@ -47,6 +50,10 @@ export class UsersController {
    * Top users by total_raffles_won, then total_prize_xlm.
    * Declared before /:address to avoid route shadowing.
    */
+  @ApiOperation({ summary: 'User leaderboard', description: 'Top users ordered by wins, then prize XLM.' })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiQuery({ name: 'offset', required: false, type: Number })
+  @ApiResponse({ status: 200, type: UserLeaderboardResponseDto })
   @Get("leaderboard")
   async leaderboard(@Query() query: PaginationQuery): Promise<UserLeaderboardResponseDto> {
     const limit = Math.min(parseInt(query.limit ?? "20", 10), 100);
@@ -92,6 +99,10 @@ export class UsersController {
    * GET /users/:address
    * User profile — cache-first, PostgreSQL fallback.
    */
+  @ApiOperation({ summary: 'Get user profile' })
+  @ApiParam({ name: 'address', description: 'Stellar public key' })
+  @ApiResponse({ status: 200, type: UserProfileDto })
+  @ApiResponse({ status: 404, description: 'User not found' })
   @Get("users/:address")
   async profile(@Param("address") address: string): Promise<UserProfileDto> {
     const cached = await this.cacheService.getUserProfile(address);
@@ -153,6 +164,11 @@ export class UsersController {
    * GET /users/:address/history
    * Paginated list of raffles the user has participated in.
    */
+  @ApiOperation({ summary: 'Get user raffle history' })
+  @ApiParam({ name: 'address', description: 'Stellar public key' })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiQuery({ name: 'offset', required: false, type: Number })
+  @ApiResponse({ status: 200, type: UserRaffleHistoryResponseDto })
   @Get("users/:address/history")
   async history(
     @Param("address") address: string,

--- a/indexer/src/main.ts
+++ b/indexer/src/main.ts
@@ -1,8 +1,30 @@
 import { NestFactory } from '@nestjs/core';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+  // ── OpenAPI / Swagger ──────────────────────────────────────────────────────
+  const swaggerConfig = new DocumentBuilder()
+    .setTitle('Tikka Indexer API')
+    .setDescription('Internal REST API for raffles, users, leaderboard, stats, and snapshots')
+    .setVersion('1.0')
+    .addApiKey({ type: 'apiKey', in: 'header', name: 'x-api-key' }, 'api-key')
+    .build();
+
+  const document = SwaggerModule.createDocument(app, swaggerConfig);
+
+  // GET /api-docs  → OpenAPI 3.x JSON document
+  // GET /api-docs/ui → Swagger UI (guarded: only when API key env var is set or non-production)
+  const serveUi = process.env.NODE_ENV !== 'production' || !!process.env.INTERNAL_API_KEY;
+
+  SwaggerModule.setup('api-docs', app, document, {
+    jsonDocumentUrl: 'api-docs',          // serves JSON at exactly /api-docs
+    swaggerUrl: serveUi ? 'api-docs/ui' : undefined,
+    swaggerOptions: { persistAuthorization: true },
+  });
+
   await app.listen(process.env.PORT ?? 3002);
 }
 bootstrap();

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -15,6 +15,64 @@ NestJS library for Soroban contract interaction: transaction building, simulatio
 - **Local Mocking Utilities**: `MockWalletAdapter` and `MockRpcService` for Storybook, UI tests, and offline development.
 - **Modular Design**: Domain-specific modules for Raffles, Tickets, and Users.
 
+## Read-Only Entry Point (`@tikka/sdk/read`)
+
+Consumers that only need to **query** raffle data (public dashboards, SSR pages, analytics) can import from the read-only sub-path. This avoids bundling wallet adapters and signing code, producing a significantly smaller bundle.
+
+```ts
+import { ReadOnlyRaffleService, ReadOnlyUserService, RpcService, resolveNetworkConfig } from '@tikka/sdk/read';
+
+const networkConfig = resolveNetworkConfig('mainnet');
+const rpcService = new RpcService(networkConfig);
+
+const raffleService = new ReadOnlyRaffleService(rpcService, networkConfig);
+const userService = new ReadOnlyUserService(rpcService, networkConfig);
+
+// List all raffle IDs
+const { value: allIds } = await raffleService.getAll();
+
+// Fetch a single raffle
+const { value: raffle } = await raffleService.getById(42);
+
+// User participation profile
+const { value: profile } = await userService.getProfile('GBIQ4VH3...');
+
+// User raffle ID history
+const { value: history } = await userService.getHistory('GBIQ4VH3...');
+```
+
+### What is included
+
+| Export | Description |
+|--------|-------------|
+| `ReadOnlyRaffleService` | `getAll()` — all raffle IDs; `getById(id)` — single raffle data |
+| `ReadOnlyUserService` | `getProfile(addr)` — participation stats; `getHistory(addr)` — raffle IDs |
+| `RpcService` | Soroban RPC client (simulate, getLedger) |
+| `HorizonService` | Horizon account/fee queries |
+| `resolveNetworkConfig`, `NetworkConfig` | Network configuration helpers |
+| `ContractFn`, `RaffleStatus` | Contract constants |
+| `ContractResponse` | Shared response envelope type |
+| Read-only types | `RaffleData`, `UserParticipation`, `AssetDescriptor`, etc. |
+| Utils | Formatting, validation, errors, retry, BigNumber |
+
+### What is excluded
+
+The read-only bundle intentionally excludes all signing-related code:
+- `ContractService` (requires wallet + TransactionBuilder)
+- `TransactionLifecycle` (requires wallet + signing)
+- All wallet adapters (Freighter, xBull, Albedo, LOBSTR, Rabet)
+- `FeeEstimatorService`
+- `sep10` auth helpers
+- Write-side service classes (`RaffleService`, `TicketService`)
+- NestJS modules
+
+### Building the read-only bundle
+
+```bash
+cd sdk
+pnpm run build:read   # outputs to dist/read/
+```
+
 ## Project Structure
 
 - `src/network/` — Customizable Soroban RPC and Horizon services.

--- a/sdk/src/index.read.ts
+++ b/sdk/src/index.read.ts
@@ -55,5 +55,9 @@ export type { RaffleData, AssetDescriptor } from './modules/raffle/raffle.types'
 export type { GetUserTicketsParams } from './modules/ticket/ticket.types';
 export type { UserParticipation, GetParticipationParams } from './modules/user/user.types';
 
+// ── Read-only service classes ────────────────────────────────────────────────
+export { ReadOnlyRaffleService } from './modules/raffle/raffle.read.service';
+export { ReadOnlyUserService } from './modules/user/user.read.service';
+
 // ── Utils ────────────────────────────────────────────────────────────────────
 export * from './utils';

--- a/sdk/src/modules/raffle/raffle.read.service.ts
+++ b/sdk/src/modules/raffle/raffle.read.service.ts
@@ -1,0 +1,100 @@
+import { RpcService } from '../../network/rpc.service';
+import { NetworkConfig } from '../../network/network.config';
+import { ContractFn } from '../../contract/bindings';
+import { getRaffleContractId } from '../../contract/constants';
+import { ContractResponse } from '../../contract/response';
+import { RaffleData } from './raffle.types';
+import { RaffleStatus } from '../../contract/bindings';
+import {
+  Contract,
+  TransactionBuilder,
+  BASE_FEE,
+  scValToNative,
+  nativeToScVal,
+  rpc,
+} from '@stellar/stellar-sdk';
+import { TikkaSdkError, TikkaSdkErrorCode } from '../../utils/errors';
+
+const ANON_KEY = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
+
+/**
+ * Read-only raffle queries — no wallet or signing dependencies required.
+ * Suitable for public dashboards and SSR pages.
+ */
+export class ReadOnlyRaffleService {
+  private readonly contractId: string;
+
+  constructor(
+    private readonly rpcService: RpcService,
+    private readonly networkConfig: NetworkConfig,
+  ) {
+    this.contractId = getRaffleContractId(networkConfig.network);
+  }
+
+  /** Fetch on-chain data for a single raffle by ID. Alias for `get`. */
+  async getById(raffleId: number): Promise<ContractResponse<RaffleData>> {
+    const raw = await this.simulate<any>(ContractFn.GET_RAFFLE_DATA, [raffleId]);
+    return { status: 'SUCCESS', value: this.mapRaffle(raffleId, raw) };
+  }
+
+  /** Return IDs of all raffles (any state). Alias for `listAll`. */
+  async getAll(): Promise<ContractResponse<number[]>> {
+    const ids = await this.simulate<number[]>(ContractFn.GET_ALL_RAFFLE_IDS, []);
+    return { status: 'SUCCESS', value: ids };
+  }
+
+  private async simulate<T>(method: string, params: any[]): Promise<T> {
+    const server = this.rpcService.getServer();
+    const contract = new Contract(this.contractId);
+
+    // Use a dummy account for read-only simulation
+    let account: any;
+    try {
+      account = await server.getAccount(ANON_KEY);
+    } catch {
+      account = { accountId: () => ANON_KEY, sequenceNumber: () => '0' } as any;
+    }
+
+    const tx = new TransactionBuilder(account, {
+      fee: BASE_FEE,
+      networkPassphrase: this.networkConfig.networkPassphrase,
+    })
+      .addOperation(contract.call(method, ...params.map((p) => nativeToScVal(p))))
+      .setTimeout(30)
+      .build();
+
+    const simResp = await this.rpcService.simulateTransaction(tx);
+
+    if (rpc.Api.isSimulationError(simResp)) {
+      throw new TikkaSdkError(
+        TikkaSdkErrorCode.SimulationFailed,
+        `Read-only simulation of ${method} failed: ${(simResp as any).error}`,
+      );
+    }
+
+    const result = (simResp as rpc.Api.SimulateTransactionSuccessResponse).result?.retval;
+    if (result === undefined) {
+      throw new TikkaSdkError(TikkaSdkErrorCode.SimulationFailed, `No return value from ${method}`);
+    }
+    return scValToNative(result) as T;
+  }
+
+  private mapRaffle(raffleId: number, raw: any): RaffleData {
+    return {
+      raffleId,
+      creator: raw.creator ?? '',
+      status: raw.status ?? RaffleStatus.Open,
+      ticketPrice: String(raw.ticket_price ?? '0'),
+      maxTickets: Number(raw.max_tickets ?? 0),
+      ticketsSold: Number(raw.tickets_sold ?? 0),
+      endTime: Number(raw.end_time ?? 0) * 1000,
+      asset: raw.asset ?? 'XLM',
+      assetIssuer: raw.asset_issuer || undefined,
+      allowMultiple: Boolean(raw.allow_multiple),
+      metadataCid: raw.metadata_cid ?? '',
+      winner: raw.winner,
+      winningTicketId: raw.winning_ticket_id,
+      prizeAmount: raw.prize_amount != null ? String(raw.prize_amount) : undefined,
+    };
+  }
+}

--- a/sdk/src/modules/user/user.read.service.ts
+++ b/sdk/src/modules/user/user.read.service.ts
@@ -1,0 +1,110 @@
+import { RpcService } from '../../network/rpc.service';
+import { NetworkConfig } from '../../network/network.config';
+import { ContractFn } from '../../contract/bindings';
+import { getRaffleContractId } from '../../contract/constants';
+import { ContractResponse } from '../../contract/response';
+import { UserParticipation } from './user.types';
+import {
+  Contract,
+  TransactionBuilder,
+  BASE_FEE,
+  scValToNative,
+  nativeToScVal,
+  rpc,
+  Address,
+} from '@stellar/stellar-sdk';
+import { TikkaSdkError, TikkaSdkErrorCode } from '../../utils/errors';
+import { assertValidPublicKey } from '../../utils/validation';
+
+const ANON_KEY = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
+
+/**
+ * Read-only user queries — no wallet or signing dependencies required.
+ * Suitable for public dashboards and SSR pages.
+ */
+export class ReadOnlyUserService {
+  private readonly contractId: string;
+
+  constructor(
+    private readonly rpcService: RpcService,
+    private readonly networkConfig: NetworkConfig,
+  ) {
+    this.contractId = getRaffleContractId(networkConfig.network);
+  }
+
+  /**
+   * Fetch on-chain participation profile for a user address.
+   * Alias for `getParticipation`.
+   */
+  async getProfile(address: string): Promise<ContractResponse<UserParticipation>> {
+    assertValidPublicKey(address);
+    const raw = await this.simulate<{
+      total_raffles_entered: number;
+      total_tickets_bought: number;
+      total_raffles_won: number;
+      raffle_ids: number[];
+    }>(ContractFn.GET_USER_PARTICIPATION, [new Address(address)]);
+
+    return {
+      success: true,
+      value: {
+        address,
+        totalRafflesEntered: raw.total_raffles_entered,
+        totalTicketsBought: raw.total_tickets_bought,
+        totalRafflesWon: raw.total_raffles_won,
+        raffleIds: raw.raffle_ids,
+      },
+    };
+  }
+
+  /**
+   * Fetch the list of raffle IDs a user has participated in.
+   * Alias for participation raffle IDs, suitable for building history views.
+   */
+  async getHistory(address: string): Promise<ContractResponse<number[]>> {
+    assertValidPublicKey(address);
+    const profile = await this.getProfile(address);
+    if (!profile.success) return profile as ContractResponse<number[]>;
+    return { success: true, value: profile.value!.raffleIds };
+  }
+
+  private async simulate<T>(method: string, params: any[]): Promise<T> {
+    const server = this.rpcService.getServer();
+    const contract = new Contract(this.contractId);
+
+    let account: any;
+    try {
+      account = await server.getAccount(ANON_KEY);
+    } catch {
+      account = { accountId: () => ANON_KEY, sequenceNumber: () => '0' } as any;
+    }
+
+    const tx = new TransactionBuilder(account, {
+      fee: BASE_FEE,
+      networkPassphrase: this.networkConfig.networkPassphrase,
+    })
+      .addOperation(
+        contract.call(
+          method,
+          ...params.map((p) => (p instanceof Object && 'toScVal' in p ? p.toScVal() : nativeToScVal(p))),
+        ),
+      )
+      .setTimeout(30)
+      .build();
+
+    const simResp = await this.rpcService.simulateTransaction(tx);
+
+    if (rpc.Api.isSimulationError(simResp)) {
+      throw new TikkaSdkError(
+        TikkaSdkErrorCode.SimulationFailed,
+        `Read-only simulation of ${method} failed: ${(simResp as any).error}`,
+      );
+    }
+
+    const result = (simResp as rpc.Api.SimulateTransactionSuccessResponse).result?.retval;
+    if (result === undefined) {
+      throw new TikkaSdkError(TikkaSdkErrorCode.SimulationFailed, `No return value from ${method}`);
+    }
+    return scValToNative(result) as T;
+  }
+}

--- a/sdk/src/test/read-only-entry.spec.ts
+++ b/sdk/src/test/read-only-entry.spec.ts
@@ -1,0 +1,198 @@
+/**
+ * Read-only entry point smoke tests (#813)
+ *
+ * Verifies:
+ * 1. `ReadOnlyRaffleService` and `ReadOnlyUserService` can be imported from
+ *    the read-only barrel (src/index.read.ts) without pulling in signing code.
+ * 2. `getAll` and `getById` are callable and return typed responses.
+ * 3. `getProfile` and `getHistory` are callable and return typed responses.
+ * 4. Signing-only symbols (`WalletAdapter`, `TransactionLifecycle`) are NOT
+ *    exported from the read-only barrel.
+ */
+
+// Import exclusively from the read barrel — no cross-barrel leakage.
+import {
+  ReadOnlyRaffleService,
+  ReadOnlyUserService,
+  RpcService,
+  resolveNetworkConfig,
+  ContractFn,
+  RaffleStatus,
+} from '../index.read';
+
+// --- Signing symbols must NOT be exported from the read barrel ---
+// TypeScript will error at build-time if these are accidentally re-exported;
+// at runtime we verify the named export is absent.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const readBarrel = require('../index.read');
+
+describe('@tikka/sdk/read — entry point', () => {
+  it('exports ReadOnlyRaffleService', () => {
+    expect(ReadOnlyRaffleService).toBeDefined();
+    expect(typeof ReadOnlyRaffleService).toBe('function'); // class
+  });
+
+  it('exports ReadOnlyUserService', () => {
+    expect(ReadOnlyUserService).toBeDefined();
+    expect(typeof ReadOnlyUserService).toBe('function');
+  });
+
+  it('exports read-only network helpers', () => {
+    expect(RpcService).toBeDefined();
+    expect(resolveNetworkConfig).toBeDefined();
+    expect(ContractFn).toBeDefined();
+    expect(RaffleStatus).toBeDefined();
+  });
+
+  it('does NOT export WalletAdapter', () => {
+    expect(readBarrel.WalletAdapter).toBeUndefined();
+  });
+
+  it('does NOT export TransactionLifecycle', () => {
+    expect(readBarrel.TransactionLifecycle).toBeUndefined();
+  });
+
+  it('does NOT export ContractService', () => {
+    expect(readBarrel.ContractService).toBeUndefined();
+  });
+
+  it('does NOT export signing wallet adapters', () => {
+    expect(readBarrel.FreighterAdapter).toBeUndefined();
+    expect(readBarrel.XBullAdapter).toBeUndefined();
+    expect(readBarrel.AlbedoAdapter).toBeUndefined();
+  });
+});
+
+describe('ReadOnlyRaffleService', () => {
+  let rpcService: jest.Mocked<RpcService>;
+  let service: ReadOnlyRaffleService;
+
+  const networkConfig = resolveNetworkConfig('testnet');
+
+  beforeEach(() => {
+    rpcService = {
+      getServer: jest.fn().mockReturnValue({
+        getAccount: jest.fn().mockResolvedValue({
+          accountId: () => 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
+          sequenceNumber: () => '0',
+          incrementSequenceNumber: jest.fn(),
+        }),
+      }),
+      simulateTransaction: jest.fn(),
+    } as unknown as jest.Mocked<RpcService>;
+
+    service = new ReadOnlyRaffleService(rpcService, networkConfig);
+  });
+
+  it('has getAll method', () => {
+    expect(typeof service.getAll).toBe('function');
+  });
+
+  it('has getById method', () => {
+    expect(typeof service.getById).toBe('function');
+  });
+
+  it('getAll returns ContractResponse with number[] on success', async () => {
+    // Mock a successful simulate response returning an empty list
+    rpcService.simulateTransaction.mockResolvedValue({
+      result: { retval: { switch: () => ({ name: 'scvVec' }), vec: () => [] } as any },
+      latestLedger: 100,
+    } as any);
+
+    // We only test the method signature — actual XDR parsing is integration-tested.
+    // Here we confirm the call does not throw for a happy-path mock.
+    const spy = jest.spyOn(service as any, 'simulate').mockResolvedValue([1, 2, 3]);
+    const result = await service.getAll();
+
+    expect(result.success).toBe(true);
+    expect(Array.isArray(result.value)).toBe(true);
+    spy.mockRestore();
+  });
+
+  it('getById returns ContractResponse with RaffleData on success', async () => {
+    const mockRaw = {
+      creator: 'GBIQ4VH3TRO5A72SCCSHV5QZJVUHMFAZVD5K4PIWL3RBQFKBDLPHJ36',
+      status: 0,
+      ticket_price: '1000000',
+      max_tickets: 100,
+      tickets_sold: 10,
+      end_time: 1700000000,
+      asset: 'XLM',
+      allow_multiple: false,
+      metadata_cid: '',
+    };
+
+    const spy = jest.spyOn(service as any, 'simulate').mockResolvedValue(mockRaw);
+    const result = await service.getById(1);
+
+    expect(result.success).toBe(true);
+    expect(result.value?.raffleId).toBe(1);
+    expect(result.value?.asset).toBe('XLM');
+    spy.mockRestore();
+  });
+});
+
+describe('ReadOnlyUserService', () => {
+  let rpcService: jest.Mocked<RpcService>;
+  let service: ReadOnlyUserService;
+
+  const networkConfig = resolveNetworkConfig('testnet');
+  const TEST_ADDRESS = 'GBIQ4VH3TRO5A72SCCSHV5QZJVUHMFAZVD5K4PIWL3RBQFKBDLPHJ36';
+
+  beforeEach(() => {
+    rpcService = {
+      getServer: jest.fn().mockReturnValue({
+        getAccount: jest.fn().mockResolvedValue({
+          accountId: () => 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
+          sequenceNumber: () => '0',
+          incrementSequenceNumber: jest.fn(),
+        }),
+      }),
+      simulateTransaction: jest.fn(),
+    } as unknown as jest.Mocked<RpcService>;
+
+    service = new ReadOnlyUserService(rpcService, networkConfig);
+  });
+
+  it('has getProfile method', () => {
+    expect(typeof service.getProfile).toBe('function');
+  });
+
+  it('has getHistory method', () => {
+    expect(typeof service.getHistory).toBe('function');
+  });
+
+  it('getProfile returns ContractResponse with UserParticipation', async () => {
+    const mockRaw = {
+      total_raffles_entered: 5,
+      total_tickets_bought: 12,
+      total_raffles_won: 1,
+      raffle_ids: [1, 2, 3],
+    };
+
+    const spy = jest.spyOn(service as any, 'simulate').mockResolvedValue(mockRaw);
+    const result = await service.getProfile(TEST_ADDRESS);
+
+    expect(result.success).toBe(true);
+    expect(result.value?.address).toBe(TEST_ADDRESS);
+    expect(result.value?.totalRafflesEntered).toBe(5);
+    expect(result.value?.raffleIds).toEqual([1, 2, 3]);
+    spy.mockRestore();
+  });
+
+  it('getHistory returns raffle IDs', async () => {
+    const mockRaw = {
+      total_raffles_entered: 2,
+      total_tickets_bought: 4,
+      total_raffles_won: 0,
+      raffle_ids: [10, 20],
+    };
+
+    const spy = jest.spyOn(service as any, 'simulate').mockResolvedValue(mockRaw);
+    const result = await service.getHistory(TEST_ADDRESS);
+
+    expect(result.success).toBe(true);
+    expect(result.value).toEqual([10, 20]);
+    spy.mockRestore();
+  });
+});

--- a/sdk/tsconfig.read.json
+++ b/sdk/tsconfig.read.json
@@ -19,10 +19,13 @@
     "src/network/horizon.service.ts",
     "src/network/network.config.ts",
     "src/contract/bindings.ts",
+    "src/contract/constants.ts",
     "src/contract/response.ts",
     "src/modules/raffle/raffle.types.ts",
+    "src/modules/raffle/raffle.read.service.ts",
     "src/modules/ticket/ticket.types.ts",
     "src/modules/user/user.types.ts",
+    "src/modules/user/user.read.service.ts",
     "src/utils/**/*.ts",
     "src/types.ts"
   ],


### PR DESCRIPTION

Closes #813 
Closes #822 
Closes #850 
Closes #838 

Desciption:
813 expose ReadOnlyRaffleService (getAll/getById) and ReadOnlyUserService (getProfile/getHistory) from @tikka/sdk/read; update tsconfig.read.json; add read-only entry point tests; document in sdk/README.md

822  add .github/dependabot.yml for npm (all 5 packages), docker, and github-actions with weekly schedule

850 install @vercel/analytics and @vercel/speed-insights in client; inject via dynamic import gated on PROD && MODE!=='test'; add client/docs/PERFORMANCE.md with CWV targets (LCP<2.5s, CLS<0.1, INP<200ms)

838 add @nestjs/swagger to indexer; enable SwaggerModule in main.ts (/api-docs JSON, /api-docs/ui Swagger UI); decorate all controllers and DTOs; add scripts/generate-openapi.ts and openapi:generate script

fixed correct YAML indentation bug in .github/workflows/e2e.yml