### PR TITLE
Implement lifecycle validation before ticket purchase (#929)

### DIFF
--- a/sdk/src/contract/bindings.ts
+++ b/sdk/src/contract/bindings.ts
@@ -22,6 +22,7 @@ export const ContractFn = {
   RECEIVE_RANDOMNESS: 'receive_randomness',
   CANCEL_RAFFLE: 'cancel_raffle',
   REFUND_TICKET: 'refund_ticket',
+  CLAIM_PRIZE: 'claim_prize',
 
   // Queries
   GET_RAFFLE_DATA: 'get_raffle_data',

--- a/sdk/src/modules/admin/admin.service.ts
+++ b/sdk/src/modules/admin/admin.service.ts
@@ -185,7 +185,7 @@ export class AdminService {
     );
     validateLifecycleTransition(
       ContractFn.TRIGGER_DRAW,
-      stateResp.value?.status ?? stateResp.value ?? -1,
+      stateResp.value?.status ?? -1,
       raffleId,
     );
     return this.contract.invoke<void>(ContractFn.TRIGGER_DRAW, [raffleId], { memo: options.memo });

--- a/sdk/src/modules/ticket/lifecycle-validation.spec.ts
+++ b/sdk/src/modules/ticket/lifecycle-validation.spec.ts
@@ -3,8 +3,8 @@
  * Issue: #929
  *
  * Covers:
- *  1. buyTickets on DRAWING raffle throws RaffleEnded without submitting
- *  2. buyTickets on OPEN raffle proceeds normally
+ *  1. buy() on DRAWING raffle throws RaffleEnded without submitting
+ *  2. buy() on OPEN raffle proceeds normally
  *  3. finalizeRaffle on DRAWING raffle throws RaffleEnded
  *  4. finalizeRaffle on OPEN raffle proceeds normally
  *  5. cancelRaffle on FINALIZED raffle throws RaffleEnded
@@ -24,6 +24,10 @@ import { BuyTicketParams } from '../ticket/ticket.types';
 const RAFFLE_ID = 42;
 const PUBLIC_KEY = 'GABC1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ234567890ABCDEF';
 
+function makeParams(): BuyTicketParams {
+  return { raffleId: RAFFLE_ID, quantity: 1 };
+}
+
 function makeContractService(stateValue: number) {
   const mockWallet = { getPublicKey: jest.fn().mockResolvedValue(PUBLIC_KEY) };
   const cs = {
@@ -35,9 +39,11 @@ function makeContractService(stateValue: number) {
       feePaid: '100',
     }),
     simulateReadOnly: jest.fn().mockResolvedValue({
+      success: true,
       status: 'SUCCESS',
-      value: { status: stateValue },
+      value: { status: stateValue, creator: PUBLIC_KEY },
     }),
+    getPublicKey: jest.fn().mockResolvedValue(PUBLIC_KEY),
     wallet: mockWallet,
   } as unknown as jest.Mocked<ContractService>;
   return cs;
@@ -47,7 +53,7 @@ function makeContractService(stateValue: number) {
 
 describe('TicketService.buy() — lifecycle validation', () => {
   it('throws RaffleEnded when raffle is DRAWING', async () => {
-    const params: BuyTicketParams = {};
+    const params = makeParams();
     const cs = makeContractService(RaffleStatus.Drawing);
     const service = new TicketService(cs);
 
@@ -59,6 +65,7 @@ describe('TicketService.buy() — lifecycle validation', () => {
   });
 
   it('throws RaffleEnded when raffle is FINALIZED', async () => {
+    const params = makeParams();
     const cs = makeContractService(RaffleStatus.Finalized);
     const service = new TicketService(cs);
 
@@ -69,6 +76,7 @@ describe('TicketService.buy() — lifecycle validation', () => {
   });
 
   it('throws RaffleEnded when raffle is CANCELLED', async () => {
+    const params = makeParams();
     const cs = makeContractService(RaffleStatus.Cancelled);
     const service = new TicketService(cs);
 
@@ -79,6 +87,7 @@ describe('TicketService.buy() — lifecycle validation', () => {
   });
 
   it('proceeds and calls invoke when raffle is OPEN', async () => {
+    const params = makeParams();
     const cs = makeContractService(RaffleStatus.Open);
     const service = new TicketService(cs);
 
@@ -93,6 +102,7 @@ describe('TicketService.buy() — lifecycle validation', () => {
   });
 
   it('fetches state before any RPC transaction call', async () => {
+    const params = makeParams();
     const cs = makeContractService(RaffleStatus.Open);
     const callOrder: string[] = [];
     cs.simulateReadOnly.mockImplementation(async () => {
@@ -171,22 +181,22 @@ describe('validateLifecycleTransition', () => {
     ).toThrow(TikkaSdkError);
     expect(() =>
       validateLifecycleTransition('buy_ticket', RaffleStatus.Drawing, RAFFLE_ID)
-    ).toThrowError(expect.objectContaining({ code: TikkaSdkErrorCode.RaffleEnded }));
+    ).toThrow(expect.objectContaining({ code: TikkaSdkErrorCode.RaffleEnded }));
   });
 
   it('throws RaffleEnded for buy_ticket on FINALIZED state', () => {
     expect(() =>
       validateLifecycleTransition('buy_ticket', RaffleStatus.Finalized, RAFFLE_ID)
-    ).toThrowError(expect.objectContaining({ code: TikkaSdkErrorCode.RaffleEnded }));
+    ).toThrow(expect.objectContaining({ code: TikkaSdkErrorCode.RaffleEnded }));
   });
 
   it('throws RaffleEnded for buy_ticket on CANCELLED state', () => {
     expect(() =>
       validateLifecycleTransition('buy_ticket', RaffleStatus.Cancelled, RAFFLE_ID)
-    ).toThrowError(expect.objectContaining({ code: TikkaSdkErrorCode.RaffleEnded }));
+    ).toThrow(expect.objectContaining({ code: TikkaSdkErrorCode.RaffleEnded }));
   });
 
-  it('does NOTate', () => {
+  it('does NOT throw for buy_ticket on OPEN state', () => {
     expect(() =>
       validateLifecycleTransition('buy_ticket', RaffleStatus.Open, RAFFLE_ID)
     ).not.toThrow();

--- a/sdk/src/modules/ticket/ticket.service.spec.ts
+++ b/sdk/src/modules/ticket/ticket.service.spec.ts
@@ -3,6 +3,7 @@ import { ContractService } from '../../contract/contract.service';
 import { ContractFn } from '../../contract/bindings';
 import { BuyTicketParams, RefundTicketParams, BuyBatchParams, BuyTicketsParams, TICKET_CONSTRAINTS } from './ticket.types';
 import { TikkaSdkError, TikkaSdkErrorCode } from '../../utils/errors';
+import { RaffleStatus } from '../../contract/bindings';
 
 describe('TicketService', () => {
   let service: TicketService;
@@ -16,7 +17,10 @@ describe('TicketService', () => {
 
     contractService = {
       invoke: jest.fn(),
-      simulateReadOnly: jest.fn(),
+      simulateReadOnly: jest.fn().mockResolvedValue({
+        success: true,
+        value: { status: RaffleStatus.Open },
+      }),
       wallet: mockWallet,
     } as any;
 

--- a/sdk/src/modules/ticket/ticket.service.ts
+++ b/sdk/src/modules/ticket/ticket.service.ts
@@ -12,12 +12,12 @@ import {
   BatchPurchaseResult,
   TICKET_CONSTRAINTS,
   BuyTicketResult,
-  RefundTicketResult,
-  BuyBatchResult,
+  ClaimPrizeParams,
+  ClaimPrizeResult,
 } from './ticket.types';
 import { ContractResponse } from '../../contract/response';
 import { assertPositiveInt } from '../../utils/validation';
-import { TikkaSdkError, TikkaSdkErrorCode } from '../../utils/errors';
+import { TikkaSdkError, TikkaSdkErrorCode, toTypedSdkError } from '../../utils/errors';
 import { validateLifecycleTransition } from '../../contract/lifecycle';
 
 @Injectable()
@@ -85,14 +85,35 @@ export class TicketService {
   }
 
   /**
+   * Fetches current raffle state and throws RaffleEnded if the given
+   * operation is not permitted in that state. Called before any
+   * simulation/submission so invalid purchases never reach the network.
+   */
+  private async assertRaffleOpenFor(
+    operation: string,
+    raffleId: number,
+  ): Promise<void> {
+    const stateResp = await this.contractService.simulateReadOnly<{ status: number } | number>(
+      ContractFn.GET_RAFFLE_STATE,
+      [raffleId],
+    );
+    const currentStatus =
+      (stateResp.value as any)?.status ?? (stateResp.value as any) ?? -1;
+    validateLifecycleTransition(operation, currentStatus as number, raffleId);
+  }
+
+  /**
    * Purchases tickets for a raffle.
    * Requires wallet signature and submission.
+   *
+   * Validates the raffle is in OPEN state before simulating/submitting —
+   * see issue #929.
    *
    * Token transfer failures (e.g. malicious SEP-41 token rejecting the call)
    * are surfaced as `ExternalContractError` so callers can handle them
    * separately from generic network/contract errors.
    *
-   * @throws TikkaSdkError if validation fails or submission is duplicate
+   * @throws TikkaSdkError if validation fails, raffle is not OPEN, or submission is duplicate
    */
   async buy(
     params: BuyTicketParams,
@@ -100,6 +121,9 @@ export class TicketService {
     const { raffleId, quantity } = params;
     assertPositiveInt(raffleId, "raffleId");
     this.validateQuantity(quantity);
+
+    // Fetch current raffle state and validate before simulating/submitting.
+    await this.assertRaffleOpenFor(ContractFn.BUY_TICKET, raffleId);
 
     const publicKey = await this.contractService["wallet"]?.getPublicKey();
     if (!publicKey) {
@@ -151,12 +175,18 @@ export class TicketService {
    * Purchases multiple tickets for a raffle in a single transaction.
    * Uses the batch purchase contract entry point.
    *
-   * @throws TikkaSdkError if validation fails or submission is duplicate
+   * Validates the raffle is in OPEN state before simulating/submitting —
+   * see issue #929.
+   *
+   * @throws TikkaSdkError if validation fails, raffle is not OPEN, or submission is duplicate
    */
   async buyTickets(params: BuyTicketsParams): Promise<ContractResponse<BuyTicketResult>> {
     const { raffleId, count, maxPricePerTicket } = params;
     assertPositiveInt(raffleId, 'raffleId');
     this.validateQuantity(count, 'count');
+
+    // Fetch current raffle state and validate before simulating/submitting.
+    await this.assertRaffleOpenFor(ContractFn.BUY_TICKET, raffleId);
 
     const publicKey = await this.contractService['wallet']?.getPublicKey();
     if (!publicKey) {

--- a/sdk/src/utils/errors.ts
+++ b/sdk/src/utils/errors.ts
@@ -36,6 +36,8 @@ export class RpcError extends Error {
 export enum TikkaSdkErrorCode {
  /** Wallet extension installed but not connected/authorized */
   WalletNotConnected = 'WALLET_NOT_CONNECTED',
+  /** No compatible wallet extension is installed in the browser */
+  WalletNotInstalled = 'WALLET_NOT_INSTALLED',
   /** User rejected the transaction / signature request */
   UserRejected = 'UserRejected',
   /** Transaction simulation failed */
@@ -68,6 +70,14 @@ export enum TikkaSdkErrorCode {
   ValidationError = 'ValidationError',
   /** An external/cross-contract call (e.g. SEP-41 token) failed */
   ExternalContractError = 'EXTERNAL_CONTRACT_ERROR',
+  /** Raffle is not in a state that permits the requested operation */
+  RaffleEnded = 'RAFFLE_ENDED',
+  /** Raffle ID does not correspond to an existing raffle */
+  RaffleNotFound = 'RAFFLE_NOT_FOUND',
+  /** Raffle has reached its maximum ticket capacity */
+  RaffleFull = 'RAFFLE_FULL',
+  /** Caller does not have sufficient balance to complete the operation */
+  InsufficientFunds = 'INSUFFICIENT_FUNDS',
 }
 
 /**
@@ -92,7 +102,7 @@ export class TikkaSdkError extends Error {
    */
   static wrap(error: unknown, defaultCode: TikkaSdkErrorCode = TikkaSdkErrorCode.Unknown): TikkaSdkError {
     if (error instanceof TikkaSdkError) return error;
-    
+
     const message = error instanceof Error ? error.message : String(error);
     return new TikkaSdkError(defaultCode, message, error);
   }
@@ -151,4 +161,144 @@ export class ContractFailureError extends TikkaSdkError {
     this.name = 'ContractFailureError';
     Object.setPrototypeOf(this, ContractFailureError.prototype);
   }
+}
+
+// ─── Typed Contract Errors ─────────────────────────────────────────────────
+//
+// These map specific on-chain Soroban contract error codes (panic codes
+// returned by the `tikka-raffle` contract) to typed SDK errors, so callers
+// can `catch (err) { if (err instanceof RaffleEndedError) ... }` instead of
+// string-matching messages.
+
+/**
+ * Contract-level error identifiers.
+ * Values are aliases of the corresponding `TikkaSdkErrorCode` members so
+ * `err.code` comparisons work against either enum interchangeably.
+ */
+export const ContractErrorType = {
+  RAFFLE_NOT_FOUND: TikkaSdkErrorCode.RaffleNotFound,
+  RAFFLE_ENDED: TikkaSdkErrorCode.RaffleEnded,
+  RAFFLE_FULL: TikkaSdkErrorCode.RaffleFull,
+  INSUFFICIENT_FUNDS: TikkaSdkErrorCode.InsufficientFunds,
+  UNAUTHORIZED: TikkaSdkErrorCode.Unauthorized,
+} as const;
+
+/** Thrown when a referenced raffle ID does not exist on-chain. */
+export class RaffleNotFoundError extends TikkaSdkError {
+  constructor(message: string, cause?: unknown) {
+    super(TikkaSdkErrorCode.RaffleNotFound, message, cause);
+    this.name = 'RaffleNotFoundError';
+    Object.setPrototypeOf(this, RaffleNotFoundError.prototype);
+  }
+}
+
+/** Thrown when an operation requires OPEN state but the raffle has moved on. */
+export class RaffleEndedError extends TikkaSdkError {
+  constructor(message: string, cause?: unknown) {
+    super(TikkaSdkErrorCode.RaffleEnded, message, cause);
+    this.name = 'RaffleEndedError';
+    Object.setPrototypeOf(this, RaffleEndedError.prototype);
+  }
+}
+
+/** Thrown when a raffle has sold its maximum number of tickets. */
+export class RaffleFullError extends TikkaSdkError {
+  constructor(message: string, cause?: unknown) {
+    super(TikkaSdkErrorCode.RaffleFull, message, cause);
+    this.name = 'RaffleFullError';
+    Object.setPrototypeOf(this, RaffleFullError.prototype);
+  }
+}
+
+/** Thrown when the caller's balance is insufficient for the operation. */
+export class InsufficientFundsError extends TikkaSdkError {
+  constructor(message: string, cause?: unknown) {
+    super(TikkaSdkErrorCode.InsufficientFunds, message, cause);
+    this.name = 'InsufficientFundsError';
+    Object.setPrototypeOf(this, InsufficientFundsError.prototype);
+  }
+}
+
+/** Thrown when the caller lacks permission for an admin/creator-only action. */
+export class UnauthorizedError extends TikkaSdkError {
+  constructor(message: string, cause?: unknown) {
+    super(TikkaSdkErrorCode.Unauthorized, message, cause);
+    this.name = 'UnauthorizedError';
+    Object.setPrototypeOf(this, UnauthorizedError.prototype);
+  }
+}
+
+/**
+ * Maps a known Soroban contract panic code to its typed error class.
+ * Extend this table as new contract error codes are added.
+ */
+const CONTRACT_ERROR_CODE_MAP: Record<number, new (message: string, cause?: unknown) => TikkaSdkError> = {
+  1: RaffleNotFoundError,
+  3: RaffleFullError,
+  4: InsufficientFundsError,
+  5: UnauthorizedError,
+  35: RaffleEndedError,
+};
+
+/**
+ * Extracts a numeric Soroban contract error code from a raw error string.
+ * Recognizes the common formats surfaced by the Stellar RPC / SDK:
+ *   - "Error(Contract, #35)"
+ *   - "ScError::Contract(4)"
+ *   - "contract error code 5"
+ *
+ * @returns the parsed code, or `undefined` if no recognizable pattern is found.
+ */
+export function parseSorobanContractErrorCode(raw: string | undefined | null): number | undefined {
+  if (!raw) return undefined;
+
+  const patterns = [
+    /Error\(Contract,\s*#(\d+)\)/,
+    /ScError::Contract\((\d+)\)/,
+    /contract error code\s*(\d+)/i,
+  ];
+
+  for (const pattern of patterns) {
+    const match = raw.match(pattern);
+    if (match) return parseInt(match[1], 10);
+  }
+
+  return undefined;
+}
+
+/**
+ * Attempts to convert a raw contract failure (message + raw error/XDR string)
+ * into a typed SDK error based on the embedded Soroban contract error code.
+ *
+ * @param message  Human-readable message to attach to the typed error.
+ * @param rawError Raw error string (e.g. simulation error or resultXdr) to parse.
+ * @returns a typed `TikkaSdkError` subclass instance, or `null` if the code
+ *          is unrecognized (callers should fall back to a generic error).
+ */
+export function toTypedContractError(message: string, rawError: string): TikkaSdkError | null {
+  const code = parseSorobanContractErrorCode(rawError);
+  if (code === undefined) return null;
+
+  const ErrorClass = CONTRACT_ERROR_CODE_MAP[code];
+  if (!ErrorClass) return null;
+
+  return new ErrorClass(message, rawError);
+}
+
+/**
+ * Upgrades a generic caught error into the most specific `TikkaSdkError`
+ * subtype possible. If `err` is already a `TikkaSdkError` with code
+ * `ContractError` and a string `cause` containing a recognizable Soroban
+ * error code, it is converted into the matching typed error. Otherwise the
+ * error is returned unchanged (if already a `TikkaSdkError`) or wrapped.
+ */
+export function toTypedSdkError(err: unknown): TikkaSdkError {
+  if (err instanceof TikkaSdkError) {
+    if (err.code === TikkaSdkErrorCode.ContractError && typeof err.cause === 'string') {
+      const typed = toTypedContractError(err.message, err.cause);
+      if (typed) return typed;
+    }
+    return err;
+  }
+  return TikkaSdkError.wrap(err);
 }


### PR DESCRIPTION
# [sdk] Add contract lifecycle validation before transaction submission

## What

Implements pre-flight raffle state validation for `TicketService.buy()` and `TicketService.buyTickets()` so purchases against a non-OPEN raffle fail fast with `RaffleEnded`, before any simulation or RPC call is made — satisfying the acceptance criteria in #929.

Also fixes a set of pre-existing compile errors in `errors.ts` that were blocking the SDK from building at all. `validateLifecycleTransition()` and `LIFECYCLE_REQUIREMENTS` already existed in `lifecycle.ts`, and `AdminService.finalizeRaffle()` / `cancelRaffle()` already called them — but `TicketService`, the actual subject of #929, never did, and several symbols the codebase already depended on (`TikkaSdkErrorCode.RaffleEnded`, `.WalletNotInstalled`, `toTypedContractError`, `toTypedSdkError`, typed contract error classes) didn't exist yet in `errors.ts`.

## Changes

**`src/utils/errors.ts`**
- Added `RaffleEnded` and `WalletNotInstalled` to `TikkaSdkErrorCode` — referenced in 9+ files (`lifecycle.ts`, `contract.service.ts`, all four wallet adapters) but never defined.
- Added `ContractErrorType` const map, and typed error classes `RaffleNotFoundError`, `RaffleEndedError`, `RaffleFullError`, `InsufficientFundsError`, `UnauthorizedError` — matches the API already expected by `errors.spec.ts`.
- Added `parseSorobanContractErrorCode()` to extract numeric panic codes from raw Soroban error strings (`Error(Contract, #35)`, `ScError::Contract(4)`, `contract error code 5`).
- Added `toTypedContractError(message, rawError)` and `toTypedSdkError(err)` — map known contract panic codes to typed errors; both were imported across the SDK but never exported.

**`src/contract/bindings.ts`**
- Added missing `ContractFn.CLAIM_PRIZE = 'claim_prize'` (referenced in `ticket.service.ts`'s `claimPrize()`, contract fn name should be double-checked against the deployed contract before merge).

**`src/modules/ticket/ticket.service.ts`**
- Fixed duplicate named imports (`RefundTicketResult`, `BuyBatchResult` were each imported twice — compile error).
- Imported the already-defined-but-unused `ClaimPrizeParams`, `ClaimPrizeResult`, and `toTypedSdkError`.
- Added `assertRaffleOpenFor(operation, raffleId)` — fetches raffle state via `simulateReadOnly(GET_RAFFLE_STATE)` and calls `validateLifecycleTransition`. Called at the top of `buy()` and `buyTickets()`, before wallet lookup or duplicate-submission checks, so the whole call short-circuits on a closed raffle.

**`src/modules/admin/admin.service.ts`**
- One-line fix in `finalizeRaffle()`: removed a redundant/incorrectly-typed fallback (`?? stateResp.value`) in the state-narrowing expression that was blocking compilation for any file importing `AdminService`.

**`src/modules/ticket/lifecycle-validation.spec.ts`** (test file for this issue, pre-existed but didn't run)
- Fixed `params` being declared inside one `it()` and referenced in sibling `it()` blocks (out of scope).
- Fixed `BuyTicketParams = {}` fixture missing required `raffleId`/`quantity`.
- Replaced `toThrowError` (unsupported by this Jest matcher version) with `toThrow`.
- Fixed `AdminService.cancelRaffle()` test mocks — missing `success: true`, `creator`, and `getPublicKey` fields were causing the FINALIZED-state test to false-pass (bailed out on an unrelated early-exit guard) and the OPEN-state test to never reach `invoke()`.

**`src/modules/ticket/ticket.service.spec.ts`**
- Gave the `simulateReadOnly` mock a default OPEN-state return value in `beforeEach`, since existing `buy()`/`buyTickets()` tests predate the new state check and previously left it unmocked (resolved to `undefined`, causing a `TypeError` once the check was added). Tests that need a different mocked response (`getUserTickets`, `buyBatch`) already override it locally and are unaffected.

## Explicitly out of scope (pre-existing, unrelated to #929)

Left untouched per discussion — separate issues:
- `src/modules/user/user.read.service.ts:67` — unsound type cast (`ContractResponse<UserParticipation>` → `ContractResponse<number[]>`).
- `src/modules/user/user.service.ts:240` — bare `Promise` missing a type argument.
- `src/modules/admin/admin.service.spec.ts`, `src/contract/contract.service.spec.ts` — both reference `TikkaSdkError` in assertions without importing it; fails independently of this PR's changes.
- `src/cli.spec.ts` and a handful of other suites fail on `pnpm test` for reasons unrelated to lifecycle validation (CLI exit codes, RPC integration, etc.) — pre-existing.

## Testing

```bash
pnpm run build          # 2 pre-existing errors remain (user.read.service.ts, user.service.ts) — nothing new
pnpm test -- lifecycle-validation.spec.ts   # 15/15 passing
pnpm test -- ticket.service.spec.ts          # 22/22 passing, no regressions
pnpm test -- lifecycle.spec.ts               # 48/48 passing, unaffected
pnpm test -- errors.spec.ts                  # passing
```

- [x] `buy()` throws `RaffleEnded` on DRAWING / FINALIZED / CANCELLED without calling `invoke()`
- [x] `buy()` proceeds normally on OPEN
- [x] `buyTickets()` covered by the same check
- [x] State is fetched before any simulate/submit call (`fetches state before any RPC transaction call` test)
- [x] `AdminService.finalizeRaffle()` / `cancelRaffle()` — pre-existing validation confirmed still correct, tests were previously silently failing to run due to compile errors and a mock gap

## Related

Closes #929.