### PR TITLE
feat(oracle): add admin cost-estimate endpoint

### DIFF
--- a/oracle/src/admin/admin-api-key.guard.ts
+++ b/oracle/src/admin/admin-api-key.guard.ts
@@ -1,0 +1,53 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  Logger,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { timingSafeEqual } from 'crypto';
+
+/**
+ * Guards admin HTTP endpoints with a shared API key.
+ *
+ * The expected key is read from the `ORACLE_ADMIN_API_KEY` config value and the
+ * caller must supply it via the `x-api-key` request header. Comparison is
+ * constant-time to avoid leaking the key through timing.
+ */
+@Injectable()
+export class AdminApiKeyGuard implements CanActivate {
+  private readonly logger = new Logger(AdminApiKeyGuard.name);
+
+  constructor(private readonly configService: ConfigService) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const expectedKey = this.configService.get<string>('ORACLE_ADMIN_API_KEY');
+
+    if (!expectedKey) {
+      this.logger.error(
+        'ORACLE_ADMIN_API_KEY is not configured; rejecting admin request',
+      );
+      throw new UnauthorizedException('Admin API is not configured');
+    }
+
+    const request = context.switchToHttp().getRequest();
+    const header = request?.headers?.['x-api-key'];
+    const provided = Array.isArray(header) ? header[0] : header;
+
+    if (!provided || !this.safeEqual(provided, expectedKey)) {
+      throw new UnauthorizedException('Invalid admin API key');
+    }
+
+    return true;
+  }
+
+  private safeEqual(a: string, b: string): boolean {
+    const bufA = Buffer.from(a);
+    const bufB = Buffer.from(b);
+    if (bufA.length !== bufB.length) {
+      return false;
+    }
+    return timingSafeEqual(bufA, bufB);
+  }
+}

--- a/oracle/src/admin/admin.controller.spec.ts
+++ b/oracle/src/admin/admin.controller.spec.ts
@@ -1,0 +1,153 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import {
+  CostEstimatorService,
+  SubmissionCostEstimate,
+} from '../submitter/cost-estimator.service';
+import { AdminController } from './admin.controller';
+import { AdminApiKeyGuard } from './admin-api-key.guard';
+
+describe('AdminController', () => {
+  let controller: AdminController;
+  let costEstimator: jest.Mocked<Pick<CostEstimatorService, 'estimateSubmissionCost'>>;
+  let nowSpy: jest.SpyInstance<number, []>;
+  let currentTime: number;
+
+  const sampleEstimate: SubmissionCostEstimate = {
+    estimatedFeeXlm: '0.0000950',
+    baseFee: 100,
+    feeMultiplier: 9.5,
+    surgeMultiplier: 9.5,
+  };
+
+  beforeEach(async () => {
+    const mockCostEstimator = {
+      estimateSubmissionCost: jest.fn().mockResolvedValue(sampleEstimate),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AdminController],
+      providers: [
+        {
+          provide: CostEstimatorService,
+          useValue: mockCostEstimator,
+        },
+      ],
+    })
+      // The guard is exercised in its own suite below.
+      .overrideGuard(AdminApiKeyGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    controller = module.get<AdminController>(AdminController);
+    costEstimator = module.get(CostEstimatorService);
+
+    // Control the clock so cache TTL behaviour is deterministic.
+    currentTime = 1_000_000;
+    nowSpy = jest.spyOn(Date, 'now').mockImplementation(() => currentTime);
+  });
+
+  afterEach(() => {
+    nowSpy.mockRestore();
+    jest.clearAllMocks();
+  });
+
+  describe('GET /admin/cost-estimate', () => {
+    it('returns the cost breakdown in XLM', async () => {
+      const result = await controller.getCostEstimate();
+
+      expect(result).toEqual({
+        estimatedFeeXlm: '0.0000950',
+        baseFee: 100,
+        feeMultiplier: 9.5,
+        surgeMultiplier: 9.5,
+      });
+      expect(costEstimator.estimateSubmissionCost).toHaveBeenCalledTimes(1);
+    });
+
+    it('serves a cached response within 30 seconds of the first call', async () => {
+      const first = await controller.getCostEstimate();
+
+      // Advance 29.999s — still inside the cache window.
+      currentTime += 29_999;
+      const second = await controller.getCostEstimate();
+
+      expect(second).toEqual(first);
+      // The underlying service is only consulted once.
+      expect(costEstimator.estimateSubmissionCost).toHaveBeenCalledTimes(1);
+    });
+
+    it('recomputes the estimate once the 30 second cache expires', async () => {
+      await controller.getCostEstimate();
+
+      // Advance just past the 30s TTL.
+      currentTime += 30_001;
+      await controller.getCostEstimate();
+
+      expect(costEstimator.estimateSubmissionCost).toHaveBeenCalledTimes(2);
+    });
+
+    it('reflects refreshed values after the cache expires', async () => {
+      const refreshed: SubmissionCostEstimate = {
+        estimatedFeeXlm: '0.0002000',
+        baseFee: 100,
+        feeMultiplier: 20,
+        surgeMultiplier: 20,
+      };
+      costEstimator.estimateSubmissionCost
+        .mockResolvedValueOnce(sampleEstimate)
+        .mockResolvedValueOnce(refreshed);
+
+      const first = await controller.getCostEstimate();
+      currentTime += 30_001;
+      const second = await controller.getCostEstimate();
+
+      expect(first).toEqual(sampleEstimate);
+      expect(second).toEqual(refreshed);
+    });
+  });
+});
+
+describe('AdminApiKeyGuard', () => {
+  const buildGuard = (expectedKey?: string) => {
+    const configService = {
+      get: jest.fn((key: string) =>
+        key === 'ORACLE_ADMIN_API_KEY' ? expectedKey : undefined,
+      ),
+    } as unknown as ConfigService;
+    return new AdminApiKeyGuard(configService);
+  };
+
+  const contextWithHeader = (headers: Record<string, unknown>) =>
+    ({
+      switchToHttp: () => ({ getRequest: () => ({ headers }) }),
+    }) as any;
+
+  it('allows requests with the correct API key', () => {
+    const guard = buildGuard('secret-key');
+    expect(
+      guard.canActivate(contextWithHeader({ 'x-api-key': 'secret-key' })),
+    ).toBe(true);
+  });
+
+  it('rejects requests with an incorrect API key', () => {
+    const guard = buildGuard('secret-key');
+    expect(() =>
+      guard.canActivate(contextWithHeader({ 'x-api-key': 'wrong-key' })),
+    ).toThrow('Invalid admin API key');
+  });
+
+  it('rejects requests missing the API key header', () => {
+    const guard = buildGuard('secret-key');
+    expect(() => guard.canActivate(contextWithHeader({}))).toThrow(
+      'Invalid admin API key',
+    );
+  });
+
+  it('rejects all requests when no admin key is configured', () => {
+    const guard = buildGuard(undefined);
+    expect(() =>
+      guard.canActivate(contextWithHeader({ 'x-api-key': 'anything' })),
+    ).toThrow('Admin API is not configured');
+  });
+});

