### PR TITLE
feat: add category filter chips to search page

### DIFF
--- a/client/src/hooks/useSearch.ts
+++ b/client/src/hooks/useSearch.ts
@@ -2,11 +2,13 @@ import { useState, useEffect, useRef } from "react";
 import { searchRaffles } from "../services/raffleService";
 import type { ApiRaffleListItem, ApiRaffleListResponse } from "../types/types";
 
-export const useSearch = (query: string) => {
+export const useSearch = (query: string, categories: string[] = []) => {
     const [results, setResults] = useState<ApiRaffleListItem[]>([]);
     const [isLoading, setIsLoading] = useState(false);
     const [error, setError] = useState<Error | null>(null);
     const requestId = useRef(0);
+
+    const categoriesKey = categories.sort().join(",");
 
     useEffect(() => {
         const currentRequest = ++requestId.current;
@@ -20,7 +22,7 @@ export const useSearch = (query: string) => {
         setIsLoading(true);
         setError(null);
 
-        searchRaffles(query)
+        searchRaffles(query, categories)
             .then((response: ApiRaffleListResponse) => {
                 if (currentRequest !== requestId.current) return;
                 setResults(response.raffles);
@@ -33,7 +35,7 @@ export const useSearch = (query: string) => {
                 if (currentRequest !== requestId.current) return;
                 setIsLoading(false);
             });
-    }, [query]);
+    }, [query, categoriesKey]);
 
     return { results, isLoading, error };
 };

--- a/client/src/pages/Search.tsx
+++ b/client/src/pages/Search.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback, useMemo } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { useSearch } from "../hooks/useSearch";
 import { toRaffleCardViewModel } from "../components/cards/raffleCardViewModel";
@@ -7,11 +7,37 @@ import RaffleCardSkeleton from "../components/ui/RaffleCardSkeleton";
 import ErrorMessage from "../components/ui/ErrorMessage";
 import { Breadcrumbs } from "../components/ui/Breadcrumbs";
 
