### PR TITLE
sdk: Add xBull wallet adapter disconnect and event listener cleanup

### DIFF
--- a/sdk/src/utils/errors.ts
+++ b/sdk/src/utils/errors.ts
@@ -34,8 +34,10 @@ export class RpcError extends Error {
  * SDK-wide error codes exactly as required by Issue #154
  */
 export enum TikkaSdkErrorCode {
-  /** Wallet extension not installed */
+ /** Wallet extension not installed in the browser */
   WalletNotInstalled = 'WALLET_NOT_INSTALLED',
+  /** Wallet extension installed but not connected/authorized */
+  WalletNotConnected = 'WALLET_NOT_CONNECTED',
   /** User rejected the transaction / signature request */
   UserRejected = 'UserRejected',
   /** Transaction simulation failed */
@@ -151,4 +153,4 @@ export class ContractFailureError extends TikkaSdkError {
     this.name = 'ContractFailureError';
     Object.setPrototypeOf(this, ContractFailureError.prototype);
   }
-}
+}

--- a/sdk/src/wallet/xbull.adapter.spec.ts
+++ b/sdk/src/wallet/xbull.adapter.spec.ts
@@ -1,6 +1,6 @@
 import { XBullAdapter } from './xbull.adapter';
 import { WalletName } from './wallet.interface';
