### PR TITLE
Fix TruffleHog base/head refs so push-to-master scans actual diff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,8 +258,8 @@ jobs:
         uses: trufflesecurity/trufflehog@main
         with:
           path: ./
-          base: ${{ github.event.repository.default_branch }}
-          head: HEAD
+          base: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          head: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.event.after }}
           extra_args: >-
             --only-verified
             --exclude-paths .trufflehog-exclude


### PR DESCRIPTION
# Fix TruffleHog base/head refs so push-to-master scans actual diff

## What

Fixes the `base`/`head` inputs passed to the TruffleHog action in `security-scan` so the scan actually diffs the right commits on both trigger types.

## Why

The previous config:
```yaml
base: ${{ github.event.repository.default_branch }}
head: HEAD
```

worked for `pull_request` events, but broke on `push` to `master`: `base` resolved to `master`'s current tip, which *is* the commit that was just pushed — identical to `head`. TruffleHog ended up diffing a commit against itself, so the push-to-`master` scan silently found nothing on every run, regardless of what was actually pushed.

## Fix

```yaml
base: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
head: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.event.after }}
```

- **PR events** → diffs the PR's actual base SHA against its head SHA (unchanged behavior).
- **Push events** → diffs `github.event.before` (commit prior to push) against `github.event.after` (commit after push), so it scans exactly what changed in that push.

## Related

Follow-up on #930.

## Testing

- [ ] Confirm `security-scan` still passes on this PR (validates the `pull_request` branch of the logic).
- [ ] After merge, push a trivial commit to `master` directly and confirm the Action run's logs show a non-identical base/head diff (validates the `push` branch of the logic).

Closes #930