### PR TITLE
feat(storage): document bucket lifecycle and add orphan cleanup script

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -13,7 +13,8 @@
     "test:e2e": "jest --config ./test/jest-e2e.json",
     "generate:openapi": "ts-node scripts/generate-openapi.ts",
     "validate:openapi": "pnpm run generate:openapi && npx swagger-cli validate openapi.json",
-    "migrations:check": "ts-node scripts/check-migrations.ts"
+    "migrations:check": "ts-node scripts/check-migrations.ts",
+    "storage:cleanup-orphans": "ts-node scripts/cleanup-orphan-images.ts"
   },
   "dependencies": {
     "@fastify/helmet": "^13.0.2",

--- a/backend/scripts/cleanup-orphan-images.ts
+++ b/backend/scripts/cleanup-orphan-images.ts
@@ -1,0 +1,322 @@
+/**
+ * Orphan raffle-image cleanup.
+ *
+ * Lists objects in the Supabase `raffle-images` bucket that are NOT referenced
+ * by any row in the `raffle_metadata` table (image_url / image_urls). These are
+ * "orphans" — typically left behind by abandoned uploads (image uploaded but the
+ * raffle was never created) or hard-deleted raffles.
+ *
+ * SAFETY: this script is dry-run by default. It prints what it *would* delete and
+ * deletes NOTHING unless you pass --delete. A grace window (default 24h) also
+ * excludes freshly-created objects so an upload that has not yet been referenced
+ * by its metadata row is never mistaken for an orphan.
+ *
+ * Usage:
+ *   ts-node scripts/cleanup-orphan-images.ts [options]
+ *
+ * Options:
+ *   --delete             Actually delete the orphans. Omit for a dry run (default).
+ *   --grace-hours <n>    Ignore objects created within the last <n> hours (default 24).
+ *   --limit <n>          Cap the number of objects deleted in one run (safety valve).
+ *   --json               Emit a machine-readable JSON report to stdout.
+ *   --help               Show this help.
+ *
+ * Environment:
+ *   SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY   (required)
+ *
+ * Exit codes:
+ *   0 — completed (dry run, or delete succeeded)
+ *   1 — missing env / bad args / unexpected error
+ *
+ * See docs/storage/README.md for the bucket layout and retention policy.
+ */
+
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { RAFFLE_IMAGE_BUCKET } from '../src/config/upload.config';
+
+const METADATA_TABLE = 'raffle_metadata';
+const LIST_PAGE_SIZE = 100;
+const DELETE_BATCH_SIZE = 100;
+const DEFAULT_GRACE_HOURS = 24;
+
+interface Options {
+  delete: boolean;
+  graceHours: number;
+  limit: number | null;
+  json: boolean;
+}
+
+interface StorageObject {
+  /** Full path within the bucket, e.g. "42/uploader/uuid.webp" */
+  path: string;
+  createdAt: string | null;
+}
+
+function parseOptions(argv: string[]): Options {
+  if (argv.includes('--help') || argv.includes('-h')) {
+    printHelp();
+    process.exit(0);
+  }
+
+  const numericFlag = (flag: string, fallback: number | null): number | null => {
+    const idx = argv.indexOf(flag);
+    if (idx === -1) return fallback;
+    const raw = argv[idx + 1];
+    const parsed = Number(raw);
+    if (!Number.isFinite(parsed) || parsed < 0) {
+      process.stderr.write(`Invalid value for ${flag}: ${raw ?? '(missing)'}\n`);
+      process.exit(1);
+    }
+    return parsed;
+  };
+
+  return {
+    delete: argv.includes('--delete'),
+    graceHours: numericFlag('--grace-hours', DEFAULT_GRACE_HOURS) as number,
+    limit: numericFlag('--limit', null),
+    json: argv.includes('--json'),
+  };
+}
+
+function printHelp(): void {
+  process.stdout.write(
+    [
+      'Cleanup orphaned raffle images in the Supabase storage bucket.',
+      '',
+      'Usage: ts-node scripts/cleanup-orphan-images.ts [options]',
+      '',
+      '  --delete           Actually delete orphans (default: dry run, deletes nothing)',
+      `  --grace-hours <n>  Skip objects newer than <n> hours (default: ${DEFAULT_GRACE_HOURS})`,
+      '  --limit <n>        Cap deletions per run',
+      '  --json             Machine-readable JSON output',
+      '  --help             Show this help',
+      '',
+    ].join('\n'),
+  );
+}
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    process.stderr.write(`Missing required environment variable: ${name}\n`);
+    process.exit(1);
+  }
+  return value;
+}
+
+/**
+ * Extract the in-bucket object path from a Supabase public URL.
+ * Public URLs look like:
+ *   https://<project>.supabase.co/storage/v1/object/public/raffle-images/<path>
+ * Returns null for anything that is not an object in RAFFLE_IMAGE_BUCKET.
+ */
+export function extractBucketPath(url: string | null | undefined): string | null {
+  if (!url) return null;
+  const marker = `/${RAFFLE_IMAGE_BUCKET}/`;
+  const idx = url.indexOf(marker);
+  if (idx === -1) return null;
+  let path = url.slice(idx + marker.length);
+  // Strip query string / fragment (e.g. cache-busting or transform params).
+  path = path.split('?')[0].split('#')[0];
+  // Decode %20 etc. so it matches the raw storage path.
+  try {
+    path = decodeURIComponent(path);
+  } catch {
+    /* leave as-is if it is not valid percent-encoding */
+  }
+  return path.length > 0 ? path : null;
+}
+
+/** Collect every object path referenced by any raffle_metadata row. */
+async function collectReferencedPaths(client: SupabaseClient): Promise<Set<string>> {
+  const referenced = new Set<string>();
+  const pageSize = 1000;
+  let from = 0;
+
+  // Paginate through all rows. We intentionally include soft-deleted rows
+  // (deleted_at set) so an image is only ever an orphan when NO row references
+  // it — purging soft-deleted raffles' images is a separate, explicit policy.
+  for (;;) {
+    const { data, error } = await client
+      .from(METADATA_TABLE)
+      .select('image_url, image_urls')
+      .range(from, from + pageSize - 1);
+
+    if (error) {
+      throw new Error(`Failed to read ${METADATA_TABLE}: ${error.message}`);
+    }
+    if (!data || data.length === 0) break;
+
+    for (const row of data as Array<{
+      image_url: string | null;
+      image_urls: string[] | null;
+    }>) {
+      const urls = [row.image_url, ...(row.image_urls ?? [])];
+      for (const url of urls) {
+        const path = extractBucketPath(url);
+        if (path) referenced.add(path);
+      }
+    }
+
+    if (data.length < pageSize) break;
+    from += pageSize;
+  }
+
+  return referenced;
+}
+
+/**
+ * Recursively list every object in the bucket. Supabase `list()` returns one
+ * directory level at a time; folders come back with a null `id`.
+ */
+async function listAllObjects(
+  client: SupabaseClient,
+  prefix = '',
+): Promise<StorageObject[]> {
+  const objects: StorageObject[] = [];
+  let offset = 0;
+
+  for (;;) {
+    const { data, error } = await client.storage
+      .from(RAFFLE_IMAGE_BUCKET)
+      .list(prefix, {
+        limit: LIST_PAGE_SIZE,
+        offset,
+        sortBy: { column: 'name', order: 'asc' },
+      });
+
+    if (error) {
+      throw new Error(`Failed to list "${prefix}": ${error.message}`);
+    }
+    if (!data || data.length === 0) break;
+
+    // Supabase types `id` as string, but folder entries return a null id at
+    // runtime — widen the type so we can distinguish files from folders.
+    const entries = data as Array<{
+      name: string;
+      id: string | null;
+      created_at: string | null;
+    }>;
+
+    for (const entry of entries) {
+      const childPath = prefix ? `${prefix}/${entry.name}` : entry.name;
+      // Folders have a null id; recurse into them. Files have an id.
+      if (entry.id === null) {
+        objects.push(...(await listAllObjects(client, childPath)));
+      } else {
+        objects.push({
+          path: childPath,
+          createdAt: entry.created_at ?? null,
+        });
+      }
+    }
+
+    if (data.length < LIST_PAGE_SIZE) break;
+    offset += LIST_PAGE_SIZE;
+  }
+
+  return objects;
+}
+
+async function deleteInBatches(
+  client: SupabaseClient,
+  paths: string[],
+): Promise<void> {
+  for (let i = 0; i < paths.length; i += DELETE_BATCH_SIZE) {
+    const batch = paths.slice(i, i + DELETE_BATCH_SIZE);
+    const { error } = await client.storage.from(RAFFLE_IMAGE_BUCKET).remove(batch);
+    if (error) {
+      throw new Error(`Failed to delete a batch of objects: ${error.message}`);
+    }
+  }
+}
+
+async function main(): Promise<void> {
+  const options = parseOptions(process.argv.slice(2));
+
+  const url = requireEnv('SUPABASE_URL');
+  const serviceRoleKey = requireEnv('SUPABASE_SERVICE_ROLE_KEY');
+  const client = createClient(url, serviceRoleKey);
+
+  const referenced = await collectReferencedPaths(client);
+  const allObjects = await listAllObjects(client);
+
+  const graceCutoff = Date.now() - options.graceHours * 60 * 60 * 1000;
+
+  const orphans: StorageObject[] = [];
+  let skippedByGrace = 0;
+
+  for (const obj of allObjects) {
+    if (referenced.has(obj.path)) continue;
+
+    // Grace window: an object with no known creation time is treated as new and
+    // skipped, erring on the side of never deleting a possibly-live upload.
+    const createdMs = obj.createdAt ? Date.parse(obj.createdAt) : NaN;
+    if (!Number.isFinite(createdMs) || createdMs > graceCutoff) {
+      skippedByGrace += 1;
+      continue;
+    }
+
+    orphans.push(obj);
+  }
+
+  const cappedOrphans =
+    options.limit !== null ? orphans.slice(0, options.limit) : orphans;
+  const orphanPaths = cappedOrphans.map((o) => o.path);
+
+  let deleted = 0;
+  if (options.delete && orphanPaths.length > 0) {
+    await deleteInBatches(client, orphanPaths);
+    deleted = orphanPaths.length;
+  }
+
+  if (options.json) {
+    process.stdout.write(
+      JSON.stringify(
+        {
+          bucket: RAFFLE_IMAGE_BUCKET,
+          mode: options.delete ? 'delete' : 'dry-run',
+          graceHours: options.graceHours,
+          totals: {
+            objectsScanned: allObjects.length,
+            referenced: referenced.size,
+            skippedByGrace,
+            orphansFound: orphans.length,
+            orphansSelected: cappedOrphans.length,
+            deleted,
+          },
+          orphans: orphanPaths,
+        },
+        null,
+        2,
+      ) + '\n',
+    );
+  } else {
+    process.stdout.write(
+      `Bucket:            ${RAFFLE_IMAGE_BUCKET}\n` +
+        `Mode:              ${options.delete ? 'DELETE' : 'dry-run (no deletions)'}\n` +
+        `Grace window:      ${options.graceHours}h\n` +
+        `Objects scanned:   ${allObjects.length}\n` +
+        `Referenced paths:  ${referenced.size}\n` +
+        `Skipped (grace):   ${skippedByGrace}\n` +
+        `Orphans found:     ${orphans.length}\n`,
+    );
+    if (orphanPaths.length > 0) {
+      process.stdout.write(
+        `\n${options.delete ? 'Deleted' : 'Would delete'} ${orphanPaths.length} object(s):\n`,
+      );
+      for (const p of orphanPaths) process.stdout.write(`  - ${p}\n`);
+    }
+    if (!options.delete && orphans.length > 0) {
+      process.stdout.write('\nRe-run with --delete to remove these objects.\n');
+    }
+  }
+
+  process.exit(0);
+}
+
+main().catch((err) => {
+  const message = err instanceof Error ? err.message : String(err);
+  process.stderr.write(`Error: ${message}\n`);
+  process.exit(1);
+});