+const CATEGORIES = ["Gaming", "Electronics", "Art", "Music", "Sports", "Collectibles", "Other"];
+
 const SearchPage: React.FC = () => {
-    const [searchParams] = useSearchParams();
+    const [searchParams, setSearchParams] = useSearchParams();
     const query = searchParams.get("q") || "";
-    const { results, isLoading, error } = useSearch(query);
+    const categoriesParam = searchParams.get("category") || "";
+    const selectedCategories = useMemo(
+        () => categoriesParam
+            ? categoriesParam.split(",").map((c) => c.trim()).filter(Boolean)
+            : [],
+        [categoriesParam]
+    );
+    const { results, isLoading, error } = useSearch(query, selectedCategories);
     const navigate = useNavigate();
+
+    const toggleCategory = useCallback((category: string) => {
+        const current = new Set(selectedCategories);
+        if (current.has(category)) {
+            current.delete(category);
+        } else {
+            current.add(category);
+        }
+        const next = Array.from(current);
+        const params = new URLSearchParams(searchParams);
+        if (next.length > 0) {
+            params.set("category", next.join(","));
+        } else {
+            params.delete("category");
+        }
+        setSearchParams(params, { replace: true });
+    }, [selectedCategories, searchParams, setSearchParams]);
 
     return (
         <div className="container mx-auto px-4 py-8">
@@ -25,6 +51,29 @@ const SearchPage: React.FC = () => {
             <h1 className="text-2xl font-bold mb-6">
                 {query ? `Search results for "${query}"` : "Search Raffles"}
             </h1>
+
+            <div className="mb-6 overflow-x-auto scrollbar-hide">
+                <div className="flex gap-2 min-w-max pb-2">
+                    {CATEGORIES.map((category) => {
+                        const isActive = selectedCategories.includes(category);
+                        return (
+                            <button
+                                key={category}
+                                onClick={() => toggleCategory(category)}
+                                className={`
+                                    px-4 py-2 rounded-full text-sm font-medium transition-all whitespace-nowrap
+                                    ${isActive
+                                        ? "bg-[#FE3796] text-white shadow-lg shadow-[#FE3796]/20"
+                                        : "bg-white dark:bg-[#11172E] text-gray-700 dark:text-gray-300 border border-gray-200 dark:border-white/10 hover:border-[#FE3796]/50"
+                                    }
+                                `}
+                            >
+                                {category}
+                            </button>
+                        );
+                    })}
+                </div>
+            </div>
 
             {isLoading && (
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
@@ -43,7 +92,6 @@ const SearchPage: React.FC = () => {
 
             {!isLoading && !error && results.length === 0 && query && (
                 <div className="flex flex-col items-center justify-center py-20 animate-in fade-in zoom-in duration-500">
-                    {/* Animated Icon */}
                     <div className="relative mb-6">
                         <div className="absolute inset-0 rounded-full bg-[#FE3796]/20 animate-ping"></div>
                         <div className="relative bg-white dark:bg-[#11172E] p-6 rounded-full border border-gray-200 dark:border-white/10">

--- a/client/src/services/raffleService.ts
+++ b/client/src/services/raffleService.ts
@@ -43,11 +43,35 @@ export async function fetchRaffleDetail(
 
 
 export async function searchRaffles(
-    query: string
+    query: string,
+    categories?: string[]
 ): Promise<ApiRaffleListResponse> {
     const trimmedQuery = query.trim();
-    const endpoint = `${API_CONFIG.endpoints.search}?q=${encodeURIComponent(trimmedQuery)}`;
-    return api.get<ApiRaffleListResponse>(endpoint);
+
+    if (!categories || categories.length === 0) {
+        const endpoint = `${API_CONFIG.endpoints.search}?q=${encodeURIComponent(trimmedQuery)}`;
+        return api.get<ApiRaffleListResponse>(endpoint);
+    }
+
+    const promises = categories.map((cat) => {
+        const endpoint = `${API_CONFIG.endpoints.search}?q=${encodeURIComponent(trimmedQuery)}&category=${encodeURIComponent(cat)}`;
+        return api.get<ApiRaffleListResponse>(endpoint);
+    });
+
+    const responses = await Promise.all(promises);
+
+    const seen = new Set<number>();
+    const merged: ApiRaffleListItem[] = [];
+    for (const response of responses) {
+        for (const raffle of response.raffles) {
+            if (!seen.has(raffle.id)) {
+                seen.add(raffle.id);
+                merged.push(raffle);
+            }
+        }
+    }
+
+    return { raffles: merged, total: merged.length };
 }
 export async function fetchUserProfile(address: string): Promise<ApiUserProfile> {
     const endpoint = API_CONFIG.endpoints.users.profile(encodeURIComponent(address));


### PR DESCRIPTION
## Summary

Adds a horizontal scrollable row of category filter chips to the Search page, allowing users to narrow raffle results by category without a full page reload.

## Changes

### `client/src/services/raffleService.ts`
- `searchRaffles` now accepts an optional `categories?: string[]` parameter
- When categories are provided, fires parallel `GET /search?q=...&category=...` requests (one per selected category) and deduplicates results by raffle ID via a `Set<number>`

### `client/src/hooks/useSearch.ts`
- Accepts a second `categories: string[]` argument (defaults to `[]`)
- Uses `categories.sort().join(',')` as a stable dependency key so the search re-fires when categories change
- Passes categories through to `searchRaffles`

### `client/src/pages/Search.tsx`
- Reads a comma-separated `?category=` from the URL and parses it into `selectedCategories` via `useMemo`
- Renders a horizontally scrollable row of rounded filter chips above the results grid
- Active chips are filled pink (`#FE3796`), inactive chips use an outlined border style
- `toggleCategory` toggles a category in/out and updates the URL via `setSearchParams` with `replace: true`
- `useSearch` receives both `query` and `selectedCategories`

## Acceptance Criteria

- [x] Clicking a category chip narrows search results to that category
- [x] Multi-select: multiple category chips can be active simultaneously
- [x] Active categories are reflected in the URL query string (`?category=gaming,art`)
- [x] Category filters survive page refresh

## Categories

`Gaming`, `Electronics`, `Art`, `Music`, `Sports`, `Collectibles`, `Other`

---

Closes #832