-import { TikkaSdkError, TikkaSdkErrorCode } from '../utils/errors';
+import { TikkaSdkErrorCode } from '../utils/errors';
 import { Networks } from '@stellar/stellar-sdk';
 
 describe('XBullAdapter', () => {
@@ -14,6 +14,11 @@ describe('XBullAdapter', () => {
     };
 
     (globalThis as any).xbull = mockXBullSdk;
+    // node env: provide a minimal window with listener APIs.
+    (globalThis as any).window = {
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    };
 
     adapter = new XBullAdapter({
       networkPassphrase: Networks.TESTNET,
@@ -22,7 +27,16 @@ describe('XBullAdapter', () => {
 
   afterEach(() => {
     delete (globalThis as any).xbull;
+    delete (globalThis as any).window;
+    jest.restoreAllMocks();
   });
+
+  /** Connect helper for tests exercising the post-connection happy path. */
+  const connect = async (publicKey = 'GCONNECTED') => {
+    mockXBullSdk.getPublicKey.mockResolvedValue(publicKey);
+    await adapter.connect();
+    mockXBullSdk.getPublicKey.mockReset();
+  };
 
   describe('name', () => {
     it('should return correct wallet name', () => {
@@ -41,45 +55,121 @@ describe('XBullAdapter', () => {
     });
   });
 
-  describe('getPublicKey', () => {
-    it('should return public key string', async () => {
-      const expectedPublicKey = 'GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
-      mockXBullSdk.getPublicKey.mockResolvedValue(expectedPublicKey);
+  describe('connect', () => {
+    it('should mark the adapter connected and cache the address', async () => {
+      mockXBullSdk.getPublicKey.mockResolvedValue('GABC');
 
-      const publicKey = await adapter.getPublicKey();
+      await adapter.connect();
 
-      expect(publicKey).toBe(expectedPublicKey);
-      expect(mockXBullSdk.getPublicKey).toHaveBeenCalledTimes(1);
+      expect(adapter.isWalletConnected()).toBe(true);
     });
 
-    it('should throw WalletNotInstalled error when xBull is not available', async () => {
+    it('should be idempotent without stacking listeners', async () => {
+      mockXBullSdk.getPublicKey.mockResolvedValue('GABC');
+
+      await adapter.connect();
+      await adapter.connect();
+
+      expect(adapter.isWalletConnected()).toBe(true);
+    });
+
+    it('should throw WalletNotInstalled when xBull is not available', async () => {
       delete (globalThis as any).xbull;
       const freshAdapter = new XBullAdapter();
 
-      await expect(freshAdapter.getPublicKey()).rejects.toThrow(TikkaSdkError);
-      await expect(freshAdapter.getPublicKey()).rejects.toMatchObject({
+      await expect(freshAdapter.connect()).rejects.toMatchObject({
         code: TikkaSdkErrorCode.WalletNotInstalled,
-        message: expect.stringContaining('xBull wallet is not installed'),
       });
     });
 
-    it('should throw UserRejected error when user cancels', async () => {
+    it('should throw UserRejected and leave adapter disconnected when user cancels', async () => {
       mockXBullSdk.getPublicKey.mockRejectedValue(new Error('User cancelled the request'));
 
-      await expect(adapter.getPublicKey()).rejects.toThrow(TikkaSdkError);
-      await expect(adapter.getPublicKey()).rejects.toMatchObject({
+      await expect(adapter.connect()).rejects.toMatchObject({
         code: TikkaSdkErrorCode.UserRejected,
-        message: 'User rejected xBull request',
+      });
+      expect(adapter.isWalletConnected()).toBe(false);
+    });
+  });
+
+  describe('disconnect', () => {
+    it('should reset the connection flag', async () => {
+      await connect();
+      expect(adapter.isWalletConnected()).toBe(true);
+
+      await adapter.disconnect();
+
+      expect(adapter.isWalletConnected()).toBe(false);
+    });
+
+    it('should remove every listener added during connection (no residual listeners)', async () => {
+      const addSpy = jest.spyOn((globalThis as any).window, 'addEventListener');
+      const removeSpy = jest.spyOn((globalThis as any).window, 'removeEventListener');
+
+      await connect();
+      await adapter.disconnect();
+
+      expect(removeSpy.mock.calls.length).toBe(addSpy.mock.calls.length);
+      for (const [type, handler] of addSpy.mock.calls) {
+        expect(removeSpy).toHaveBeenCalledWith(type, handler);
+      }
+    });
+
+    it('should be safe to call when not connected', async () => {
+      await expect(adapter.disconnect()).resolves.toBeUndefined();
+      expect(adapter.isWalletConnected()).toBe(false);
+    });
+  });
+
+  describe('connection guard', () => {
+    it('should throw WalletNotConnected from getPublicKey before connect()', async () => {
+      await expect(adapter.getPublicKey()).rejects.toMatchObject({
+        code: TikkaSdkErrorCode.WalletNotConnected,
       });
     });
 
-    it('should throw Unknown error for other failures', async () => {
-      mockXBullSdk.getPublicKey.mockRejectedValue(new Error('Network timeout'));
+    it('should throw WalletNotConnected from signTransaction before connect()', async () => {
+      await expect(adapter.signTransaction('xdr')).rejects.toMatchObject({
+        code: TikkaSdkErrorCode.WalletNotConnected,
+      });
+      expect(mockXBullSdk.signTransaction).not.toHaveBeenCalled();
+    });
 
-      await expect(adapter.getPublicKey()).rejects.toThrow(TikkaSdkError);
+    it('should throw WalletNotConnected after disconnect()', async () => {
+      await connect();
+      await adapter.disconnect();
+
+      await expect(adapter.signTransaction('xdr')).rejects.toMatchObject({
+        code: TikkaSdkErrorCode.WalletNotConnected,
+      });
+      expect(mockXBullSdk.signTransaction).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getPublicKey', () => {
+    beforeEach(() => connect());
+
+    it('should return the cached public key string', async () => {
+      const result = await adapter.getPublicKey();
+      expect(result).toBe('GCONNECTED');
+    });
+
+    it('should resolve via sdk when no address is cached', async () => {
+      await adapter.disconnect();
+      mockXBullSdk.getPublicKey.mockResolvedValue('GFRESH');
+      await adapter.connect();
+      // Force the cache miss path by reconnecting without a cached value.
+      mockXBullSdk.getPublicKey.mockResolvedValue('GFRESH');
+
+      const result = await adapter.getPublicKey();
+      expect(result).toBe('GFRESH');
+    });
+
+    it('should throw WalletNotInstalled when xBull is not available', async () => {
+      delete (globalThis as any).xbull;
+
       await expect(adapter.getPublicKey()).rejects.toMatchObject({
-        code: TikkaSdkErrorCode.Unknown,
-        message: expect.stringContaining('xBull getPublicKey failed'),
+        code: TikkaSdkErrorCode.WalletNotInstalled,
       });
     });
   });
@@ -87,6 +177,8 @@ describe('XBullAdapter', () => {
   describe('signTransaction', () => {
     const mockXdr = 'AAAAAgAAAABqxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxQ==';
     const mockSignedXdr = 'AAAAAgAAAABqyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyQ==';
+
+    beforeEach(() => connect());
 
     it('should sign transaction and return signed XDR', async () => {
       mockXBullSdk.signTransaction.mockResolvedValue(mockSignedXdr);
@@ -125,12 +217,10 @@ describe('XBullAdapter', () => {
       });
     });
 
-    it('should throw WalletNotInstalled error when xBull is not available', async () => {
+    it('should throw WalletNotInstalled when xBull is not available', async () => {
       delete (globalThis as any).xbull;
-      const freshAdapter = new XBullAdapter();
 
-      await expect(freshAdapter.signTransaction(mockXdr)).rejects.toThrow(TikkaSdkError);
-      await expect(freshAdapter.signTransaction(mockXdr)).rejects.toMatchObject({
+      await expect(adapter.signTransaction(mockXdr)).rejects.toMatchObject({
         code: TikkaSdkErrorCode.WalletNotInstalled,
       });
     });
@@ -138,7 +228,6 @@ describe('XBullAdapter', () => {
     it('should throw UserRejected error when user cancels', async () => {
       mockXBullSdk.signTransaction.mockRejectedValue(new Error('User cancelled transaction'));
 
-      await expect(adapter.signTransaction(mockXdr)).rejects.toThrow(TikkaSdkError);
       await expect(adapter.signTransaction(mockXdr)).rejects.toMatchObject({
         code: TikkaSdkErrorCode.UserRejected,
         message: 'User rejected transaction signing',
@@ -148,7 +237,6 @@ describe('XBullAdapter', () => {
     it('should throw Unknown error for other failures', async () => {
       mockXBullSdk.signTransaction.mockRejectedValue(new Error('Invalid transaction XDR'));
 
-      await expect(adapter.signTransaction(mockXdr)).rejects.toThrow(TikkaSdkError);
       await expect(adapter.signTransaction(mockXdr)).rejects.toMatchObject({
         code: TikkaSdkErrorCode.Unknown,
         message: expect.stringContaining('xBull signTransaction failed'),
@@ -178,6 +266,8 @@ describe('XBullAdapter', () => {
       expect(typeof adapter.signTransaction).toBe('function');
       expect(typeof adapter.signMessage).toBe('function');
       expect(typeof adapter.getNetwork).toBe('function');
+      expect(typeof adapter.connect).toBe('function');
+      expect(typeof adapter.disconnect).toBe('function');
     });
 
     it('should have name property', () => {
@@ -186,6 +276,7 @@ describe('XBullAdapter', () => {
     });
 
     it('should return SignTransactionResult with signedXdr property', async () => {
+      await connect();
       const mockSignedXdr = 'AAAAAgAAAABqyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyQ==';
       mockXBullSdk.signTransaction.mockResolvedValue(mockSignedXdr);
 
@@ -197,12 +288,9 @@ describe('XBullAdapter', () => {
   });
 
   describe('error mapping consistency', () => {
-    it('should map cancel errors consistently', async () => {
-      mockXBullSdk.getPublicKey.mockRejectedValueOnce(new Error('User cancelled'));
-      await expect(adapter.getPublicKey()).rejects.toMatchObject({
-        code: TikkaSdkErrorCode.UserRejected,
-      });
+    beforeEach(() => connect());
 
+    it('should map cancel errors consistently', async () => {
       mockXBullSdk.signTransaction.mockRejectedValueOnce(new Error('User cancelled'));
       await expect(adapter.signTransaction('xdr')).rejects.toMatchObject({
         code: TikkaSdkErrorCode.UserRejected,
@@ -210,11 +298,6 @@ describe('XBullAdapter', () => {
     });
 
     it('should map rejected errors consistently', async () => {
-      mockXBullSdk.getPublicKey.mockRejectedValueOnce(new Error('Request rejected'));
-      await expect(adapter.getPublicKey()).rejects.toMatchObject({
-        code: TikkaSdkErrorCode.UserRejected,
-      });
-
       mockXBullSdk.signTransaction.mockRejectedValueOnce(new Error('Request rejected'));
       await expect(adapter.signTransaction('xdr')).rejects.toMatchObject({
         code: TikkaSdkErrorCode.UserRejected,
@@ -222,11 +305,6 @@ describe('XBullAdapter', () => {
     });
 
     it('should map denied errors consistently', async () => {
-      mockXBullSdk.getPublicKey.mockRejectedValueOnce(new Error('Access denied'));
-      await expect(adapter.getPublicKey()).rejects.toMatchObject({
-        code: TikkaSdkErrorCode.UserRejected,
-      });
-
       mockXBullSdk.signTransaction.mockRejectedValueOnce(new Error('Access denied'));
       await expect(adapter.signTransaction('xdr')).rejects.toMatchObject({
         code: TikkaSdkErrorCode.UserRejected,

--- a/sdk/src/wallet/xbull.adapter.ts
+++ b/sdk/src/wallet/xbull.adapter.ts
@@ -7,15 +7,24 @@ import {
 } from './wallet.interface';
 import { TikkaSdkError, TikkaSdkErrorCode } from '../utils/errors';
 
-/**
- * xBull wallet adapter.
- *
- * Uses the `window.xbull` global injected by the xBull extension / PWA.
- * 
- * @see https://docs.xbull.app/
- */
+
+interface TrackedListener {
+  type: string;
+  handler: EventListenerOrEventListenerObject;
+}
+
+
 export class XBullAdapter extends WalletAdapter {
   readonly name = WalletName.XBull;
+
+  /** Internal connection state, toggled by connect()/disconnect(). */
+  private connected = false;
+
+  /** Cached address resolved at connect time; cleared on disconnect. */
+  private address: string | null = null;
+
+  /** All window listeners registered during connect(), removed on disconnect(). */
+  private listeners: TrackedListener[] = [];
 
   constructor(options: WalletAdapterOptions = {}) {
     super(options);
@@ -28,27 +37,62 @@ export class XBullAdapter extends WalletAdapter {
     );
   }
 
-  async getPublicKey(): Promise<string> {
+
+  async connect(): Promise<void> {
     this.assertInstalled();
+
+    // Re-resolving on an existing connection must not stack listeners.
+    if (this.connected) {
+      this.removeAllListeners();
+    }
 
     try {
       const sdk = this.getSdk();
-      const publicKey: string = await sdk.getPublicKey();
-      return publicKey;
+      this.address = await sdk.getPublicKey();
+      this.connected = true;
     } catch (err: any) {
+      this.resetState();
       if (this.isUserRejection(err)) {
         throw new TikkaSdkError(
           TikkaSdkErrorCode.UserRejected,
           'User rejected xBull request',
-          err
+          err,
         );
       }
-
       throw new TikkaSdkError(
         TikkaSdkErrorCode.Unknown,
-        `xBull getPublicKey failed: ${err?.message ?? err}`,
-        err
+        `xBull connect failed: ${err?.message ?? err}`,
+        err,
       );
+    }
+  }
+
+  
+  async disconnect(): Promise<void> {
+    this.removeAllListeners();
+    this.resetState();
+  }
+
+  /** Whether the adapter currently considers itself connected (cached flag). */
+  isWalletConnected(): boolean {
+    return this.connected;
+  }
+
+  async getPublicKey(): Promise<string> {
+    this.assertInstalled();
+    this.assertConnected();
+
+    if (this.address) {
+      return this.address;
+    }
+
+    try {
+      const sdk = this.getSdk();
+      const publicKey: string = await sdk.getPublicKey();
+      this.address = publicKey;
+      return publicKey;
+    } catch (err: any) {
+      throw this.mapError(err, 'getPublicKey', 'User rejected xBull request');
     }
   }
 
@@ -57,6 +101,7 @@ export class XBullAdapter extends WalletAdapter {
     opts?: { networkPassphrase?: string; accountToSign?: string },
   ): Promise<SignTransactionResult> {
     this.assertInstalled();
+    this.assertConnected();
 
     const networkPassphrase =
       opts?.networkPassphrase ?? this.options.networkPassphrase;
@@ -71,23 +116,11 @@ export class XBullAdapter extends WalletAdapter {
 
       return { signedXdr };
     } catch (err: any) {
-      if (this.isUserRejection(err)) {
-        throw new TikkaSdkError(
-          TikkaSdkErrorCode.UserRejected,
-          'User rejected transaction signing',
-          err
-        );
-      }
-
-      throw new TikkaSdkError(
-        TikkaSdkErrorCode.Unknown,
-        `xBull signTransaction failed: ${err?.message ?? err}`,
-        err
-      );
+      throw this.mapError(err, 'signTransaction', 'User rejected transaction signing');
     }
   }
 
-  /* ---------------------- Capabilities ---------------------- */
+  /* Capabilities*/
 
   getCapabilities(): WalletCapabilities {
     return {
@@ -98,7 +131,32 @@ export class XBullAdapter extends WalletAdapter {
     };
   }
 
-  /* ---------------------- Helpers ---------------------- */
+  /* Helpers  */
+  private addTrackedListener(
+    type: string,
+    handler: EventListenerOrEventListenerObject,
+  ): void {
+    const target = (globalThis as any).window;
+    if (target?.addEventListener) {
+      target.addEventListener(type, handler);
+      this.listeners.push({ type, handler });
+    }
+  }
+
+  /** Removes every tracked listener and empties the tracking array. */
+  private removeAllListeners(): void {
+    const target = (globalThis as any).window;
+    for (const { type, handler } of this.listeners) {
+      target?.removeEventListener?.(type, handler);
+    }
+    this.listeners = [];
+  }
+
+  /** Clears connection flag and cached address. */
+  private resetState(): void {
+    this.connected = false;
+    this.address = null;
+  }
 
   private getSdk(): any {
     return (globalThis as any).xbull;
@@ -108,9 +166,36 @@ export class XBullAdapter extends WalletAdapter {
     if (!this.isAvailable()) {
       throw new TikkaSdkError(
         TikkaSdkErrorCode.WalletNotInstalled,
-        'xBull wallet is not installed. Install it from https://xbull.app'
+        'xBull wallet is not installed. Install it from https://xbull.app',
       );
     }
+  }
+
+  private assertConnected(): void {
+    if (!this.connected) {
+      throw new TikkaSdkError(
+        TikkaSdkErrorCode.WalletNotConnected,
+        'xBull wallet is not connected. Call connect() before using wallet methods.',
+      );
+    }
+  }
+
+  private mapError(err: any, op: string, rejectionMessage: string): TikkaSdkError {
+    if (err instanceof TikkaSdkError) {
+      return err;
+    }
+    if (this.isUserRejection(err)) {
+      return new TikkaSdkError(
+        TikkaSdkErrorCode.UserRejected,
+        rejectionMessage,
+        err,
+      );
+    }
+    return new TikkaSdkError(
+      TikkaSdkErrorCode.Unknown,
+      `xBull ${op} failed: ${err?.message ?? err}`,
+      err,
+    );
   }
 
   private isUserRejection(err: any): boolean {


### PR DESCRIPTION
Closes #818 
---
# PR Title: feat(sdk): Add connection lifecycle and listener cleanup to XBullAdapter
---
## 🎯 Summary

Adds an explicit connection lifecycle (`connect()` / `disconnect()`) to `XBullAdapter`, a connection guard on wallet-dependent methods, and listener-tracking infrastructure so any event listeners registered during connection are removed on `disconnect()`. This prevents listener leaks in single-page apps where the adapter outlives a single connection, and brings xBull in line with the `WalletNotConnected` guard added to `LobstrAdapter` in #812.

## 📋 Problem

`sdk/src/wallet/xbull.adapter.ts` was stateless and had no teardown path:

- No `disconnect()` and no way to release resources tied to a connection
- No connection guard — `getPublicKey()` / `signTransaction()` could be called at any time with no notion of "connected"
- No mechanism to track or remove `window` event listeners, so any listener added during connection would leak across connect/disconnect cycles in an SPA

> ⚠️ **Note on the original premise:** the issue describes cleaning up `window.addEventListener` calls made during connection. The current adapter registers **no** listeners — it reads the injected `window.xbull` SDK synchronously per call. So there is no *active* leak in today's code. This PR therefore implements the lifecycle + cleanup the issue's intent points at (so the infrastructure is in place and load-bearing the moment connection logic registers a listener), rather than a fix to an existing leak. See "Open questions" below.

## ✨ Solution

A connection lifecycle modelled on the `LobstrAdapter` work from #812:

1. **Internal `connected` flag + cached `address`** — set by `connect()`, cleared by `disconnect()`
2. **`assertConnected()` guard** — wallet-dependent methods throw `WalletNotConnected` before connection
3. **Tracked listeners** — `addTrackedListener()` records every `window` listener in an array; `disconnect()` calls `removeEventListener` for each and empties the array
4. **State reset on disconnect** — `connected` flag and cached `address` cleared

## 🚀 Features

### Core Behavior
- ✅ **`connect()`** — resolves and caches the address, sets the connected flag; idempotent (re-connecting clears existing listeners first, no stacking)
- ✅ **`disconnect()`** — removes all tracked listeners and resets state; safe to call when not connected (no-op)
- ✅ **Connection guard** — `getPublicKey()` / `signTransaction()` throw `WalletNotConnected` before `connect()` or after `disconnect()`
- ✅ **No residual listeners** — `removeEventListener` is called once per `addEventListener`, with matching `(type, handler)` pairs
- ✅ **`isWalletConnected()`** — exposes the cached connection flag
- ✅ **Preserved behavior** — `WalletNotInstalled` when xBull is absent, `UserRejected` for cancel/reject/denied, `Unknown` otherwise; network-passphrase and `accountToSign` handling unchanged

### Technical Details

- `addTrackedListener(type, handler)` wraps `window.addEventListener` and pushes to a `listeners[]` array
- `removeAllListeners()` iterates the array calling `removeEventListener`, then clears it
- `connect()` failure resets state and maps the error (`UserRejected` / `Unknown`)
- Requires `TikkaSdkErrorCode.WalletNotInstalled` and `WalletNotConnected` in `src/utils/errors.ts`

## 🧪 Tests

`src/wallet/xbull.adapter.spec.ts` — 32 tests passing. Added on top of the existing coverage:

- **Listener cleanup** (the #818 acceptance test): `jest.spyOn(window, 'addEventListener' / 'removeEventListener')`, connect → disconnect, asserts removal count matches add count and every `(type, handler)` pair is removed
- `connect()` — connected flag set, idempotency, `WalletNotInstalled` when absent, `UserRejected` leaves adapter disconnected
- `disconnect()` — resets flag, safe when not connected
- Connection guard — `getPublicKey` / `signTransaction` before connect and after disconnect throw `WalletNotConnected`, underlying SDK never called
- All prior happy-path / error-mapping / capability tests retained (connect first where needed)

## ⚠️ Open questions / out of scope

- **Is the listener tracking load-bearing?** As shipped, nothing calls `addTrackedListener` because the current SDK usage registers no listeners, so the cleanup test asserts `0 === 0`. If xBull is expected to grow event-based connection logic (e.g. its `postMessage` bridge), this infrastructure becomes active. If the stateless model is intended, the listener array could be dropped and this PR reframed as "add connection lifecycle + guard." Would like a steer before merge.
- **Cross-adapter consistency** (#812): Freighter, Albedo, and Rabet still lack this lifecycle. If the `connect`/`disconnect`/guard pattern should be shared, it likely belongs in the base `WalletAdapter` rather than copied per adapter. Flagging for a separate decision.