--- a/docs/storage/README.md
+++ b/docs/storage/README.md
@@ -1,0 +1,129 @@
+# Object storage: buckets, lifecycle & cleanup
+
+Tikka stores raffle images in **Supabase Storage**. This document describes the
+bucket layout, object naming, how objects are referenced, the retention /
+lifecycle policy, and the orphan-cleanup script.
+
+Operational alerts, dashboards, and runbooks live in
+[`storage/OPERATIONAL.md`](../../storage/OPERATIONAL.md).
+
+## Buckets
+
+| Bucket          | Access | Contents                                    | Defined in |
+| --------------- | ------ | ------------------------------------------- | ---------- |
+| `raffle-images` | Public | Raffle cover images + responsive variants   | `backend/src/config/upload.config.ts` (`RAFFLE_IMAGE_BUCKET`) |
+
+Uploads are handled by `StorageService.uploadRaffleImage`
+(`backend/src/services/storage.service.ts`). Images are optimised to WebP and a
+set of responsive width variants is generated before upload.
+
+Constraints (see `upload.config.ts`):
+
+- Max upload size: **5 MB** (`MAX_UPLOAD_BYTES`).
+- Allowed input types: `image/jpeg`, `image/png`, `image/webp`.
+- Stored primary object is WebP (falls back to the original format only if
+  optimisation fails).
+
+## Object naming
+
+Objects use a deterministic, collision-resistant path per raffle and uploader:
+
+```
+<raffleId>/<uploaderId>/<uuid>.<ext>            # primary image
+<raffleId>/<uploaderId>/<uuid>-<width>w.webp    # responsive variant
+```
+
+- `raffleId` and `uploaderId` are sanitised to `[A-Za-z0-9_-]` (invalid input
+  collapses to `unknown`).
+- `uuid` is a random v4 UUID generated per upload, so re-uploading never
+  overwrites a previous image (`upsert: false`).
+- `<width>w` is the variant's pixel width (e.g. `320w`, `640w`).
+
+## How objects are referenced
+
+Raffle metadata lives in the **`raffle_metadata`** Postgres table
+(`backend/src/services/metadata.service.ts`). The image references are:
+
+- `image_url` — the primary image's public URL.
+- `image_urls` — array of variant public URLs.
+
+A public URL embeds the object path:
+
+```
+https://<project>.supabase.co/storage/v1/object/public/raffle-images/<path>
+```
+
+**An object is "referenced" if its `<path>` appears in the `image_url` or
+`image_urls` of any `raffle_metadata` row** (including soft-deleted rows, i.e.
+`deleted_at` set). Any object not referenced by *any* row is an **orphan**.
+
+Orphans arise from:
+
+- **Abandoned uploads** — an image is uploaded (via the upload endpoint) but the
+  raffle/metadata row referencing it is never created.
+- **Hard-deleted raffles** — the metadata row is removed without deleting its
+  storage objects.
+
+> Soft-deleted raffles (row present, `deleted_at` set) still *reference* their
+> images, so those images are **not** treated as orphans. Purging images for
+> soft-deleted raffles is a separate, deliberate retention decision — do it by
+> hard-deleting the rows first (or extend the cleanup policy explicitly).
+
+## Retention / lifecycle policy
+
+1. **Live images** — referenced by a `raffle_metadata` row: retained
+   indefinitely while the raffle exists.
+2. **Explicit deletes** — when a raffle image is replaced or a raffle is removed
+   through the app, call `StorageService.deleteRaffleImage(path)` to delete the
+   object synchronously.
+3. **Orphans** — unreferenced objects older than the grace window are eligible
+   for cleanup via the script below. A **grace window (default 24h)** protects
+   objects that were just uploaded but whose metadata row has not been written
+   yet, so a live upload is never mistaken for an orphan.
+4. **PII / cost** — because raffle images can contain user-provided imagery,
+   orphans are both a storage-cost and a data-minimisation (PII) concern. Run
+   the cleanup on a schedule (e.g. weekly) so unreferenced objects do not
+   accumulate.
+
+Supabase does not currently apply a server-side lifecycle rule to this bucket;
+retention is enforced by the cleanup script. If bucket versioning is enabled,
+deleted objects may be recoverable per the storage provider's retention — see
+`storage/OPERATIONAL.md`.
+
+## Orphan cleanup script
+
+Script: [`backend/scripts/cleanup-orphan-images.ts`](../../backend/scripts/cleanup-orphan-images.ts)
+npm script: `storage:cleanup-orphans` (in `backend/package.json`).
+
+It lists every object in `raffle-images`, builds the set of paths referenced by
+`raffle_metadata`, and reports objects referenced by no row.
+
+**It is dry-run by default and deletes nothing** unless `--delete` is passed.
+
+```bash
+# From backend/. Requires SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY.
+
+# Dry run — list orphans, delete nothing (default):
+npm run storage:cleanup-orphans
+
+# Machine-readable dry run:
+npm run storage:cleanup-orphans -- --json
+
+# Actually delete orphans older than 48h, capped at 500 per run:
+npm run storage:cleanup-orphans -- --delete --grace-hours 48 --limit 500
+```
+
+Options:
+
+| Flag              | Default | Meaning                                                        |
+| ----------------- | ------- | -------------------------------------------------------------- |
+| `--delete`        | off     | Perform deletions. Omit for a dry run (deletes nothing).       |
+| `--grace-hours n` | `24`    | Ignore objects created within the last `n` hours.              |
+| `--limit n`       | none    | Cap the number of objects deleted in a single run.            |
+| `--json`          | off     | Emit a JSON report instead of human-readable text.            |
+
+Exit codes: `0` on success (including dry run), `1` on missing env / bad args /
+error.
+
+**Recommended workflow:** always run a dry run first, eyeball the reported
+paths, then re-run with `--delete`.

