### PR TITLE
feat(client): integrate Web Share API with clipboard fallback in ShareRaffle

### DIFF
--- a/client/src/components/ShareRaffle.spec.tsx
+++ b/client/src/components/ShareRaffle.spec.tsx
@@ -1,0 +1,57 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+vi.mock("sonner", () => ({
+    toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+import { toast } from "sonner";
+import ShareRaffle from "./ShareRaffle";
+
+function getFakeNavigator(overrides: Record<string, unknown> = {}) {
+    return { ...navigator, share: undefined, clipboard: undefined, ...overrides };
+}
+
+describe("ShareRaffle", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    test("calls navigator.share with correct params and handles AbortError silently", async () => {
+        const shareFn = vi.fn().mockRejectedValue(
+            new DOMException("The user aborted a request.", "AbortError"),
+        );
+        vi.stubGlobal("navigator", getFakeNavigator({ share: shareFn }));
+
+        render(<ShareRaffle raffleId={42} title="Cool Prize" />);
+        fireEvent.click(screen.getByRole("button", { name: /share using your device/i }));
+
+        await new Promise((r) => setTimeout(r, 50));
+
+        expect(shareFn).toHaveBeenCalledWith({
+            title: "Cool Prize",
+            text: "Check out this raffle: Cool Prize",
+            url: expect.stringContaining("/raffles/42"),
+        });
+        expect(toast.error).not.toHaveBeenCalled();
+    });
+
+    test("falls back to clipboard copy when navigator.share is unavailable and shows toast", async () => {
+        const writeTextFn = vi.fn().mockResolvedValue(undefined);
+        vi.stubGlobal("navigator", getFakeNavigator({ clipboard: { writeText: writeTextFn } }));
+
+        render(<ShareRaffle raffleId={7} title="Another Raffle" />);
+        fireEvent.click(screen.getByRole("button", { name: /share using your device/i }));
+
+        await new Promise((r) => setTimeout(r, 50));
+
+        expect(writeTextFn).toHaveBeenCalledWith(
+            expect.stringContaining("/raffles/7"),
+        );
+        expect(toast.success).toHaveBeenCalledWith("Link copied!");
+    });
+});

--- a/client/src/components/ShareRaffle.tsx
+++ b/client/src/components/ShareRaffle.tsx
@@ -86,20 +86,38 @@ const ShareRaffle = ({ raffleId, title }: ShareRaffleProps) => {
         [raffleId],
     );
 
-    const canWebShare =
-        typeof navigator !== "undefined" &&
-        typeof navigator.share === "function";
-
     const handleNativeShare = useCallback(async () => {
-        if (!canWebShare) return;
-        try {
-            await navigator.share({ title, text: shareBlurb, url: nativeShareUrl });
-        } catch (err) {
-            const name = err instanceof DOMException ? err.name : "";
-            if (name === "AbortError") return;
-            toast.error("Sharing was cancelled or failed.");
+        if (typeof navigator !== "undefined" && typeof navigator.share === "function") {
+            try {
+                await navigator.share({ title, text: shareBlurb, url: nativeShareUrl });
+                return;
+            } catch (err) {
+                const name = err instanceof DOMException ? err.name : "";
+                if (name === "AbortError") return;
+                toast.error("Sharing was cancelled or failed.");
+                return;
+            }
         }
-    }, [canWebShare, nativeShareUrl, shareBlurb, title]);
+        try {
+            await navigator.clipboard.writeText(nativeShareUrl);
+            toast.success("Link copied!");
+        } catch {
+            const ta = document.createElement("textarea");
+            ta.value = nativeShareUrl;
+            ta.style.cssText = "position:fixed;top:-9999px;left:-9999px;opacity:0";
+            document.body.appendChild(ta);
+            ta.focus();
+            ta.select();
+            try {
+                document.execCommand("copy");
+                toast.success("Link copied!");
+            } catch {
+                toast.error("Could not copy link");
+            } finally {
+                document.body.removeChild(ta);
+            }
+        }
+    }, [nativeShareUrl, shareBlurb, title]);
 
     const handleCopyLink = useCallback(async () => {
         let success = false;
@@ -116,7 +134,7 @@ const ShareRaffle = ({ raffleId, title }: ShareRaffleProps) => {
         }
         if (success) {
             setCopied(true);
-            toast.success("Link copied to clipboard");
+            toast.success("Link copied!");
             window.setTimeout(() => setCopied(false), 2000);
         } else {
             toast.error("Could not copy link");
@@ -167,17 +185,15 @@ const ShareRaffle = ({ raffleId, title }: ShareRaffleProps) => {
                 </p>
 
                 <div className="mt-5 flex flex-wrap items-center gap-3">
-                    {canWebShare ? (
-                        <button
-                            type="button"
-                            className={`${iconButtonClass} gap-2 px-4 py-2 rounded-full text-sm font-medium`}
-                            onClick={handleNativeShare}
-                            aria-label="Share using your device"
-                        >
-                            <Share2 className="h-5 w-5 shrink-0" />
-                            <span className="text-gray-100">Share</span>
-                        </button>
-                    ) : null}
+                    <button
+                        type="button"
+                        className={`${iconButtonClass} gap-2 px-4 py-2 rounded-full text-sm font-medium`}
+                        onClick={handleNativeShare}
+                        aria-label="Share using your device"
+                    >
+                        <Share2 className="h-5 w-5 shrink-0" />
+                        <span className="text-gray-100">Share</span>
+                    </button>
 
                     <a
                         href={twitterHref}


### PR DESCRIPTION
## Summary

Integrates the Web Share API (`navigator.share`) into the ShareRaffle component with a clipboard fallback for desktop browsers where the API is unavailable.

## Changes

- **`ShareRaffle.tsx`**: `handleNativeShare` now calls `navigator.share({ title, text, url })` when available, silently handling `AbortError` (user dismisses the share sheet). Falls back to `navigator.clipboard.writeText(url)`, showing a _Link copied!_ success toast, with `document.execCommand('copy')` as a last resort. The Share button is now always rendered (previously hidden without Web Share).
- **`ShareRaffle.spec.tsx`**: Two tests using `vi.stubGlobal` covering both code paths — `navigator.share` with AbortError handling and clipboard fallback.

## Acceptance Criteria

- [x] On mobile, clicking Share opens the native share sheet
- [x] On desktop, clicking Share copies the URL to clipboard with a toast confirmation
- [x] AbortError is caught silently
- [x] Tests pass (`pnpm vitest run src/components/ShareRaffle.spec.tsx`)
- [x] Lint clean (`pnpm eslint src/components/ShareRaffle.tsx src/components/ShareRaffle.spec.tsx`)