### PR TITLE
fix(sdk): add named RPC retry constants and transient-failure recover…

### DIFF
--- a/sdk/src/network/network.config.ts
+++ b/sdk/src/network/network.config.ts
@@ -44,13 +44,16 @@ export interface RpcConfig {
   circuitBreakerResetTimeoutMs?: number;
 }
 
+export const SOROBAN_RPC_MAX_RETRIES = 3;
+export const SOROBAN_RPC_BASE_DELAY_MS = 300;
+
 export const DEFAULT_RPC_CONFIG: RpcConfig = {
   headers: {},
   failoverEndpoints: [],
   timeoutMs: 30_000,
   enableRetries: true,
-  maxRetryAttempts: 3,
-  retryBaseDelayMs: 300,
+  maxRetryAttempts: SOROBAN_RPC_MAX_RETRIES,
+  retryBaseDelayMs: SOROBAN_RPC_BASE_DELAY_MS,
   retryBackoffFactor: 2,
   retryableStatusCodes: [429, 500, 502, 503, 504, 'RATE_LIMIT', 'UNAVAILABLE', 'TIMEOUT', 'ECONNRESET'],
   circuitBreakerFailureThreshold: 5,

--- a/sdk/src/network/rpc.service.spec.ts
+++ b/sdk/src/network/rpc.service.spec.ts
@@ -8,7 +8,7 @@ import {
   InvalidResponseError,
   ContractFailureError,
 } from '../utils/errors';
-import { NetworkConfig, TikkaNetwork } from './network.config';
+import { NetworkConfig, TikkaNetwork, SOROBAN_RPC_MAX_RETRIES, SOROBAN_RPC_BASE_DELAY_MS } from './network.config';
 import { Networks } from '@stellar/stellar-sdk';
 
 describe('RpcService', () => {
@@ -232,6 +232,37 @@ describe('RpcService', () => {
       const mockTx = { toXDR: () => 'mock-xdr' };
       await expect(service.simulateTransaction(mockTx)).rejects.toThrow(UnavailableError);
       expect(mockFetch).toHaveBeenCalledTimes(3);
+    });
+
+    it('should succeed after exactly 2 transient 503 failures using SOROBAN_RPC_MAX_RETRIES attempts', async () => {
+      const mockResult = { status: 'ok-after-two-failures' };
+      const mockFetch = jest.fn()
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 503,
+          statusText: 'Service Unavailable',
+        })
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 503,
+          statusText: 'Service Unavailable',
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: jest.fn().mockResolvedValue({ result: mockResult }),
+        });
+
+      service.configure({
+        fetchClient: mockFetch as any,
+        maxRetryAttempts: SOROBAN_RPC_MAX_RETRIES,
+        retryBaseDelayMs: 1,
+      });
+
+      const mockTx = { toXDR: () => 'mock-xdr' };
+      const result = await service.simulateTransaction(mockTx);
+
+      expect(result).toEqual(mockResult);
+      expect(mockFetch).toHaveBeenCalledTimes(SOROBAN_RPC_MAX_RETRIES);
     });
 
     it('should fail immediately without retrying on non-retryable errors (e.g. invalid response status 400)', async () => {


### PR DESCRIPTION
…y test

Export SOROBAN_RPC_MAX_RETRIES and SOROBAN_RPC_BASE_DELAY_MS from network.config.ts and wire them into DEFAULT_RPC_CONFIG so callsites can reference the canonical values. Add a test asserting that two consecutive 503 responses are retried and the third (success) response is returned, covering the core transient-failure recovery path.