--- a/oracle/src/admin/admin.controller.ts
+++ b/oracle/src/admin/admin.controller.ts
@@ -1,0 +1,46 @@
+import { Controller, Get, Logger, UseGuards } from '@nestjs/common';
+import {
+  CostEstimatorService,
+  SubmissionCostEstimate,
+} from '../submitter/cost-estimator.service';
+import { AdminApiKeyGuard } from './admin-api-key.guard';
+
+/**
+ * Admin-only HTTP endpoints for oracle operators.
+ * Protected by the shared admin API key (see {@link AdminApiKeyGuard}).
+ */
+@Controller('admin')
+@UseGuards(AdminApiKeyGuard)
+export class AdminController {
+  private readonly logger = new Logger(AdminController.name);
+
+  /** Fee estimates change slowly, so the breakdown is cached briefly. */
+  private readonly CACHE_TTL_MS = 30_000;
+  private cached: { value: SubmissionCostEstimate; expiresAt: number } | null =
+    null;
+
+  constructor(private readonly costEstimator: CostEstimatorService) {}
+
+  /**
+   * Returns the estimated cost of submitting a single randomness transaction.
+   * The response is cached for {@link CACHE_TTL_MS} to limit RPC load.
+   */
+  @Get('cost-estimate')
+  async getCostEstimate(): Promise<SubmissionCostEstimate> {
+    const now = Date.now();
+
+    if (this.cached && this.cached.expiresAt > now) {
+      return this.cached.value;
+    }
+
+    const estimate = await this.costEstimator.estimateSubmissionCost();
+    this.cached = { value: estimate, expiresAt: now + this.CACHE_TTL_MS };
+    this.logger.debug(
+      `Computed cost estimate: ${estimate.estimatedFeeXlm} XLM ` +
+        `(base ${estimate.baseFee}, fee x${estimate.feeMultiplier}, ` +
+        `surge x${estimate.surgeMultiplier})`,
+    );
+
+    return estimate;
+  }
+}

--- a/oracle/src/admin/admin.module.ts
+++ b/oracle/src/admin/admin.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { MetricsModule } from '../metrics/metrics.module';
+import { CostEstimatorService } from '../submitter/cost-estimator.service';
+import { FeeEstimatorService } from '../submitter/fee-estimator.service';
+import { AdminController } from './admin.controller';
+import { AdminApiKeyGuard } from './admin-api-key.guard';
+
+@Module({
+  imports: [MetricsModule],
+  controllers: [AdminController],
+  providers: [AdminApiKeyGuard, CostEstimatorService, FeeEstimatorService],
+})
+export class AdminModule {}

--- a/oracle/src/app.module.ts
+++ b/oracle/src/app.module.ts
@@ -9,6 +9,7 @@ import { MultiOracleModule } from './multi-oracle/multi-oracle.module';
 import { RescueModule } from './rescue/rescue.module';
 import { AuditLogModule } from './audit/audit.module';
 import { MetricsModule } from './metrics/metrics.module';