--- a/storage/OPERATIONAL.md
+++ b/storage/OPERATIONAL.md
@@ -2,6 +2,9 @@
 
 Owner: @storage-team
 
+> Bucket layout, object naming, retention/lifecycle policy, and the orphan
+> cleanup script are documented in [`docs/storage/README.md`](../docs/storage/README.md).
+
 Required links:
 - Dashboards:
   - Object errors (4xx/5xx): <link>


### PR DESCRIPTION
## Summary

Closes #1158.

Documents the object-storage lifecycle for raffle images and adds a **dry-run-first** orphan cleanup script.

## Context (from the code)

- Raffle images live in the **Supabase Storage `raffle-images` bucket** (`backend/src/config/upload.config.ts`, `backend/src/services/storage.service.ts`).
- Object paths: `<raffleId>/<uploaderId>/<uuid>.<ext>` for the primary image and `<raffleId>/<uploaderId>/<uuid>-<width>w.webp` for responsive variants.
- References are stored in the **`raffle_metadata`** table's `image_url` / `image_urls` columns (`backend/src/services/metadata.service.ts`). An object is an **orphan** when its path is referenced by no row (abandoned uploads, hard-deleted raffles).

## Changes

**Docs — `docs/storage/README.md`** (linked from `storage/OPERATIONAL.md`)
- Bucket table, object naming, upload constraints.
- How objects are referenced and what counts as an orphan (soft-deleted rows still reference their images, so they're **not** orphaned).
- Retention / lifecycle policy incl. the PII + cost rationale and grace window.

**Script — `backend/scripts/cleanup-orphan-images.ts`** (`npm run storage:cleanup-orphans`)
- Recursively lists bucket objects, builds the referenced-path set from `raffle_metadata`, reports orphans.
- **Dry-run by default — deletes nothing.** Deletion only behind an explicit `--delete` flag.
- `--grace-hours <n>` (default 24) skips freshly uploaded objects so a live upload whose metadata row isn't written yet is never mistaken for an orphan.
- `--limit <n>` caps deletions per run; `--json` for machine-readable output.
- Exit `0` on success (incl. dry run), `1` on missing env / bad args / error.

## Acceptance criteria
- [x] Lifecycle documented (structure, naming, retention).
- [x] Cleanup script's dry run lists orphans and **deletes nothing by default**.

## Notes / testing
The backend workspace isn't installed in my environment, so I couldn't run `tsc`/the script live. The script is standalone (`ts-node scripts/cleanup-orphan-images.ts`, like the existing `backfill.ts`), only touches Supabase, and I widened the `list()` entry type so folder detection (`id === null`) type-checks under strict mode. A dry run in a real environment is recommended before first `--delete`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)