### PR TITLE
fix(compose): make service healthchecks functional and add start_period

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,10 +21,11 @@ services:
     volumes:
       - postgres-data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-tikka}"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-tikka} -d ${POSTGRES_DB:-tikka}"]
       interval: 10s
       timeout: 5s
       retries: 5
+      start_period: 10s
 
   redis:
     image: redis:7-alpine
@@ -36,6 +37,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+      start_period: 5s
 
   backend:
     build:
@@ -55,11 +57,13 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
+    # The runner image is node:alpine, which ships busybox wget (not curl).
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3001/health"]
+      test: ["CMD-SHELL", "wget -q -O /dev/null http://localhost:3001/health || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 5
+      start_period: 20s
 
   indexer:
     build:
@@ -78,11 +82,13 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
+    # The runner image is node:alpine, which ships busybox wget (not curl).
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3002/health"]
+      test: ["CMD-SHELL", "wget -q -O /dev/null http://localhost:3002/health || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 5
+      start_period: 20s
 
   oracle:
     build:
@@ -98,11 +104,13 @@ services:
     depends_on:
       redis:
         condition: service_healthy
+    # The runner image is node:alpine, which ships busybox wget (not curl).
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3003/health"]
+      test: ["CMD-SHELL", "wget -q -O /dev/null http://localhost:3003/health || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 5
+      start_period: 20s
 
   client:
     build:

--- a/oracle/Dockerfile
+++ b/oracle/Dockerfile
@@ -14,4 +14,6 @@ RUN pnpm install --prod --frozen-lockfile
 COPY --from=builder /app/dist ./dist
 ENV NODE_ENV=production
 EXPOSE 3003
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD wget --quiet --tries=1 http://localhost:3003/health -O /dev/null || exit 1
 CMD ["node", "dist/main.js"]


### PR DESCRIPTION
## Summary

Closes #1159.

`docker-compose.yml` already had `healthcheck` blocks and `depends_on: condition: service_healthy`, but the app healthchecks **didn't actually work** — so services could still start out of order / hang on first boot.

## Root cause

The backend/indexer/oracle healthchecks used `curl`:

```yaml
test: ["CMD", "curl", "-f", "http://localhost:3001/health"]
```

But their runner images are `node:22-alpine`, which ships **busybox `wget`, not `curl`**. `curl` isn't installed, so the healthcheck command always fails → the container never reports `healthy` → anything gated on it (e.g. `client` → `backend: service_healthy`) waits/hangs. The Dockerfiles themselves already use `wget` for their `HEALTHCHECK`, so the compose file was inconsistent with the images.

## Changes

- **backend / indexer / oracle** — switch the healthcheck to busybox-compatible `wget`:
  `wget -q -O /dev/null http://localhost:<port>/health || exit 1` (short flags `-q`/`-O` are guaranteed in busybox).
- **`start_period` added to every healthcheck** (5–20s) so slow first-boot startup isn't counted against the retry budget — this is what removes the "connection-refused noise on first boot".
- **Postgres** — added an explicit `-d ${POSTGRES_DB:-tikka}` to `pg_isready`.
- **`oracle/Dockerfile`** — added a `HEALTHCHECK` (backend and indexer already had one; oracle was the only app image without one). Verified oracle serves `GET /health` on 3003 (`oracle/src/health/health.controller.ts`).

## Acceptance criteria
- [x] Every service that needs one has a working healthcheck (pg_isready / redis-cli ping / wget on `/health`).
- [x] Dependents already use `depends_on: condition: service_healthy`; with functional healthchecks they now actually wait for readiness, so `docker compose up` comes up in order.

## Notes / testing
Docker isn't available in my environment, so I couldn't run `docker compose up` live. I validated the compose YAML parses and confirmed each base image (`node:22-alpine`) has busybox `wget` but not `curl`, and that each targeted `/health` endpoint exists. A live `docker compose --profile full up` is recommended to confirm ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)