+import { AdminModule } from './admin/admin.module';
 
 @Module({
   imports: [
@@ -22,6 +23,7 @@ import { MetricsModule } from './metrics/metrics.module';
     RescueModule,
     AuditLogModule,
     MetricsModule,
+    AdminModule,
   ],
   controllers: [],
   providers: [],

--- a/oracle/src/submitter/cost-estimator.service.ts
+++ b/oracle/src/submitter/cost-estimator.service.ts
@@ -48,6 +48,21 @@ export interface ActualCostMetrics {
   periodEnd: Date;
 }
 
+/**
+ * Per-submission cost breakdown for a single randomness transaction.
+ * Exposed to operators (e.g. via the admin API) for funding planning.
+ */
+export interface SubmissionCostEstimate {
+  /** Estimated fee for one submission, in XLM (string to preserve precision) */
+  estimatedFeeXlm: string;
+  /** Network base fee in stroops */
+  baseFee: number;
+  /** Effective multiplier applied to the base fee after capping */
+  feeMultiplier: number;
+  /** Network congestion surge: how much the priority fee exceeds the base fee */
+  surgeMultiplier: number;
+}
+
 export interface CostAlert {
   type: 'COST_EXCEEDED' | 'HIGH_FEE_DETECTED' | 'BUDGET_WARNING' | 'SUBMISSION_FAILED';
   message: string;
@@ -165,6 +180,39 @@ export class CostEstimatorService {
     this.metricsService.recordEstimatedFee(avgCostPerReveal, this.network, 'average');
     
     return estimate;
+  }
+
+  /**
+   * Estimates the cost of submitting a single randomness transaction.
+   * Derives a per-submission breakdown from the current network fee stats,
+   * suitable for operator funding planning via the admin API.
+   *
+   * @param rafflePrizeXLM - Optional prize value used to select the fee cap tier
+   * @returns Cost breakdown with the estimated fee expressed in XLM
+   */
+  async estimateSubmissionCost(
+    rafflePrizeXLM?: number,
+  ): Promise<SubmissionCostEstimate> {
+    const fee = await this.feeEstimator.estimateFee(rafflePrizeXLM);
+
+    const baseFee = fee.baseFee;
+    // Surge: how much the network's priority (p95) fee exceeds the base fee.
+    const surgeMultiplier =
+      baseFee > 0 ? this.round(fee.priorityFee / baseFee, 2) : 1;
+    // Effective multiplier applied to the base fee once the cap is enforced.
+    const feeMultiplier =
+      baseFee > 0 ? this.round(fee.cappedFee / baseFee, 2) : 1;
+    const estimatedFeeXlm = (fee.cappedFee / this.STROOPS_PER_XLM).toFixed(7);
+
+    return { estimatedFeeXlm, baseFee, feeMultiplier, surgeMultiplier };
+  }
+
+  /**
+   * Rounds a number to the given number of decimal places.
+   */
+  private round(value: number, decimals: number): number {
+    const factor = 10 ** decimals;
+    return Math.round(value * factor) / factor;
   }
 
   /**


### PR DESCRIPTION
## Summary

Adds GET /admin/cost-estimate to the oracle's HTTP API so operators can plan oracle funding without reading logs or metrics. The endpoint returns a per-submission cost breakdown in XLM, derived from the current network fee stats.

Closes #848.

## What changed

- *CostEstimatorService.estimateSubmissionCost()* — new method that builds a single-submission breakdown on top of FeeEstimatorService.estimateFee():
  - estimatedFeeXlm — capped fee converted to XLM (string, to preserve precision)
  - baseFee — network base fee in stroops
  - feeMultiplier — effective multiplier applied to base after capping (cappedFee / baseFee)
  - surgeMultiplier — network congestion surge (priorityFee / baseFee)
- *AdminController* (GET /admin/cost-estimate) — guarded admin route with a 30s in-memory cache (fee estimates change slowly, so this limits RPC load).
- *AdminApiKeyGuard* — validates the x-api-key header against ORACLE_ADMIN_API_KEY using a constant-time compare; rejects missing/wrong keys and refuses to serve when no key is configured.
- *AdminModule* wired into AppModule.

## Testing

oracle/src/admin/admin.controller.spec.ts — unit tests using a *mock CostEstimatorService*, covering:
- response returns the XLM cost breakdown
- a cached response is served within 30s (service consulted once)
- the estimate is recomputed once the 30s TTL expires, reflecting refreshed values
- guard suite: accepts correct key, rejects wrong/missing key, and fails closed when unconfigured

All 8 tests pass; new files typecheck cleanly.

## Config

Set ORACLE_ADMIN_API_KEY in the oracle environment; callers pass it via the x-api-key header.

## Note for reviewers

Two *pre-existing* files are syntactically broken and unrelated to this change but will block a full app build until fixed: oracle/src/health/health.controller.ts (missing closing brace on getComponentHealth) and oracle/src/queue/queue-health.controller.ts (invalid function method syntax). This PR's files are isolated from them (ts-jest compiles per-file), but they should be addressed separately.