### PR TITLE
feat(oracle): add PagerDuty/webhook alerting for circuit breaker, DLQ, and VRF failures

### DIFF
--- a/oracle/package.json
+++ b/oracle/package.json
@@ -43,6 +43,7 @@
   "devDependencies": {
     "@nestjs/cli": "^10.4.0",
     "@nestjs/testing": "^10.4.22",
+    "@types/express": "^4.17.21",
     "@types/jest": "^30.0.0",
     "@types/node": "^22.0.0",
     "@typescript-eslint/eslint-plugin": "^8.62.0",

--- a/oracle/pnpm-lock.yaml
+++ b/oracle/pnpm-lock.yaml
@@ -68,6 +68,13 @@ importers:
       zod:
         specifier: ^4.4.3
         version: 4.4.3
+    optionalDependencies:
+      '@aws-sdk/client-kms':
+        specifier: ^3.0.0
+        version: 3.1056.0
+      '@google-cloud/kms':
+        specifier: ^4.0.0
+        version: 4.5.0
     devDependencies:
       '@nestjs/cli':
         specifier: ^10.4.0
@@ -75,6 +82,9 @@ importers:
       '@nestjs/testing':
         specifier: ^10.4.22
         version: 10.4.22(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)(@nestjs/platform-express@10.4.22)
+      '@types/express':
+        specifier: ^4.17.21
+        version: 4.17.25
       '@types/jest':
         specifier: ^30.0.0
         version: 30.0.0
@@ -105,13 +115,6 @@ importers:
       typescript:
         specifier: ^5.6.0
         version: 5.9.3
-    optionalDependencies:
-      '@aws-sdk/client-kms':
-        specifier: ^3.0.0
-        version: 3.1056.0
-      '@google-cloud/kms':
-        specifier: ^4.0.0
-        version: 4.5.0
 
 packages:
 
@@ -990,8 +993,14 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/body-parser@1.19.6':
+    resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
+
   '@types/caseless@0.12.5':
     resolution: {integrity: sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==}
+
+  '@types/connect@3.4.38':
+    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
   '@types/eslint-scope@3.7.7':
     resolution: {integrity: sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==}
@@ -1004,6 +1013,15 @@ packages:
 
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/express-serve-static-core@4.19.9':
+    resolution: {integrity: sha512-QP2ESEe/ImWY0HDwNAnK9PvEffUyhLTnWkk7KXzHfyeWAnlrDe1fN77bXl6ia8KT3wPlmA7t9/VPRpnf4Ex9sg==}
+
+  '@types/express@4.17.25':
+    resolution: {integrity: sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==}
+
+  '@types/http-errors@2.0.5':
+    resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
 
   '@types/istanbul-lib-coverage@2.0.6':
     resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
@@ -1023,11 +1041,29 @@ packages:
   '@types/long@4.0.2':
     resolution: {integrity: sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==}
 
+  '@types/mime@1.3.5':
+    resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
+
   '@types/node@22.19.15':
     resolution: {integrity: sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==}
 
+  '@types/qs@6.15.1':
+    resolution: {integrity: sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==}
+
+  '@types/range-parser@1.2.7':
+    resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
+
   '@types/request@2.48.13':
     resolution: {integrity: sha512-FGJ6udDNUCjd19pp0Q3iTiDkwhYup7J8hpMW9c4k53NrccQFFWKRho6hvtPPEhnXWKvukfwAlB6DbDz4yhH5Gg==}
+
+  '@types/send@0.17.6':
+    resolution: {integrity: sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==}
+
+  '@types/send@1.2.1':
+    resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}
+
+  '@types/serve-static@1.15.10':
+    resolution: {integrity: sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==}
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
@@ -4900,8 +4936,17 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@types/body-parser@1.19.6':
+    dependencies:
+      '@types/connect': 3.4.38
+      '@types/node': 22.19.15
+
   '@types/caseless@0.12.5':
     optional: true
+
+  '@types/connect@3.4.38':
+    dependencies:
+      '@types/node': 22.19.15
 
   '@types/eslint-scope@3.7.7':
     dependencies:
@@ -4916,6 +4961,22 @@ snapshots:
   '@types/esrecurse@4.3.1': {}
 
   '@types/estree@1.0.9': {}
+
+  '@types/express-serve-static-core@4.19.9':
+    dependencies:
+      '@types/node': 22.19.15
+      '@types/qs': 6.15.1
+      '@types/range-parser': 1.2.7
+      '@types/send': 1.2.1
+
+  '@types/express@4.17.25':
+    dependencies:
+      '@types/body-parser': 1.19.6
+      '@types/express-serve-static-core': 4.19.9
+      '@types/qs': 6.15.1
+      '@types/serve-static': 1.15.10
+
+  '@types/http-errors@2.0.5': {}
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 
@@ -4937,9 +4998,15 @@ snapshots:
   '@types/long@4.0.2':
     optional: true
 
+  '@types/mime@1.3.5': {}
+
   '@types/node@22.19.15':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/qs@6.15.1': {}
+
+  '@types/range-parser@1.2.7': {}
 
   '@types/request@2.48.13':
     dependencies:
@@ -4948,6 +5015,21 @@ snapshots:
       '@types/tough-cookie': 4.0.5
       form-data: 2.5.5
     optional: true
+
+  '@types/send@0.17.6':
+    dependencies:
+      '@types/mime': 1.3.5
+      '@types/node': 22.19.15
+
+  '@types/send@1.2.1':
+    dependencies:
+      '@types/node': 22.19.15
+
+  '@types/serve-static@1.15.10':
+    dependencies:
+      '@types/http-errors': 2.0.5
+      '@types/node': 22.19.15
+      '@types/send': 0.17.6
 
   '@types/stack-utils@2.0.3': {}
 

--- a/oracle/src/app.module.ts
+++ b/oracle/src/app.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { LoggerModule } from './logger/logger.module';
 import { OracleConfigModule } from './config';
 import { QueueModule } from './queue/queue.module';
 import { HealthModule } from './health/health.module';
@@ -13,6 +14,7 @@ import { AdminModule } from './admin/admin.module';
 
 @Module({
   imports: [
+    LoggerModule,
     OracleConfigModule.forRoot(),
     KeysModule,
     QueueModule,

--- a/oracle/src/audit/audit-log.service.spec.ts
+++ b/oracle/src/audit/audit-log.service.spec.ts
@@ -1,14 +1,16 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
 import { AuditLogService } from './audit-log.service';
+import { OracleLoggerService } from '../logger/oracle-logger';
 import { SUPABASE_CLIENT } from './supabase.provider';
 import { RecordSubmissionParams } from './audit.types';
 
 describe('AuditLogService - record()', () => {
   let service: AuditLogService;
   let supabaseClient: any;
+  let loggerMock: { log: jest.Mock; warn: jest.Mock; error: jest.Mock; debug: jest.Mock };
 
   beforeEach(async () => {
+    loggerMock = { log: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() };
     const mockSupabase = {
       from: jest.fn().mockReturnThis(),
       select: jest.fn().mockReturnThis(),
@@ -26,6 +28,10 @@ describe('AuditLogService - record()', () => {
       providers: [
         AuditLogService,
         {
+          provide: OracleLoggerService,
+          useValue: loggerMock,
+        },
+        {
           provide: SUPABASE_CLIENT,
           useValue: mockSupabase,
         },
@@ -34,11 +40,6 @@ describe('AuditLogService - record()', () => {
 
     service = module.get<AuditLogService>(AuditLogService);
     supabaseClient = module.get(SUPABASE_CLIENT);
-
-    // Mock logger to avoid console output during tests
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
-    jest.spyOn(Logger.prototype, 'warn').mockImplementation();
   });
 
   afterEach(() => {
@@ -131,7 +132,7 @@ describe('AuditLogService - record()', () => {
 
       // Should not throw, just log error
       await expect(service.record(mockParams)).resolves.not.toThrow();
-      expect(Logger.prototype.error).toHaveBeenCalled();
+      expect(loggerMock.error).toHaveBeenCalled();
     });
 
     it('should handle missing requestId gracefully', async () => {
@@ -174,7 +175,7 @@ describe('AuditLogService - record()', () => {
 
       await service.record(mockParams);
 
-      expect(Logger.prototype.log).toHaveBeenCalledWith(
+      expect(loggerMock.log).toHaveBeenCalledWith(
         expect.stringContaining('Audit record saved for raffle 123'),
       );
     });

--- a/oracle/src/config/ENVIRONMENT_VARIABLES.md
+++ b/oracle/src/config/ENVIRONMENT_VARIABLES.md
@@ -434,6 +434,20 @@ This document describes all environment variables used by the Tikka Oracle servi
 - **Description**: Opsgenie API key
 - **Example**: `OPSGENIE_API_KEY=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`
 
+### `ALERT_WEBHOOK_URL`
+- **Type**: String (URL)
+- **Default**: None
+- **Required**: No
+- **Description**: Slack-compatible webhook URL. When set, alerts are POSTed here in addition to (or instead of) `ALERTING_PROVIDER`. Fires on circuit breaker OPEN, dead-letter queue depth exceeding `DLQ_DEPTH_ALERT_THRESHOLD`, and VRF signing key unavailability. Each payload includes `oracle_id`, `raffle_id` (when applicable), and severity.
+- **Example**: `ALERT_WEBHOOK_URL=https://hooks.slack.com/services/T00/B00/XXXX`
+
+### `DLQ_DEPTH_ALERT_THRESHOLD`
+- **Type**: Integer
+- **Default**: `5`
+- **Required**: No
+- **Description**: Number of dead-lettered jobs that triggers a critical alert
+- **Example**: `DLQ_DEPTH_ALERT_THRESHOLD=10`
+
 ---
 
 ## Heartbeat Configuration
@@ -556,6 +570,8 @@ REDIS_PORT=6379
 # Alerting
 ALERTING_PROVIDER=pagerduty
 PAGERDUTY_ROUTING_KEY=R0XXXXXXXXXXXXXXXXXXXXXXXXXX
+ALERT_WEBHOOK_URL=https://hooks.slack.com/services/T00/B00/XXXX
+DLQ_DEPTH_ALERT_THRESHOLD=10
 
 # Logging
 LOG_LEVEL=info

--- a/oracle/src/config/config.loader.ts
+++ b/oracle/src/config/config.loader.ts
@@ -165,6 +165,7 @@ export function loadOracleConfig(): OracleConfig {
       provider: (process.env.ALERTING_PROVIDER || 'none') as 'none' | 'pagerduty' | 'opsgenie',
       pagerdutyRoutingKey: process.env.PAGERDUTY_ROUTING_KEY,
       opsgenieApiKey: process.env.OPSGENIE_API_KEY,
+      webhookUrl: process.env.ALERT_WEBHOOK_URL,
     },
     heartbeat: {
       intervalMs: parseInteger(process.env.HEARTBEAT_INTERVAL_MS, 3600000),

--- a/oracle/src/config/config.schema.ts
+++ b/oracle/src/config/config.schema.ts
@@ -129,6 +129,7 @@ const AlertingSchema = z.object({
   provider: z.enum(['none', 'pagerduty', 'opsgenie']).default('none'),
   pagerdutyRoutingKey: z.string().optional(),
   opsgenieApiKey: z.string().optional(),
+  webhookUrl: z.string().url().optional(),
 }).refine(
   (data) => {
     if (data.provider === 'pagerduty') {

--- a/oracle/src/config/verify-config.ts
+++ b/oracle/src/config/verify-config.ts
@@ -109,6 +109,7 @@ try {
   } else if (config.alerting.provider === 'opsgenie') {
     console.log(`  Opsgenie API Key: [REDACTED]`);
   }
+  console.log(`  Alert Webhook: ${config.alerting.webhookUrl ? 'Configured' : 'Not configured'}`);
   
   console.log('\n💓 Heartbeat:');
   console.log(`  Interval: ${config.heartbeat.intervalMs}ms`);

--- a/oracle/src/contract/contract.builders.spec.ts
+++ b/oracle/src/contract/contract.builders.spec.ts
@@ -27,7 +27,7 @@ describe('ContractBuilders', () => {
   });
 
   it('should build receive_randomness invocation', () => {
-    const inv = ContractBuilders.buildReceiveRandomness(123, { seed: 'seed', proof: 'proof', result: 'result' });
+    const inv = ContractBuilders.buildReceiveRandomness(123, { seed: 'seed', proof: 'proof' });
     expect(inv.method).toEqual('receive_randomness');
     expect(inv.args).toHaveLength(3);
     expect(inv.args[0].u32()).toEqual(123);

--- a/oracle/src/health/alerting.service.spec.ts
+++ b/oracle/src/health/alerting.service.spec.ts
@@ -1,0 +1,160 @@
+import { AlertingService } from './alerting.service';
+import { OracleLoggerService } from '../logger/oracle-logger';
+
+function makeLogger(): OracleLoggerService {
+  return { log: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() } as unknown as OracleLoggerService;
+}
+
+describe('AlertingService', () => {
+  const ORIGINAL_ENV = { ...process.env };
+  let fetchMock: jest.Mock;
+
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    delete process.env.ALERTING_PROVIDER;
+    delete process.env.PAGERDUTY_ROUTING_KEY;
+    delete process.env.OPSGENIE_API_KEY;
+    delete process.env.ALERT_WEBHOOK_URL;
+
+    fetchMock = jest.fn().mockResolvedValue({ ok: true, text: jest.fn().mockResolvedValue('') });
+    global.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    jest.restoreAllMocks();
+  });
+
+  describe('webhook (Slack-compatible)', () => {
+    it('does not POST when ALERT_WEBHOOK_URL is not set', async () => {
+      const service = new AlertingService(makeLogger());
+
+      await service.fire({
+        severity: 'critical',
+        summary: 'circuit open',
+        dedupKey: 'test-key',
+      });
+
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('POSTs a Slack-compatible payload to ALERT_WEBHOOK_URL when configured', async () => {
+      process.env.ALERT_WEBHOOK_URL = 'https://hooks.example.com/webhook';
+      const service = new AlertingService(makeLogger());
+
+      await service.fire({
+        severity: 'critical',
+        summary: 'Circuit breaker OPEN',
+        details: 'threshold=5, resetTimeoutMs=60000',
+        dedupKey: 'circuit-breaker-open',
+        context: { oracle_id: 'oracle-001', raffle_id: 42 },
+      });
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toBe('https://hooks.example.com/webhook');
+      expect(init.method).toBe('POST');
+      expect(init.headers).toMatchObject({ 'Content-Type': 'application/json' });
+
+      const body = JSON.parse(init.body);
+      expect(body.text).toContain('CRITICAL');
+      expect(body.text).toContain('Circuit breaker OPEN');
+      expect(body.attachments).toHaveLength(1);
+      expect(body.attachments[0].text).toBe('threshold=5, resetTimeoutMs=60000');
+      expect(body.attachments[0].fields).toEqual(
+        expect.arrayContaining([
+          { title: 'oracle_id', value: 'oracle-001', short: true },
+          { title: 'raffle_id', value: '42', short: true },
+        ]),
+      );
+    });
+
+    it('includes enough context to diagnose the issue without SSH access', async () => {
+      process.env.ALERT_WEBHOOK_URL = 'https://hooks.example.com/webhook';
+      const service = new AlertingService(makeLogger());
+
+      await service.fire({
+        severity: 'warning',
+        summary: 'DLQ depth exceeded',
+        details: 'Most recently dead-lettered job was for raffle 7.',
+        dedupKey: 'dlq-depth-threshold',
+        context: { oracle_id: 'oracle-001', raffle_id: 7 },
+      });
+
+      const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+      const fieldTitles = body.attachments[0].fields.map((f: any) => f.title);
+      expect(fieldTitles).toEqual(expect.arrayContaining(['oracle_id', 'raffle_id']));
+      expect(body.text).toContain('WARNING');
+      expect(body.attachments[0].text).toContain('raffle 7');
+    });
+
+    it('POSTs a resolved message to the webhook on resolve()', async () => {
+      process.env.ALERT_WEBHOOK_URL = 'https://hooks.example.com/webhook';
+      const service = new AlertingService(makeLogger());
+
+      await service.resolve('circuit-breaker-open');
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+      expect(body.text).toContain('RESOLVED');
+      expect(body.text).toContain('circuit-breaker-open');
+    });
+
+    it('logs but does not throw when the webhook POST fails', async () => {
+      process.env.ALERT_WEBHOOK_URL = 'https://hooks.example.com/webhook';
+      fetchMock.mockResolvedValue({ ok: false, status: 500, text: jest.fn().mockResolvedValue('server error') });
+      const logger = makeLogger();
+      const service = new AlertingService(logger);
+
+      await expect(
+        service.fire({ severity: 'critical', summary: 'x', dedupKey: 'k' }),
+      ).resolves.toBeUndefined();
+
+      expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('Failed to POST alert webhook'));
+    });
+
+    it('fires both the configured provider and the webhook when both are set', async () => {
+      process.env.ALERTING_PROVIDER = 'pagerduty';
+      process.env.PAGERDUTY_ROUTING_KEY = 'pd-key';
+      process.env.ALERT_WEBHOOK_URL = 'https://hooks.example.com/webhook';
+      const service = new AlertingService(makeLogger());
+
+      await service.fire({ severity: 'critical', summary: 'x', dedupKey: 'k' });
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      const urls = fetchMock.mock.calls.map((c) => c[0]);
+      expect(urls).toEqual(
+        expect.arrayContaining([
+          'https://events.pagerduty.com/v2/enqueue',
+          'https://hooks.example.com/webhook',
+        ]),
+      );
+    });
+  });
+
+  describe('PagerDuty', () => {
+    it('includes alert context in custom_details', async () => {
+      process.env.ALERTING_PROVIDER = 'pagerduty';
+      process.env.PAGERDUTY_ROUTING_KEY = 'pd-key';
+      const service = new AlertingService(makeLogger());
+
+      await service.fire({
+        severity: 'critical',
+        summary: 'VRF signing key unavailable',
+        details: 'KMS access denied',
+        dedupKey: 'vrf-key-unavailable',
+        context: { oracle_id: 'oracle-001', raffle_id: 9, request_id: 'req-9' },
+      });
+
+      const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+      expect(body.routing_key).toBe('pd-key');
+      expect(body.dedup_key).toBe('vrf-key-unavailable');
+      expect(body.payload.custom_details).toMatchObject({
+        details: 'KMS access denied',
+        oracle_id: 'oracle-001',
+        raffle_id: 9,
+        request_id: 'req-9',
+      });
+    });
+  });
+});

--- a/oracle/src/health/alerting.service.ts
+++ b/oracle/src/health/alerting.service.ts
@@ -9,6 +9,8 @@ export interface AlertPayload {
   details?: string;
   /** Stable key used to de-duplicate and auto-resolve the same alert. */
   dedupKey: string;
+  /** Diagnostic context (e.g. oracle_id, raffle_id) included in outbound alert payloads. */
+  context?: Record<string, unknown>;
 }
 
 type AlertingProvider = 'pagerduty' | 'opsgenie' | 'none';
@@ -34,6 +36,9 @@ export class AlertingService {
   private readonly opsgenieApiKey: string;
   private readonly opsgenieApiUrl = 'https://api.opsgenie.com/v2/alerts';
 
+  // Generic webhook (Slack-compatible)
+  private readonly webhookUrl: string;
+
   constructor(private readonly logger: OracleLoggerService) {
     const raw = (process.env.ALERTING_PROVIDER ?? 'none').toLowerCase();
     if (raw === 'pagerduty' || raw === 'opsgenie') {
@@ -44,39 +49,59 @@ export class AlertingService {
 
     this.pdRoutingKey = process.env.PAGERDUTY_ROUTING_KEY ?? '';
     this.opsgenieApiKey = process.env.OPSGENIE_API_KEY ?? '';
+    this.webhookUrl = process.env.ALERT_WEBHOOK_URL ?? '';
 
     if (this.provider !== 'none') {
       this.logger.log(`Alerting provider: ${this.provider}`);
     }
-  }
-
-  /** Fire (trigger) an alert. No-op when provider is "none". */
-  async fire(payload: AlertPayload): Promise<void> {
-    if (this.provider === 'none') return;
-
-    try {
-      if (this.provider === 'pagerduty') {
-        await this.pagerdutyTrigger(payload);
-      } else {
-        await this.opsgenieTrigger(payload);
-      }
-    } catch (err) {
-      this.logger.error(`Failed to fire alert "${payload.dedupKey}": ${(err as Error).message}`);
+    if (this.webhookUrl) {
+      this.logger.log('Alert webhook configured');
     }
   }
 
-  /** Resolve a previously fired alert. No-op when provider is "none". */
-  async resolve(dedupKey: string): Promise<void> {
-    if (this.provider === 'none') return;
-
-    try {
-      if (this.provider === 'pagerduty') {
-        await this.pagerdutyResolve(dedupKey);
-      } else {
-        await this.opsgenieResolve(dedupKey);
+  /** Fire (trigger) an alert. Dispatches to the configured provider and/or webhook. */
+  async fire(payload: AlertPayload): Promise<void> {
+    if (this.provider !== 'none') {
+      try {
+        if (this.provider === 'pagerduty') {
+          await this.pagerdutyTrigger(payload);
+        } else {
+          await this.opsgenieTrigger(payload);
+        }
+      } catch (err) {
+        this.logger.error(`Failed to fire alert "${payload.dedupKey}": ${(err as Error).message}`);
       }
-    } catch (err) {
-      this.logger.error(`Failed to resolve alert "${dedupKey}": ${(err as Error).message}`);
+    }
+
+    if (this.webhookUrl) {
+      try {
+        await this.webhookTrigger(payload);
+      } catch (err) {
+        this.logger.error(`Failed to POST alert webhook "${payload.dedupKey}": ${(err as Error).message}`);
+      }
+    }
+  }
+
+  /** Resolve a previously fired alert. Dispatches to the configured provider and/or webhook. */
+  async resolve(dedupKey: string): Promise<void> {
+    if (this.provider !== 'none') {
+      try {
+        if (this.provider === 'pagerduty') {
+          await this.pagerdutyResolve(dedupKey);
+        } else {
+          await this.opsgenieResolve(dedupKey);
+        }
+      } catch (err) {
+        this.logger.error(`Failed to resolve alert "${dedupKey}": ${(err as Error).message}`);
+      }
+    }
+
+    if (this.webhookUrl) {
+      try {
+        await this.webhookResolve(dedupKey);
+      } catch (err) {
+        this.logger.error(`Failed to POST alert-resolved webhook "${dedupKey}": ${(err as Error).message}`);
+      }
     }
   }
 
@@ -91,7 +116,10 @@ export class AlertingService {
         summary: payload.summary,
         severity: payload.severity === 'critical' ? 'critical' : 'warning',
         source: 'tikka-oracle',
-        custom_details: payload.details ? { details: payload.details } : undefined,
+        custom_details:
+          payload.details || payload.context
+            ? { details: payload.details, ...payload.context }
+            : undefined,
       },
     };
 
@@ -175,5 +203,67 @@ export class AlertingService {
     }
 
     this.logger.log(`Opsgenie alert resolved: ${dedupKey}`);
+  }
+
+  // ── Generic webhook (Slack-compatible) ──────────────────────────────────────
+
+  private async webhookTrigger(payload: AlertPayload): Promise<void> {
+    const fields = Object.entries(payload.context ?? {}).map(([title, value]) => ({
+      title,
+      value: String(value),
+      short: true,
+    }));
+
+    const body = {
+      text: `[${payload.severity.toUpperCase()}] ${payload.summary}`,
+      attachments: [
+        {
+          color: payload.severity === 'critical' ? '#e01e5a' : '#ecb22e',
+          fields,
+          text: payload.details,
+          footer: 'tikka-oracle',
+          ts: Math.floor(Date.now() / 1000),
+        },
+      ],
+    };
+
+    const res = await fetch(this.webhookUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`Alert webhook POST failed (${res.status}): ${text}`);
+    }
+
+    this.logger.warn(`Alert webhook posted: ${payload.dedupKey}`);
+  }
+
+  private async webhookResolve(dedupKey: string): Promise<void> {
+    const body = {
+      text: `[RESOLVED] ${dedupKey}`,
+      attachments: [
+        {
+          color: '#2eb886',
+          footer: 'tikka-oracle',
+          ts: Math.floor(Date.now() / 1000),
+        },
+      ],
+    };
+
+    const res = await fetch(this.webhookUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`Alert-resolved webhook POST failed (${res.status}): ${text}`);
+    }
+
+    this.logger.log(`Alert-resolved webhook posted: ${dedupKey}`);
   }
 }

--- a/oracle/src/health/health.controller.ts
+++ b/oracle/src/health/health.controller.ts
@@ -90,6 +90,8 @@ export class HealthController {
       },
       overallStatus: this.healthService.isHealthy() ? 'healthy' : this.healthService.isDegraded() ? 'degraded' : 'unhealthy',
     };
+  }
+
   @Get('metrics')
   async getMetrics() {
     return this.metricsService.getMetrics();

--- a/oracle/src/health/health.service.spec.ts
+++ b/oracle/src/health/health.service.spec.ts
@@ -1,9 +1,11 @@
 import { HealthService, ComponentStatus } from './health.service';
 import { CircuitBreakerService } from '../listener/circuit-breaker.service';
+import { OracleLoggerService } from '../logger/oracle-logger';
 
 describe('HealthService', () => {
   let service: HealthService;
   let circuitBreakerServiceMock: any;
+  let loggerMock: jest.Mocked<OracleLoggerService>;
 
   beforeEach(() => {
     circuitBreakerServiceMock = {
@@ -11,7 +13,8 @@ describe('HealthService', () => {
       getFailureCount: jest.fn().mockReturnValue(0),
       getLastFailureAt: jest.fn().mockReturnValue(null),
     };
-    service = new HealthService(circuitBreakerServiceMock as unknown as CircuitBreakerService);
+    loggerMock = { log: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() } as unknown as jest.Mocked<OracleLoggerService>;
+    service = new HealthService(loggerMock, circuitBreakerServiceMock as unknown as CircuitBreakerService);
   });
 
   describe('circuitState', () => {

--- a/oracle/src/health/health.service.ts
+++ b/oracle/src/health/health.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger, Inject, forwardRef } from '@nestjs/common';
+import { OracleLoggerService } from '../logger/oracle-logger';
 import { CircuitState } from '../listener/circuit-breaker.types';
 import { PriorityTier } from '../queue/priority-classifier.service';
 import { CircuitBreakerService } from '../listener/circuit-breaker.service';
@@ -73,8 +74,6 @@ export interface ErrorRecord {
 
 @Injectable()
 export class HealthService {
-  constructor(private readonly logger: OracleLoggerService) {}
-
   private readonly startTime = Date.now();
   private queueDepth = 0;
   private lastProcessedAt: Date | null = null;
@@ -89,6 +88,7 @@ export class HealthService {
   private tierCounts: Record<PriorityTier, number> = { HIGH: 0, MEDIUM: 0, LOW: 0 };
 
   constructor(
+    private readonly logger: OracleLoggerService,
     @Inject(forwardRef(() => CircuitBreakerService))
     private readonly circuitBreakerService: CircuitBreakerService,
   ) {}

--- a/oracle/src/keys/key-provider.factory.ts
+++ b/oracle/src/keys/key-provider.factory.ts
@@ -66,7 +66,7 @@ export class KeyProviderFactory {
       'For production, use AWS KMS or GCP KMS.',
     );
 
-    return new EnvKeyProvider(privateKey);
+    return new EnvKeyProvider(this.logger, privateKey);
   }
 
   private static createAwsKmsProvider(configService: ConfigService): AwsKmsKeyProvider {
@@ -80,7 +80,7 @@ export class KeyProviderFactory {
     }
 
     this.logger.log('Using AWS KMS for secure key management');
-    return new AwsKmsKeyProvider(region, keyId);
+    return new AwsKmsKeyProvider(this.logger, region, keyId);
   }
 
   private static createGcpKmsProvider(configService: ConfigService): GcpKmsKeyProvider {
@@ -94,6 +94,6 @@ export class KeyProviderFactory {
     }
 
     this.logger.log('Using Google Cloud KMS for secure key management');
-    return new GcpKmsKeyProvider(projectId, keyPath);
+    return new GcpKmsKeyProvider(this.logger, projectId, keyPath);
   }
 }

--- a/oracle/src/keys/key.service.integration.spec.ts
+++ b/oracle/src/keys/key.service.integration.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
 import { KeyService } from './key.service';
+import { OracleLoggerService } from '../logger/oracle-logger';
 import * as StellarSdk from '@stellar/stellar-sdk';
 
 describe('KeyService Integration', () => {
@@ -15,6 +16,7 @@ describe('KeyService Integration', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         KeyService,
+        { provide: OracleLoggerService, useValue: { log: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() } },
         {
           provide: ConfigService,
           useValue: {

--- a/oracle/src/keys/key.service.spec.ts
+++ b/oracle/src/keys/key.service.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
 import { KeyService } from './key.service';
 import { EnvKeyProvider } from './providers/env-key.provider';
+import { OracleLoggerService } from '../logger/oracle-logger';
 import * as StellarSdk from '@stellar/stellar-sdk';
 
 describe('KeyService', () => {
@@ -17,6 +18,7 @@ describe('KeyService', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         KeyService,
+        { provide: OracleLoggerService, useValue: { log: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() } },
         {
           provide: ConfigService,
           useValue: {

--- a/oracle/src/keys/providers/aws-kms-key.provider.spec.ts
+++ b/oracle/src/keys/providers/aws-kms-key.provider.spec.ts
@@ -2,6 +2,9 @@ import { AwsKmsKeyProvider } from './aws-kms-key.provider';
 import { KeyProviderError } from '../key-provider.error';
 import { ConfigService } from '@nestjs/config';
 import { KeyProviderFactory } from '../key-provider.factory';
+import { OracleLoggerService } from '../../logger/oracle-logger';
+
+const mockLogger = { log: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() } as unknown as OracleLoggerService;
 
 // Mock the AWS KMS client constructor and its commands
 jest.mock('@aws-sdk/client-kms', () => {
@@ -29,13 +32,13 @@ describe('AwsKmsKeyProvider', () => {
     jest.clearAllMocks();
     const awsKmsMock = require('@aws-sdk/client-kms');
     mockSend = awsKmsMock.__mockSend;
-    provider = new AwsKmsKeyProvider(mockRegion, mockKeyId);
+    provider = new AwsKmsKeyProvider(mockLogger, mockRegion, mockKeyId);
   });
 
   describe('constructor and config', () => {
     it('throws KeyProviderError if region or keyId is missing', () => {
-      expect(() => new AwsKmsKeyProvider('', mockKeyId)).toThrow(KeyProviderError);
-      expect(() => new AwsKmsKeyProvider(mockRegion, '')).toThrow(KeyProviderError);
+      expect(() => new AwsKmsKeyProvider(mockLogger, '', mockKeyId)).toThrow(KeyProviderError);
+      expect(() => new AwsKmsKeyProvider(mockLogger, mockRegion, '')).toThrow(KeyProviderError);
     });
 
     it('reads the correct AWS_KMS_KEY_ID from the config via KeyProviderFactory', () => {

--- a/oracle/src/keys/providers/gcp-kms-key.provider.spec.ts
+++ b/oracle/src/keys/providers/gcp-kms-key.provider.spec.ts
@@ -1,5 +1,7 @@
 import { GcpKmsKeyProvider } from './gcp-kms-key.provider';
+import { OracleLoggerService } from '../../logger/oracle-logger';
 
+const mockLogger = { log: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() } as unknown as OracleLoggerService;
 const mockGetPublicKey = jest.fn();
 const mockAsymmetricSign = jest.fn();
 const mockGetCryptoKeyVersion = jest.fn();
@@ -22,13 +24,13 @@ describe('GcpKmsKeyProvider', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    provider = new GcpKmsKeyProvider('test-project', testKeyPath);
+    provider = new GcpKmsKeyProvider(mockLogger, 'test-project', testKeyPath);
   });
 
   describe('initialization', () => {
     it('throws error if project ID or key path are missing', () => {
-      expect(() => new GcpKmsKeyProvider('', 'key-path')).toThrow();
-      expect(() => new GcpKmsKeyProvider('project', '')).toThrow();
+      expect(() => new GcpKmsKeyProvider(mockLogger, '', 'key-path')).toThrow();
+      expect(() => new GcpKmsKeyProvider(mockLogger, 'project', '')).toThrow();
     });
   });
 

--- a/oracle/src/listener/circuit-breaker.service.spec.ts
+++ b/oracle/src/listener/circuit-breaker.service.spec.ts
@@ -1,11 +1,16 @@
-import { Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { CircuitBreakerService } from './circuit-breaker.service';
 import { HealthService } from '../health/health.service';
+import { AlertingService } from '../health/alerting.service';
+import { OracleLoggerService } from '../logger/oracle-logger';
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+function makeLogger(): OracleLoggerService {
+  return { log: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() } as unknown as OracleLoggerService;
+}
 
 function makeConfigService(overrides: Record<string, string | undefined> = {}): ConfigService {
   return {
@@ -19,15 +24,29 @@ function makeHealthService(): jest.Mocked<HealthService> {
   } as unknown as jest.Mocked<HealthService>;
 }
 
+function makeAlertingService(): jest.Mocked<AlertingService> {
+  return {
+    fire: jest.fn().mockResolvedValue(undefined),
+    resolve: jest.fn().mockResolvedValue(undefined),
+  } as unknown as jest.Mocked<AlertingService>;
+}
+
 /** Build a CircuitBreakerService with a controllable clock. */
 function makeService(
   configOverrides: Record<string, string | undefined> = {},
   nowFn?: () => number,
-): { svc: CircuitBreakerService; health: jest.Mocked<HealthService> } {
+): {
+  svc: CircuitBreakerService;
+  health: jest.Mocked<HealthService>;
+  logger: jest.Mocked<OracleLoggerService>;
+  alerting: jest.Mocked<AlertingService>;
+} {
   const health = makeHealthService();
   const config = makeConfigService(configOverrides);
-  const svc = new CircuitBreakerService(config, health, nowFn);
-  return { svc, health };
+  const logger = makeLogger() as jest.Mocked<OracleLoggerService>;
+  const alerting = makeAlertingService();
+  const svc = new CircuitBreakerService(logger, config, health, alerting, nowFn);
+  return { svc, health, logger, alerting };
 }
 
 /** Drive the circuit from closed → open by recording N failures. */
@@ -41,9 +60,15 @@ function driveToOpen(svc: CircuitBreakerService, threshold: number): void {
 function driveToHalfOpen(
   threshold: number,
   resetTimeoutMs: number,
-): { svc: CircuitBreakerService; health: jest.Mocked<HealthService>; now: { value: number } } {
+): {
+  svc: CircuitBreakerService;
+  health: jest.Mocked<HealthService>;
+  now: { value: number };
+  logger: jest.Mocked<OracleLoggerService>;
+  alerting: jest.Mocked<AlertingService>;
+} {
   const now = { value: 0 };
-  const { svc, health } = makeService(
+  const { svc, health, logger, alerting } = makeService(
     {
       ORACLE_CB_FAILURE_THRESHOLD: String(threshold),
       ORACLE_CB_RESET_TIMEOUT_MS: String(resetTimeoutMs),
@@ -56,7 +81,7 @@ function driveToHalfOpen(
   const allowed = svc.canAttempt(); // triggers open → half-open transition
   expect(allowed).toBe(true);
   expect(svc.getState()).toBe('half-open');
-  return { svc, health, now };
+  return { svc, health, now, logger, alerting };
 }
 
 // ---------------------------------------------------------------------------
@@ -386,108 +411,94 @@ describe('CircuitBreakerService — config parsing', () => {
 // ---------------------------------------------------------------------------
 
 describe('CircuitBreakerService — logging', () => {
-  let warnSpy: jest.SpyInstance;
-  let logSpy: jest.SpyInstance;
-  let debugSpy: jest.SpyInstance;
-
-  beforeEach(() => {
-    warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => {});
-    logSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation(() => {});
-    debugSpy = jest.spyOn(Logger.prototype, 'debug').mockImplementation(() => {});
-  });
-
-  afterEach(() => {
-    jest.restoreAllMocks();
-  });
-
   it('emits warn log when closed → open', () => {
-    const { svc } = makeService({ ORACLE_CB_FAILURE_THRESHOLD: '2' });
+    const { svc, logger } = makeService({ ORACLE_CB_FAILURE_THRESHOLD: '2' });
     driveToOpen(svc, 2);
-    expect(warnSpy).toHaveBeenCalledTimes(1);
-    expect(warnSpy.mock.calls[0][0]).toMatch(/closed.*open|open.*closed/i);
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect((logger.warn as jest.Mock).mock.calls[0][0]).toMatch(/closed.*open|open.*closed/i);
   });
 
   it('warn log for closed → open includes threshold and resetTimeout', () => {
-    const { svc } = makeService({
+    const { svc, logger } = makeService({
       ORACLE_CB_FAILURE_THRESHOLD: '3',
       ORACLE_CB_RESET_TIMEOUT_MS: '30000',
     });
     driveToOpen(svc, 3);
-    const msg: string = warnSpy.mock.calls[0][0];
+    const msg: string = (logger.warn as jest.Mock).mock.calls[0][0];
     expect(msg).toContain('3');
     expect(msg).toContain('30000');
   });
 
   it('emits log (info) when open → half-open', () => {
     const now = { value: 0 };
-    const { svc } = makeService(
+    const { svc, logger } = makeService(
       { ORACLE_CB_FAILURE_THRESHOLD: '2', ORACLE_CB_RESET_TIMEOUT_MS: '1000' },
       () => now.value,
     );
     driveToOpen(svc, 2);
     now.value = 1000;
     svc.canAttempt();
-    expect(logSpy).toHaveBeenCalled();
-    const calls: string[] = logSpy.mock.calls.map((c) => c[0]);
+    expect(logger.log).toHaveBeenCalled();
+    const calls: string[] = (logger.log as jest.Mock).mock.calls.map((c) => c[0]);
     expect(calls.some((m) => /half.?open/i.test(m))).toBe(true);
   });
 
   it('emits log (info) when half-open → closed', () => {
-    const { svc } = driveToHalfOpen(2, 1000);
-    logSpy.mockClear();
+    const { svc, logger } = driveToHalfOpen(2, 1000);
+    (logger.log as jest.Mock).mockClear();
     svc.recordSuccess();
-    expect(logSpy).toHaveBeenCalled();
-    const calls: string[] = logSpy.mock.calls.map((c) => c[0]);
+    expect(logger.log).toHaveBeenCalled();
+    const calls: string[] = (logger.log as jest.Mock).mock.calls.map((c) => c[0]);
     expect(calls.some((m) => /closed|recover/i.test(m))).toBe(true);
   });
 
   it('emits warn log when half-open → open', () => {
-    const { svc } = driveToHalfOpen(2, 1000);
-    warnSpy.mockClear();
+    const { svc, logger } = driveToHalfOpen(2, 1000);
+    (logger.warn as jest.Mock).mockClear();
     svc.recordFailure();
-    expect(warnSpy).toHaveBeenCalled();
-    const calls: string[] = warnSpy.mock.calls.map((c) => c[0]);
+    expect(logger.warn).toHaveBeenCalled();
+    const calls: string[] = (logger.warn as jest.Mock).mock.calls.map((c) => c[0]);
     expect(calls.some((m) => /half.?open.*open|re.?open|probe.*fail/i.test(m))).toBe(true);
   });
 
   it('emits debug log when attempt is suppressed while open', () => {
     const now = { value: 0 };
-    const { svc } = makeService(
+    const { svc, logger } = makeService(
       { ORACLE_CB_FAILURE_THRESHOLD: '2', ORACLE_CB_RESET_TIMEOUT_MS: '60000' },
       () => now.value,
     );
     driveToOpen(svc, 2);
     now.value = 1000; // still within timeout
     svc.canAttempt();
-    expect(debugSpy).toHaveBeenCalled();
-    const calls: string[] = debugSpy.mock.calls.map((c) => c[0]);
+    expect(logger.debug).toHaveBeenCalled();
+    const calls: string[] = (logger.debug as jest.Mock).mock.calls.map((c) => c[0]);
     expect(calls.some((m) => /suppress|skip|open/i.test(m))).toBe(true);
   });
 
   it('debug log for suppressed attempt includes remaining cooldown', () => {
     const now = { value: 0 };
-    const { svc } = makeService(
+    const { svc, logger } = makeService(
       { ORACLE_CB_FAILURE_THRESHOLD: '2', ORACLE_CB_RESET_TIMEOUT_MS: '60000' },
       () => now.value,
     );
     driveToOpen(svc, 2);
     now.value = 10_000;
     svc.canAttempt();
-    const calls: string[] = debugSpy.mock.calls.map((c) => c[0]);
+    const calls: string[] = (logger.debug as jest.Mock).mock.calls.map((c) => c[0]);
     expect(calls.some((m) => m.includes('50000'))).toBe(true);
   });
 
   it('emits warn log for invalid ORACLE_CB_FAILURE_THRESHOLD', () => {
-    makeService({ ORACLE_CB_FAILURE_THRESHOLD: 'bad' });
-    expect(warnSpy).toHaveBeenCalled();
-    const calls: string[] = warnSpy.mock.calls.map((c) => c[0]);
+    const { logger } = makeService({ ORACLE_CB_FAILURE_THRESHOLD: 'bad' });
+    expect(logger.warn).toHaveBeenCalled();
+    const calls: string[] = (logger.warn as jest.Mock).mock.calls.map((c) => c[0]);
     expect(calls.some((m) => /ORACLE_CB_FAILURE_THRESHOLD/i.test(m))).toBe(true);
   });
 
   it('emits warn log for invalid ORACLE_CB_RESET_TIMEOUT_MS', () => {
-    makeService({ ORACLE_CB_RESET_TIMEOUT_MS: '0' });
-    expect(warnSpy).toHaveBeenCalled();
-    const calls: string[] = warnSpy.mock.calls.map((c) => c[0]);
+    const { logger } = makeService({ ORACLE_CB_RESET_TIMEOUT_MS: '0' });
+    expect(logger.warn).toHaveBeenCalled();
+    const calls: string[] = (logger.warn as jest.Mock).mock.calls.map((c) => c[0]);
     expect(calls.some((m) => /ORACLE_CB_RESET_TIMEOUT_MS/i.test(m))).toBe(true);
   });
 });
@@ -533,5 +544,57 @@ describe('CircuitBreakerService — getState() and getRemainingCooldownMs()', ()
     svc.recordFailure();
     now.value = 3_000;
     expect(svc.getRemainingCooldownMs()).toBe(7_000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Alerting — circuit breaker OPEN
+// ---------------------------------------------------------------------------
+
+describe('CircuitBreakerService — alerting', () => {
+  it('fires a critical alert when closed → open', () => {
+    const { svc, alerting } = makeService({ ORACLE_CB_FAILURE_THRESHOLD: '2' });
+    driveToOpen(svc, 2);
+
+    expect(alerting.fire).toHaveBeenCalledWith(
+      expect.objectContaining({
+        severity: 'critical',
+        summary: expect.stringContaining('Circuit breaker OPEN'),
+        dedupKey: 'circuit-breaker-open',
+        context: expect.objectContaining({ oracle_id: expect.any(String) }),
+      }),
+    );
+  });
+
+  it('fires a critical alert when half-open → open', () => {
+    const { svc, alerting } = driveToHalfOpen(2, 1000);
+    alerting.fire.mockClear();
+
+    svc.recordFailure();
+
+    expect(alerting.fire).toHaveBeenCalledWith(
+      expect.objectContaining({
+        severity: 'critical',
+        summary: expect.stringContaining('re-OPENED'),
+        dedupKey: 'circuit-breaker-open',
+      }),
+    );
+  });
+
+  it('does not fire an alert while below threshold', () => {
+    const { svc, alerting } = makeService({ ORACLE_CB_FAILURE_THRESHOLD: '5' });
+    svc.recordFailure();
+    svc.recordFailure();
+
+    expect(alerting.fire).not.toHaveBeenCalled();
+  });
+
+  it('resolves the alert when half-open → closed', () => {
+    const { svc, alerting } = driveToHalfOpen(2, 1000);
+    alerting.resolve.mockClear();
+
+    svc.recordSuccess();
+
+    expect(alerting.resolve).toHaveBeenCalledWith('circuit-breaker-open');
   });
 });

--- a/oracle/src/listener/circuit-breaker.service.ts
+++ b/oracle/src/listener/circuit-breaker.service.ts
@@ -3,8 +3,11 @@ import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { CircuitState } from './circuit-breaker.types';
 import { HealthService } from '../health/health.service';
+import { AlertingService } from '../health/alerting.service';
 
 export { CircuitState };
+
+const CIRCUIT_BREAKER_ALERT_DEDUP_KEY = 'circuit-breaker-open';
 
 export interface CircuitBreakerConfig {
   failureThreshold: number; // ORACLE_CB_FAILURE_THRESHOLD
@@ -14,7 +17,7 @@ export interface CircuitBreakerConfig {
 const DEFAULT_FAILURE_THRESHOLD = 5;
 const DEFAULT_RESET_TIMEOUT_MS = 60_000;
 
-function parsePositiveInt(raw: string | undefined, varName: string, logger: Logger, defaultValue: number): number {
+function parsePositiveInt(raw: string | undefined, varName: string, logger: OracleLoggerService, defaultValue: number): number {
   if (raw === undefined || raw === null || raw === '') {
     return defaultValue;
   }
@@ -44,6 +47,7 @@ export class CircuitBreakerService {
     private readonly logger: OracleLoggerService,
     private readonly configService: ConfigService,
     private readonly healthService: HealthService,
+    private readonly alertingService: AlertingService,
     nowFn?: () => number,
   ) {
     this.nowFn = nowFn ?? Date.now;
@@ -103,6 +107,7 @@ export class CircuitBreakerService {
     if (this.state === 'half-open') {
       this.state = 'closed';
       this.logger.log('Circuit transitioned half-open → closed. Connection recovered.');
+      void this.alertingService.resolve(CIRCUIT_BREAKER_ALERT_DEDUP_KEY);
     }
     // closed stays closed
     this.consecutiveFailures = 0;
@@ -127,6 +132,9 @@ export class CircuitBreakerService {
           `(threshold: ${this.config.failureThreshold}, resetTimeout: ${this.config.resetTimeoutMs}ms).`,
         );
         this.healthService.updateCircuitState('open');
+        this.fireCircuitOpenAlert(
+          `Circuit breaker OPEN after ${this.consecutiveFailures} consecutive failures`,
+        );
       }
       return;
     }
@@ -139,7 +147,22 @@ export class CircuitBreakerService {
         `Circuit transitioned half-open → open. Probe attempt failed. Circuit re-opened.`,
       );
       this.healthService.updateCircuitState('open');
+      this.fireCircuitOpenAlert('Circuit breaker re-OPENED after failed half-open probe');
     }
+  }
+
+  private fireCircuitOpenAlert(summary: string): void {
+    void this.alertingService.fire({
+      severity: 'critical',
+      summary,
+      details:
+        `threshold=${this.config.failureThreshold}, resetTimeoutMs=${this.config.resetTimeoutMs}, ` +
+        `consecutiveFailures=${this.consecutiveFailures}`,
+      dedupKey: CIRCUIT_BREAKER_ALERT_DEDUP_KEY,
+      context: {
+        oracle_id: process.env.LOCAL_ORACLE_ID || 'oracle-001',
+      },
+    });
   }
 
   /** Returns milliseconds until the open circuit transitions to half-open.

--- a/oracle/src/listener/event-listener.service.spec.ts
+++ b/oracle/src/listener/event-listener.service.spec.ts
@@ -6,7 +6,7 @@ import { LagMonitorService } from '../health/lag-monitor.service';
 import { RandomnessWorker } from '../queue/randomness.worker';
 import { CommitRevealWorker } from '../queue/commit-reveal.worker';
 import { CircuitBreakerService } from './circuit-breaker.service';
-import { Logger } from '@nestjs/common';
+import { OracleLoggerService } from '../logger/oracle-logger';
 
 // Compatibility Rules Documented Here:
 // 1. Versioning: Event payloads without a 'version' key or with 'version: 1' are considered supported.
@@ -25,7 +25,16 @@ describe('EventListenerService', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         EventListenerService,
-        { provide: ConfigService, useValue: { get: jest.fn().mockReturnValue('test') } },
+        { provide: OracleLoggerService, useValue: { log: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() } },
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn((key: string, defaultValue?: string) => {
+              if (key === 'HORIZON_URL') return 'https://horizon-testnet.stellar.org';
+              return defaultValue ?? 'test';
+            }),
+          },
+        },
         { provide: HealthService, useValue: { updateStreamStatus: jest.fn(), updateQueueDepth: jest.fn() } },
         { provide: LagMonitorService, useValue: { updateCurrentLedger: jest.fn(), trackRequest: jest.fn() } },
         { 
@@ -139,6 +148,8 @@ describe('EventListenerService', () => {
         expect(randomnessWorker.processRequest).toHaveBeenCalledWith({
           raffleId: 123,
           requestId: 'req_123',
+          stableRequestId: 'ledger:0:tx:unknown:event:0:raffle:123',
+          replayOverride: false,
           prizeAmount: 50, // 500000000 / 10_000_000
           priority: 1
         });

--- a/oracle/src/listener/event-listener.service.ts
+++ b/oracle/src/listener/event-listener.service.ts
@@ -8,6 +8,7 @@ import { CommitRevealWorker } from '../queue/commit-reveal.worker';
 import { HealthService } from '../health/health.service';
 import { LagMonitorService } from '../health/lag-monitor.service';
 import { CircuitBreakerService } from './circuit-breaker.service';
+import { DrawRequestLedgerService, DrawRequestIdentity } from './draw-request-ledger.service';
 import { InjectQueue } from '@nestjs/bull';
 import { Queue } from 'bull';
 import { RANDOMNESS_QUEUE, RandomnessJobPayload } from '../queue/randomness.queue';
@@ -164,7 +165,7 @@ export class EventListenerService implements OnModuleInit, OnModuleDestroy {
             }
 
         } catch (e: any) {
-            this.logger.error(`Error processing event: ${e.message}`, { event: eventResponse });
+            this.logger.error(`Error processing event: ${e.message}`, JSON.stringify({ event: eventResponse }));
         }
     }
 

--- a/oracle/src/multi-oracle/multi-oracle-coordinator-consensus.spec.ts
+++ b/oracle/src/multi-oracle/multi-oracle-coordinator-consensus.spec.ts
@@ -1,5 +1,8 @@
 import { MultiOracleCoordinatorService } from './multi-oracle-coordinator.service';
 import { RandomnessResult } from '../queue/queue.types';
+import { OracleLoggerService } from '../logger/oracle-logger';
+
+const mockLogger = { log: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() } as unknown as OracleLoggerService;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -47,7 +50,7 @@ describe('MultiOracleCoordinatorService - Consensus Validation', () => {
       return defaultValue;
     });
 
-    service = new MultiOracleCoordinatorService(registry as any, config as any);
+    service = new MultiOracleCoordinatorService(mockLogger, registry as any, config as any);
   });
 
   // -------------------------------------------------------------------------

--- a/oracle/src/multi-oracle/multi-oracle-coordinator.service.spec.ts
+++ b/oracle/src/multi-oracle/multi-oracle-coordinator.service.spec.ts
@@ -1,4 +1,7 @@
 import { MultiOracleCoordinatorService } from './multi-oracle-coordinator.service';
+import { OracleLoggerService } from '../logger/oracle-logger';
+
+const mockLogger = { log: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() } as unknown as OracleLoggerService;
 
 describe('MultiOracleCoordinatorService (Quorum)', () => {
   let service: MultiOracleCoordinatorService;
@@ -26,6 +29,7 @@ describe('MultiOracleCoordinatorService (Quorum)', () => {
     registry.getConsensusThreshold.mockReturnValue(1);
 
     service = new MultiOracleCoordinatorService(
+      mockLogger,
       registry as any,
       config as any,
     );

--- a/oracle/src/multi-oracle/oracle-registry.service.spec.ts
+++ b/oracle/src/multi-oracle/oracle-registry.service.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
 import { OracleRegistryService } from './oracle-registry.service';
 import { KeyService } from '../keys/key.service';
+import { OracleLoggerService } from '../logger/oracle-logger';
 import {
   OracleAuditEntry,
   OracleConfig,
@@ -58,6 +59,7 @@ describe('OracleRegistryService', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         OracleRegistryService,
+        { provide: OracleLoggerService, useValue: { log: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() } },
         { provide: ConfigService, useValue: configService },
         { provide: KeyService, useValue: keyService },
       ],

--- a/oracle/src/queue/job-state-manager.spec.ts
+++ b/oracle/src/queue/job-state-manager.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
 import { JobStateManager } from './job-state-manager';
 import { JobState, DEFAULT_QUEUE_CONFIG } from './job-state.types';
+import { OracleLoggerService } from '../logger/oracle-logger';
 
 describe('JobStateManager', () => {
   let manager: JobStateManager;
@@ -10,6 +11,7 @@ describe('JobStateManager', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         JobStateManager,
+        { provide: OracleLoggerService, useValue: { log: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() } },
         {
           provide: ConfigService,
           useValue: {

--- a/oracle/src/queue/job-state-manager.ts
+++ b/oracle/src/queue/job-state-manager.ts
@@ -39,7 +39,7 @@ export class JobStateManager {
   /**
    * Initialize a new job in the queued state.
    */
-  function initializeJob(requestId: string, raffleId: number): JobMetadata {
+  initializeJob(requestId: string, raffleId: number): JobMetadata {
     const now = Date.now();
     const metadata: JobMetadata = {
       requestId,
@@ -66,7 +66,7 @@ export class JobStateManager {
   /**
    * Transition a job to a new state with validation.
    */
-  function transitionState(
+  transitionState(
     requestId: string,
     toState: JobState,
     reason?: string,
@@ -125,7 +125,7 @@ export class JobStateManager {
   /**
    * Increment attempt count and check if job should be dead-lettered.
    */
-  function incrementAttempt(requestId: string): boolean {
+  incrementAttempt(requestId: string): boolean {
     const metadata = this.jobMetadata.get(requestId);
     if (!metadata) {
       return false;
@@ -148,14 +148,14 @@ export class JobStateManager {
   /**
    * Check if a job can acquire a processing slot based on concurrency limits.
    */
-  function canAcquireProcessingSlot(): boolean {
+  canAcquireProcessingSlot(): boolean {
     return this.activeProcessingCount < this.config.maxConcurrency;
   }
 
   /**
    * Calculate exponential backoff delay for retry.
    */
-  function calculateBackoff(attemptCount: number): number {
+  calculateBackoff(attemptCount: number): number {
     if (attemptCount <= 0) {
       return 0;
     }
@@ -169,7 +169,7 @@ export class JobStateManager {
   /**
    * Record transaction hash and ledger for a job.
    */
-  function recordTransactionResult(requestId: string, txHash: string, ledger: number): void {
+  recordTransactionResult(requestId: string, txHash: string, ledger: number): void {
     const metadata = this.jobMetadata.get(requestId);
     if (metadata) {
       metadata.txHash = txHash;
@@ -181,14 +181,14 @@ export class JobStateManager {
   /**
    * Get job metadata by request ID.
    */
-  function getJobMetadata(requestId: string): JobMetadata | undefined {
+  getJobMetadata(requestId: string): JobMetadata | undefined {
     return this.jobMetadata.get(requestId);
   }
 
   /**
    * Get all jobs in a specific state.
    */
-  function getJobsByState(state: JobState): JobMetadata[] {
+  getJobsByState(state: JobState): JobMetadata[] {
     return Array.from(this.jobMetadata.values()).filter(
       (metadata) => metadata.currentState === state,
     );
@@ -197,14 +197,14 @@ export class JobStateManager {
   /**
    * Get queue configuration.
    */
-  function getConfig(): QueueConfig {
+  getConfig(): QueueConfig {
     return { ...this.config };
   }
 
   /**
    * Get comprehensive queue metrics for operator visibility.
    */
-  function getMetrics(): QueueMetrics {
+  getMetrics(): QueueMetrics {
     const jobs = Array.from(this.jobMetadata.values());
 
     const queuedCount = jobs.filter((j) => j.currentState === JobState.QUEUED).length;
@@ -236,7 +236,7 @@ export class JobStateManager {
   /**
    * Clean up completed or terminal jobs older than retention period.
    */
-  function cleanupOldJobs(retentionMs: number = 3600000): number {
+  cleanupOldJobs(retentionMs: number = 3600000): number {
     const now = Date.now();
     let cleaned = 0;
 
@@ -298,14 +298,14 @@ export class JobStateManager {
   /**
    * Get active processing count for monitoring.
    */
-  function getActiveProcessingCount(): number {
+  getActiveProcessingCount(): number {
     return this.activeProcessingCount;
   }
 
   /**
    * Reset all state (for testing purposes).
    */
-  function reset(): void {
+  reset(): void {
     this.jobMetadata.clear();
     this.activeProcessingCount = 0;
     this.logger.log('JobStateManager reset');

--- a/oracle/src/queue/queue-health.controller.ts
+++ b/oracle/src/queue/queue-health.controller.ts
@@ -19,7 +19,7 @@ export class QueueHealthController {
    * @returns QueueMetrics with counts for all states and aggregated pending/failed counts
    */
   @Get('metrics')
-  function getMetrics(): QueueMetrics {
+  getMetrics(): QueueMetrics {
     const metrics = this.stateManager.getMetrics();
     this.logger.debug(`Queue metrics requested: ${JSON.stringify(metrics)}`);
     return metrics;
@@ -32,7 +32,7 @@ export class QueueHealthController {
    * @returns Health status object with key indicators
    */
   @Get('health')
-  function getHealth(): {
+  getHealth(): {
     status: 'healthy' | 'degraded' | 'unhealthy';
     pendingCount: number;
     failedCount: number;
@@ -76,7 +76,7 @@ export class QueueHealthController {
    * @returns Array of job metadata for jobs in the specified state
    */
   @Get('jobs/:state')
-  function getJobsByState(state: string): any[] {
+  getJobsByState(state: string): any[] {
     const jobState = state.toUpperCase().replace(/-/g, '_') as JobState;
     
     if (!Object.values(JobState).includes(jobState)) {
@@ -110,7 +110,7 @@ export class QueueHealthController {
    * @returns Array of dead-lettered job metadata
    */
   @Get('dead-letter')
-  function getDeadLetteredJobs(): any[] {
+  getDeadLetteredJobs(): any[] {
     const jobs = this.stateManager.getJobsByState(JobState.DEAD_LETTERED);
     
     this.logger.log(`Dead-lettered jobs query: ${jobs.length} jobs require rescue`);
@@ -138,7 +138,7 @@ export class QueueHealthController {
    * @returns Current queue configuration
    */
   @Get('config')
-  function getConfig(): any {
+  getConfig(): any {
     const config = this.stateManager.getConfig();
     return {
       ...config,

--- a/oracle/src/queue/randomness-processor.service.spec.ts
+++ b/oracle/src/queue/randomness-processor.service.spec.ts
@@ -10,6 +10,7 @@ import { PrngService } from '../randomness/prng.service';
 import { TxSubmitterService } from '../submitter/tx-submitter.service';
 import { HealthService } from '../health/health.service';
 import { LagMonitorService } from '../health/lag-monitor.service';
+import { OracleLoggerService } from '../logger/oracle-logger';
 
 describe('RandomnessProcessorService', () => {
   let processor: RandomnessProcessorService;
@@ -25,6 +26,7 @@ describe('RandomnessProcessorService', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         RandomnessProcessorService,
+        { provide: OracleLoggerService, useValue: { log: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() } },
         {
           provide: JobStateManager,
           useValue: {
@@ -159,7 +161,7 @@ describe('RandomnessProcessorService', () => {
 
       contractService.isRandomnessSubmitted.mockResolvedValue(false);
       contractService.getRaffleData.mockResolvedValue({ prizeAmount: 300 } as any);
-      prngService.compute.mockRejectedValue(new Error('Rate limit exceeded'));
+      prngService.compute.mockImplementation(() => { throw new Error('Rate limit exceeded'); });
 
       const result = await processor.processRequest(request);
 
@@ -345,7 +347,7 @@ describe('RandomnessProcessorService', () => {
 
       contractService.isRandomnessSubmitted.mockResolvedValue(false);
       contractService.getRaffleData.mockResolvedValue({ prizeAmount: 400 } as any);
-      prngService.compute.mockResolvedValue({ seed: 'seed-abc', proof: 'proof-abc' });
+      prngService.compute.mockReturnValue({ seed: 'seed-abc', proof: 'proof-abc' });
       txSubmitter.submitRandomness.mockRejectedValue(new Error('Malformed transaction'));
 
       const result = await processor.processRequest(request);
@@ -436,7 +438,7 @@ describe('RandomnessProcessorService', () => {
 
       contractService.isRandomnessSubmitted.mockResolvedValue(false);
       contractService.getRaffleData.mockResolvedValue({ prizeAmount: 300 } as any);
-      prngService.compute.mockRejectedValue(new Error('Service timeout'));
+      prngService.compute.mockImplementation(() => { throw new Error('Service timeout'); });
 
       await processor.processRequest(request);
 

--- a/oracle/src/queue/randomness-processor.service.ts
+++ b/oracle/src/queue/randomness-processor.service.ts
@@ -48,7 +48,7 @@ export class RandomnessProcessorService {
    * Process a randomness request through the complete lifecycle.
    * Returns a result indicating success, retry eligibility, and error details.
    */
-  async function processRequest(request: RandomnessRequest): Promise<ProcessingResult> {
+  async processRequest(request: RandomnessRequest): Promise<ProcessingResult> {
     const { requestId, raffleId } = request;
 
     // Initialize job if not already tracked

--- a/oracle/src/queue/randomness.worker.spec.ts
+++ b/oracle/src/queue/randomness.worker.spec.ts
@@ -1,5 +1,10 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { RandomnessWorker } from './randomness.worker';
+import { OracleLoggerService } from '../logger/oracle-logger';
+import { JobStateManager } from './job-state-manager';
+import { RandomnessProcessorService } from './randomness-processor.service';
+import { AuditLogService } from '../audit/audit-log.service';
+import { AlertingService } from '../health/alerting.service';
 import { ContractService } from '../contract/contract.service';
 import { VrfService } from '../randomness/vrf.service';
 import { PrngService } from '../randomness/prng.service';
@@ -21,11 +26,30 @@ describe('RandomnessWorker', () => {
   let lagMonitor: jest.Mocked<LagMonitorService>;
   let oracleRegistry: jest.Mocked<OracleRegistryService>;
   let multiOracleCoordinator: jest.Mocked<MultiOracleCoordinatorService>;
+  let stateManager: { incrementAttempt: jest.Mock; transitionState: jest.Mock; getConfig: jest.Mock; getMetrics: jest.Mock; calculateBackoff: jest.Mock; getJobMetadata: jest.Mock };
+  let processor: { processRequest: jest.Mock };
+  let alertingService: { fire: jest.Mock; resolve: jest.Mock };
 
   beforeEach(async () => {
+    stateManager = {
+      incrementAttempt: jest.fn().mockReturnValue(false),
+      transitionState: jest.fn(),
+      getConfig: jest.fn().mockReturnValue({ maxRetries: 5 }),
+      getMetrics: jest.fn().mockReturnValue({ deadLetteredCount: 0 }),
+      calculateBackoff: jest.fn().mockReturnValue(0),
+      getJobMetadata: jest.fn().mockReturnValue({ attemptCount: 1 }),
+    };
+    processor = { processRequest: jest.fn() };
+    alertingService = { fire: jest.fn().mockResolvedValue(undefined), resolve: jest.fn().mockResolvedValue(undefined) };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         RandomnessWorker,
+        { provide: OracleLoggerService, useValue: { log: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() } },
+        { provide: JobStateManager, useValue: stateManager },
+        { provide: RandomnessProcessorService, useValue: processor },
+        { provide: AuditLogService, useValue: { record: jest.fn().mockResolvedValue(undefined) } },
+        { provide: AlertingService, useValue: alertingService },
         {
           provide: ContractService,
           useValue: {
@@ -50,6 +74,7 @@ describe('RandomnessWorker', () => {
           provide: TxSubmitterService,
           useValue: {
             submitRandomness: jest.fn(),
+            keyService: { getPublicKey: jest.fn().mockResolvedValue('GORACLETESTADDRESS') },
           },
         },
         {
@@ -197,6 +222,42 @@ describe('RandomnessWorker', () => {
       expect(contractService.getRaffleData).toHaveBeenCalledWith(42);
       expect(vrfService.compute).toHaveBeenCalledWith('req-400-enqueued', 42);
       expect(prngService.compute).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handleRandomnessJob - DLQ depth alerting', () => {
+    const makeJob = (raffleId: number, requestId: string) => ({
+      id: `job-${requestId}`,
+      data: { raffleId, requestId, stableRequestId: `s-${requestId}`, replayOverride: false },
+      opts: {},
+    } as any);
+
+    beforeEach(() => {
+      processor.processRequest.mockResolvedValue({ success: false, shouldRetry: true, error: 'boom' });
+      stateManager.incrementAttempt.mockReturnValue(true); // always dead-letters
+    });
+
+    it('fires a critical alert once dead-lettered count reaches the threshold', async () => {
+      stateManager.getMetrics.mockReturnValue({ deadLetteredCount: 5 });
+
+      await expect(worker.handleRandomnessJob(makeJob(1, 'req-dlq-1'))).rejects.toThrow('Dead-lettered');
+
+      expect(alertingService.fire).toHaveBeenCalledWith(
+        expect.objectContaining({
+          severity: 'critical',
+          summary: expect.stringContaining('Dead-letter queue depth'),
+          dedupKey: 'dlq-depth-threshold',
+          context: expect.objectContaining({ raffle_id: 1 }),
+        }),
+      );
+    });
+
+    it('does not fire an alert while dead-lettered count is below the threshold', async () => {
+      stateManager.getMetrics.mockReturnValue({ deadLetteredCount: 1 });
+
+      await expect(worker.handleRandomnessJob(makeJob(2, 'req-dlq-2'))).rejects.toThrow('Dead-lettered');
+
+      expect(alertingService.fire).not.toHaveBeenCalled();
     });
   });
 });

--- a/oracle/src/queue/randomness.worker.ts
+++ b/oracle/src/queue/randomness.worker.ts
@@ -13,17 +13,21 @@ import { OracleRegistryService } from '../multi-oracle/oracle-registry.service';
 import { MultiOracleCoordinatorService } from '../multi-oracle/multi-oracle-coordinator.service';
 import { PriorityClassifierService } from './priority-classifier.service';
 import { AuditLogService } from '../audit/audit-log.service';
+import { AlertingService } from '../health/alerting.service';
 import { Processor, Process, OnQueueActive, OnQueueCompleted, OnQueueFailed } from '@nestjs/bull';
 import { Job } from 'bull';
 import { RANDOMNESS_QUEUE, RandomnessJobPayload } from './randomness.queue';
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 
+const DLQ_DEPTH_ALERT_DEDUP_KEY = 'dlq-depth-threshold';
+
 @Processor(RANDOMNESS_QUEUE)
 @Injectable()
 export class RandomnessWorker {
-  
+
   private readonly vrfThresholdXlm: number;
+  private readonly dlqDepthAlertThreshold: number;
   private readonly processedRequestIds = new Set<string>();
   private highPriorityJobStartTimes = new Map<string, number>();
 
@@ -41,9 +45,13 @@ export class RandomnessWorker {
     private readonly multiOracleCoordinator: MultiOracleCoordinatorService,
     private readonly configService: ConfigService,
     private readonly auditLogService: AuditLogService,
+    private readonly alertingService: AlertingService,
   ) {
     this.vrfThresholdXlm = Number(
       this.configService.get<string>('VRF_THRESHOLD_XLM', '500'),
+    );
+    this.dlqDepthAlertThreshold = Number(
+      this.configService.get<string>('DLQ_DEPTH_ALERT_THRESHOLD', '5'),
     );
   }
 
@@ -80,6 +88,7 @@ export class RandomnessWorker {
           `[DEAD-LETTER] Job ${job.id} for raffle ${job.data.raffleId}, request ${job.data.requestId} ` +
           `exhausted all retry attempts. Manual intervention required.`,
         );
+        this.checkDlqDepthAlert(job.data.raffleId);
         throw new Error(`Dead-lettered: ${result.error}`);
       } else {
         // Calculate backoff and schedule retry
@@ -109,6 +118,24 @@ export class RandomnessWorker {
 
   private delay(ms: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  /** Fires a critical alert when the dead-letter queue depth exceeds the configured threshold. */
+  private checkDlqDepthAlert(raffleId: number): void {
+    const deadLetteredCount = this.stateManager.getMetrics().deadLetteredCount;
+
+    if (deadLetteredCount >= this.dlqDepthAlertThreshold) {
+      void this.alertingService.fire({
+        severity: 'critical',
+        summary: `Dead-letter queue depth (${deadLetteredCount}) exceeds threshold (${this.dlqDepthAlertThreshold})`,
+        details: `Most recently dead-lettered job was for raffle ${raffleId}. Manual rescue intervention required.`,
+        dedupKey: DLQ_DEPTH_ALERT_DEDUP_KEY,
+        context: {
+          oracle_id: process.env.LOCAL_ORACLE_ID || 'oracle-001',
+          raffle_id: raffleId,
+        },
+      });
+    }
   }
 
   clearProcessedCache() {

--- a/oracle/src/randomness/vrf.service.ts
+++ b/oracle/src/randomness/vrf.service.ts
@@ -8,6 +8,9 @@ import * as crypto from 'crypto';
 import { IVrfProvider, VrfAlgorithm } from './vrf.interface';
 import { Ed25519Sha256VrfProvider } from './ed25519-sha256.vrf-provider';
 import { MetricsService } from '../metrics/metrics.service';
+import { AlertingService } from '../health/alerting.service';
+
+const VRF_KEY_UNAVAILABLE_ALERT_DEDUP_KEY = 'vrf-key-unavailable';
 
 /**
  * VrfService — Verifiable Random Function computation for high-stakes raffles.
@@ -32,6 +35,7 @@ export class VrfService {
     private readonly keyService: KeyService,
     private readonly oracleRegistry: OracleRegistryService,
     private readonly metricsService: MetricsService,
+    private readonly alertingService: AlertingService,
   ) {
     this.ed25519Provider = new Ed25519Sha256VrfProvider(keyService, metricsService);
   }
@@ -44,7 +48,24 @@ export class VrfService {
    *                   with the same requestId still produce distinct seeds.
    */
   async compute(requestId: string, raffleId?: number): Promise<RandomnessResult> {
-    return this.ed25519Provider.compute(requestId, raffleId);
+    try {
+      const result = await this.ed25519Provider.compute(requestId, raffleId);
+      void this.alertingService.resolve(VRF_KEY_UNAVAILABLE_ALERT_DEDUP_KEY);
+      return result;
+    } catch (error: any) {
+      void this.alertingService.fire({
+        severity: 'critical',
+        summary: 'VRF signing key unavailable',
+        details: error?.message || String(error),
+        dedupKey: VRF_KEY_UNAVAILABLE_ALERT_DEDUP_KEY,
+        context: {
+          oracle_id: process.env.LOCAL_ORACLE_ID || 'oracle-001',
+          raffle_id: raffleId,
+          request_id: requestId,
+        },
+      });
+      throw error;
+    }
   }
 
   /**

--- a/oracle/src/rescue/rescue.cli.ts
+++ b/oracle/src/rescue/rescue.cli.ts
@@ -15,7 +15,6 @@
  *   npm run oracle:rescue logs [--raffle <raffleId>] [--limit <n>]
  */
 
-import { fileURLToPath, pathToFileURL } from 'url';
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from '../app.module';
 import { RescueService } from './rescue.service';
@@ -209,7 +208,7 @@ function printStuckDrawReport(report: StuckDrawReport, jsonMode: boolean): void 
 }
 
 async function main() {
-  const { command, args, options } = parseArgs();
+  const { command, args, options } = parseArgs(process.argv.slice(2));
 
   if (!command || command === 'help' || command === '--help' || command === '-h') {
     printUsage();
@@ -262,9 +261,9 @@ export async function executeRescueCommand(
 
       console.log('DRY RUN: Re-enqueue operation will not be applied unless --execute is provided.');
       console.log('Action: Re-enqueue job');
-      console.log(`Target Job ID: ${preview.preview.jobId}`);
-      console.log(`Target Raffle ID: ${preview.preview.raffleId}`);
-      console.log(`Target Request ID: ${preview.preview.requestId}`);
+      console.log(`Target Job ID: ${preview.preview!.jobId}`);
+      console.log(`Target Raffle ID: ${preview.preview!.raffleId}`);
+      console.log(`Target Request ID: ${preview.preview!.requestId}`);
       console.log(`Operator: ${operator}`);
       console.log(`Reason: ${reason}`);
 
@@ -281,37 +280,21 @@ export async function executeRescueCommand(
         return 0;
       }
 
-      case 'list-stuck': {
-        const jsonMode = options.json === 'true';
-        if (!jsonMode) {
-          console.log('Building stuck draw report...\n');
-        }
-        const report = await rescueService.getStuckDrawReport();
-        printStuckDrawReport(report, jsonMode);
-        if (report.summary.stuck > 0 && !jsonMode) {
-          process.exitCode = 2;
-        }
-        break;
-      }
+      console.error(`✗ Failed: ${result.message}`);
+      return 1;
+    }
 
-      case 'list-all': {
-        console.log('Fetching all jobs...\n');
-        const allJobs = await rescueService.getAllJobs();
-        
-        console.log(`Waiting: ${allJobs.waiting.length}`);
-        console.log(`Active: ${allJobs.active.length}`);
-        console.log(`Completed: ${allJobs.completed.length}`);
-        console.log(`Failed: ${allJobs.failed.length}`);
-        console.log(`Delayed: ${allJobs.delayed.length}`);
-        console.log('');
+    case 'force-submit': {
+      const raffleId = parseInt(args[0], 10);
+      const requestId = args[1];
+      const operator = options.operator;
+      const reason = options.reason;
+      const prizeAmount = options.prize ? parseFloat(options.prize) : undefined;
 
-        if (allJobs.failed.length > 0) {
-          console.log('Failed Jobs:');
-          allJobs.failed.forEach((job) => {
-            console.log(`  ${job.id} - Raffle ${job.raffleId} - ${job.failedReason || 'Unknown error'}`);
-          });
-        }
-        break;
+      if (!raffleId || !requestId || !operator || !reason) {
+        console.error('Error: Missing required arguments');
+        console.error('Usage: npm run oracle:rescue force-submit <raffleId> <requestId> --operator <name> --reason <reason> [--prize <amount>]');
+        return 1;
       }
 
       const preview = await rescueService.getForceSubmitPreview(
@@ -326,18 +309,18 @@ export async function executeRescueCommand(
 
       console.log('DRY RUN: Force-submit operation will not be applied unless --execute is provided.');
       console.log('Action: Force submit randomness');
-      console.log(`Target Raffle ID: ${preview.preview.raffleId}`);
-      console.log(`Target Request ID: ${preview.preview.requestId}`);
-      console.log(`Network: ${getNetworkName(preview.preview.network)}`);
-      console.log(`Source Account: ${preview.preview.sourceAccount}`);
-      console.log(`Randomness Method: ${preview.preview.method}`);
+      console.log(`Target Raffle ID: ${preview.preview!.raffleId}`);
+      console.log(`Target Request ID: ${preview.preview!.requestId}`);
+      console.log(`Network: ${getNetworkName(preview.preview!.network)}`);
+      console.log(`Source Account: ${preview.preview!.sourceAccount}`);
+      console.log(`Randomness Method: ${preview.preview!.method}`);
       console.log(
-        `Estimated Fee: ${preview.preview.feeEstimate.cappedFee} stroops (${formatStroopsAsXlm(
-          preview.preview.feeEstimate.cappedFee,
+        `Estimated Fee: ${preview.preview!.feeEstimate.cappedFee} stroops (${formatStroopsAsXlm(
+          preview.preview!.feeEstimate.cappedFee,
         )})`,
       );
-      console.log(`Prize Amount: ${preview.preview.prizeAmount} XLM`);
-      console.log(`RPC Endpoint: ${preview.preview.rpcUrl}`);
+      console.log(`Prize Amount: ${preview.preview!.prizeAmount} XLM`);
+      console.log(`RPC Endpoint: ${preview.preview!.rpcUrl}`);
       console.log(`Operator: ${operator}`);
       console.log(`Reason: ${reason}`);
 
@@ -383,9 +366,9 @@ export async function executeRescueCommand(
 
       console.log('DRY RUN: Force-fail operation will not be applied unless --execute is provided.');
       console.log('Action: Force fail job');
-      console.log(`Target Job ID: ${preview.preview.jobId}`);
-      console.log(`Target Raffle ID: ${preview.preview.raffleId}`);
-      console.log(`Target Request ID: ${preview.preview.requestId}`);
+      console.log(`Target Job ID: ${preview.preview!.jobId}`);
+      console.log(`Target Raffle ID: ${preview.preview!.raffleId}`);
+      console.log(`Target Request ID: ${preview.preview!.requestId}`);
       console.log(`Operator: ${operator}`);
       console.log(`Reason: ${reason}`);
 
@@ -446,6 +429,19 @@ export async function executeRescueCommand(
       return 0;
     }
 
+    case 'list-stuck': {
+      const jsonMode = options.json === 'true';
+      if (!jsonMode) {
+        console.log('Building stuck draw report...\n');
+      }
+      const report = await rescueService.getStuckDrawReport();
+      printStuckDrawReport(report, jsonMode);
+      if (report.summary.stuck > 0 && !jsonMode) {
+        process.exitCode = 2;
+      }
+      return 0;
+    }
+
     case 'logs': {
       const raffleId = options.raffle ? parseInt(options.raffle, 10) : null;
       const limit = options.limit ? parseInt(options.limit, 10) : 100;
@@ -480,9 +476,6 @@ export async function executeRescueCommand(
   }
 }
 
-const isDirectExecution =
-  process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url;
-
-if (isDirectExecution) {
-  runRescueCli(process.argv.slice(2)).then((code) => process.exit(code));
+if (require.main === module) {
+  main().then((code) => process.exit(code));
 }

--- a/oracle/src/rescue/rescue.service.spec.ts
+++ b/oracle/src/rescue/rescue.service.spec.ts
@@ -8,6 +8,7 @@ import { PrngService } from '../randomness/prng.service';
 import { TxSubmitterService } from '../submitter/tx-submitter.service';
 import { LagMonitorService } from '../health/lag-monitor.service';
 import { HealthService } from '../health/health.service';
+import { OracleLoggerService } from '../logger/oracle-logger';
 
 describe('RescueService', () => {
   let service: RescueService;
@@ -81,6 +82,7 @@ describe('RescueService', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         RescueService,
+        { provide: OracleLoggerService, useValue: { log: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() } },
         {
           provide: getQueueToken(RANDOMNESS_QUEUE),
           useValue: mockQueue,

--- a/oracle/src/rescue/rescue.service.ts
+++ b/oracle/src/rescue/rescue.service.ts
@@ -1,4 +1,4 @@
-import { OracleLoggerService } from '../logger/oracle-logger';
+import { OracleLoggerService, OracleLogFields } from '../logger/oracle-logger';
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectQueue } from '@nestjs/bull';
 import { Queue, Job } from 'bull';

--- a/oracle/src/submitter/cost-estimator.example.ts
+++ b/oracle/src/submitter/cost-estimator.example.ts
@@ -15,15 +15,17 @@ import { ConfigService } from '@nestjs/config';
 import { CostEstimatorService } from './cost-estimator.service';
 import { FeeEstimatorService } from './fee-estimator.service';
 import { MetricsService } from '../metrics/metrics.service';
+import { OracleLoggerService } from '../logger/oracle-logger';
 
 async function main() {
   console.log('🔮 Oracle Cost Estimator Example\n');
 
   // Initialize services
+  const logger = new OracleLoggerService();
   const configService = new ConfigService();
-  const feeEstimator = new FeeEstimatorService(configService);
+  const feeEstimator = new FeeEstimatorService(logger, configService);
   const metricsService = new MetricsService();
-  const costEstimator = new CostEstimatorService(configService, feeEstimator, metricsService);
+  const costEstimator = new CostEstimatorService(logger, configService, feeEstimator, metricsService);
 
   // Example 1: Estimate monthly costs for different volumes
   console.log('📊 Example 1: Monthly Cost Estimates\n');

--- a/oracle/src/submitter/cost-estimator.service.spec.ts
+++ b/oracle/src/submitter/cost-estimator.service.spec.ts
@@ -3,6 +3,7 @@ import { ConfigService } from '@nestjs/config';
 import { CostEstimatorService } from './cost-estimator.service';
 import { FeeEstimatorService } from './fee-estimator.service';
 import { MetricsService } from '../metrics/metrics.service';
+import { OracleLoggerService } from '../logger/oracle-logger';
 
 describe('CostEstimatorService', () => {
   let service: CostEstimatorService;
@@ -23,6 +24,7 @@ describe('CostEstimatorService', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         CostEstimatorService,
+        { provide: OracleLoggerService, useValue: { log: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() } },
         {
           provide: ConfigService,
           useValue: {

--- a/oracle/src/submitter/tx-submitter.service.spec.ts
+++ b/oracle/src/submitter/tx-submitter.service.spec.ts
@@ -2,7 +2,9 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
 import { TxSubmitterService, TransactionOutcome, TransactionState } from './tx-submitter.service';
 import { FeeEstimatorService } from './fee-estimator.service';
+import { CostEstimatorService } from './cost-estimator.service';
 import { KeyService } from '../keys/key.service';
+import { OracleLoggerService } from '../logger/oracle-logger';
 
 describe('TxSubmitterService', () => {
   let service: TxSubmitterService;
@@ -55,9 +57,18 @@ describe('TxSubmitterService', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         TxSubmitterService,
+        { provide: OracleLoggerService, useValue: { log: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() } },
         { provide: ConfigService, useValue: mockConfigService },
         { provide: FeeEstimatorService, useValue: mockFeeEstimator },
         { provide: KeyService, useValue: mockKeyService },
+        {
+          provide: CostEstimatorService,
+          useValue: {
+            recordRevealCost: jest.fn(),
+            recordSubmissionRetry: jest.fn(),
+            recordSubmissionFailure: jest.fn(),
+          },
+        },
       ],
     }).compile();
 
@@ -90,8 +101,10 @@ describe('TxSubmitterService', () => {
       const outcome = await service.submitRandomnessTyped(100, 'req-1', randomness);
 
       expect(outcome.status).toBe('SUCCESS');
-      expect(outcome.txHash).toBe(txHash);
-      expect(outcome.ledger).toBe(ledger);
+      if (outcome.status === 'SUCCESS') {
+        expect(outcome.txHash).toBe(txHash);
+        expect(outcome.ledger).toBe(ledger);
+      }
       expect(outcome.retriable).toBe(false);
       expect(mockRpcServer.sendTransaction).toHaveBeenCalledTimes(1);
       expect(mockRpcServer.getTransaction).toHaveBeenCalled();
@@ -138,8 +151,10 @@ describe('TxSubmitterService', () => {
       const outcome = await service.submitRandomnessTyped(102, 'req-3', randomness);
 
       expect(outcome.status).toBe('SUCCESS');
-      expect(outcome.txHash).toBe(txHash);
-      expect(outcome.ledger).toBe(ledger);
+      if (outcome.status === 'SUCCESS') {
+        expect(outcome.txHash).toBe(txHash);
+        expect(outcome.ledger).toBe(ledger);
+      }
       expect(mockRpcServer.getTransaction).toHaveBeenCalledWith(txHash);
       expect(mockRpcServer.getTransaction).toHaveBeenCalledTimes(3);
     });
@@ -434,7 +449,7 @@ describe('TxSubmitterService', () => {
 
       const logCalls = logSpy.mock.calls;
       const finalLog = logCalls[logCalls.length - 1][0];
-      const logEntry = JSON.parse(finalLog);
+      const logEntry = JSON.parse(finalLog as string);
 
       expect(logEntry).toHaveProperty('txHash');
       expect(logEntry).toHaveProperty('raffleId', 119);

--- a/oracle/src/submitter/tx-submitter.service.ts
+++ b/oracle/src/submitter/tx-submitter.service.ts
@@ -1,4 +1,4 @@
-import { OracleLoggerService } from '../logger/oracle-logger';
+import { OracleLoggerService, OracleLogFields } from '../logger/oracle-logger';
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import * as StellarSdk from '@stellar/stellar-sdk';
@@ -6,6 +6,7 @@ import { RandomnessResult } from '../queue/queue.types';
 import { FeeEstimatorService, FeeEstimate } from './fee-estimator.service';
 import { KeyService } from '../keys/key.service';
 import { CostEstimatorService } from './cost-estimator.service';
+import { ContractBuilders } from '../contract/contract.builders';
 
 /**
  * Explicit transaction lifecycle states for state machine tracking
@@ -224,7 +225,7 @@ export class TxSubmitterService {
           if (submitResult.outcome) {
             telemetry.durationMs = Date.now() - startTime;
             telemetry.finalOutcome = this.mapOutcomeToState(submitResult.outcome);
-            telemetry.txHash = submitResult.outcome.txHash;
+            telemetry.txHash = 'txHash' in submitResult.outcome ? submitResult.outcome.txHash : undefined;
             this.logTelemetry(telemetry, `Transaction completed: ${submitResult.outcome.status}`);
             return submitResult.outcome;
           }
@@ -746,7 +747,7 @@ export class TxSubmitterService {
     }
 
     return {
-      txHash: outcome.txHash || '',
+      txHash: ('txHash' in outcome ? outcome.txHash : undefined) || '',
       ledger: 0,
       success: false,
     };
@@ -861,102 +862,6 @@ export class TxSubmitterService {
       attempt,
       lastError,
       `Persistent failure calling ${method} after ${attempt} attempts.`,
-    );
-    return { txHash: '', ledger: 0, success: false };
-  }
-
-  async submitRandomness(raffleId: number, randomness: RandomnessResult): Promise<SubmitResult> {
-    if (!this.contractId) {
-      this.logger.error('Missing configuration for TxSubmitter (RAFFLE_CONTRACT_ID).');
-      return { txHash: '', ledger: 0, success: false };
-    }
-
-    const publicKey = await this.keyService.getPublicKey();
-
-    let attempt = 0;
-    let lastError: unknown = null;
-    let feeBump = 1;
-
-    // Get initial fee estimate from network stats
-    const feeEstimate = await this.feeEstimator.estimateFee(0);
-    this.logger.log(
-      `Submitting randomness for raffle ${raffleId} with fee ${feeEstimate.cappedFee} stroops ` +
-      `(p95: ${feeEstimate.priorityFee}, capped: ${feeEstimate.isCapped})`,
-      JSON.stringify({ raffle_id: raffleId } as OracleLogFields),
-    );
-
-    while (attempt < this.maxAttempts) {
-      attempt++;
-      try {
-        const prepared = await this.buildPreparedTx(publicKey, raffleId, randomness, feeBump);
-        await this.keyService.signTransaction(prepared);
-
-        const sendRes = await this.rpcServer.sendTransaction(prepared);
-        const txHash = sendRes.hash || sendRes?.transactionHash || '';
-
-        if (!txHash) {
-          const msg = JSON.stringify(sendRes);
-          if (this.isInsufficientFeeError(msg)) {
-            feeBump = Math.max(feeBump * 2, feeBump + 1);
-            this.costEstimator.recordSubmissionRetry(raffleId, 'VRF');
-            await this.logRetryAndBackoff('receive_randomness', attempt, msg);
-            continue;
-          }
-          lastError = new Error('sendTransaction returned no hash');
-          await this.logRetryAndBackoff('receive_randomness', attempt, lastError);
-          continue;
-        }
-
-        const confirm = await this.pollForConfirmation(txHash);
-        if (confirm?.status === 'SUCCESS') {
-          const ledger = (confirm.ledger as number) || (confirm.latestLedger as number) || 0;
-          const feePaid = Number(confirm.feeCharged) || (Number((StellarSdk as any).BASE_FEE || 100) * feeBump);
-          this.costEstimator.recordRevealCost(raffleId, 'VRF', feePaid);
-          return { txHash, ledger, success: true, feePaid };
-        }
-
-        if (confirm && this.isInsufficientFeeError(JSON.stringify(confirm))) {
-          feeBump = Math.max(feeBump * 2, feeBump + 1);
-          this.costEstimator.recordSubmissionRetry(raffleId, 'VRF');
-          await this.logRetryAndBackoff('receive_randomness', attempt, JSON.stringify(confirm));
-          continue;
-        }
-
-        lastError = new Error(
-          `Transaction failed or not confirmed (status=${confirm?.status || 'UNKNOWN'})`,
-        );
-        if (!this.isRetriableError(lastError, JSON.stringify(confirm))) {
-          this.costEstimator.recordSubmissionFailure(raffleId, 'VRF', JSON.stringify(confirm));
-          break;
-        }
-        await this.logRetryAndBackoff('receive_randomness', attempt, lastError);
-      } catch (e: any) {
-        const msg = e?.message || String(e);
-        if (this.isRpcError(msg)) {
-          this.failoverRpc();
-        } else if (this.isInsufficientFeeError(msg)) {
-          feeBump = Math.max(feeBump * 2, feeBump + 1);
-          this.costEstimator.recordSubmissionRetry(raffleId, 'VRF');
-        }
-        this.logger.error(
-          `Error submitting randomness (attempt ${attempt}/${this.maxAttempts}): ${msg}`,
-          JSON.stringify({ raffle_id: raffleId, attempt, outcome: 'failure' } as OracleLogFields),
-        );
-        lastError = e;
-        if (!this.isRetriableError(e, msg)) {
-          this.costEstimator.recordSubmissionFailure(raffleId, 'VRF', msg);
-          break;
-        }
-        await this.logRetryAndBackoff('receive_randomness', attempt, lastError);
-      }
-    }
-
-    await this.handleFinalFailure(
-      'receive_randomness',
-      attempt,
-      lastError,
-      `Persistent failure submitting randomness for raffle ${raffleId} after ${attempt} attempts.`,
-      { raffle_id: raffleId },
     );
     return { txHash: '', ledger: 0, success: false };
   }

--- a/oracle/src/subscriber/stellar-subscriber.service.spec.ts
+++ b/oracle/src/subscriber/stellar-subscriber.service.spec.ts
@@ -1,6 +1,11 @@
 import { StellarSubscriberService } from './stellar-subscriber.service';
 import { ConfigService } from '@nestjs/config';
 import { HealthService } from '../health/health.service';
+import { OracleLoggerService } from '../logger/oracle-logger';
+
+function makeLogger(): OracleLoggerService {
+  return { log: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() } as unknown as OracleLoggerService;
+}
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -23,7 +28,7 @@ function makeConfigService(url = 'https://horizon-testnet.stellar.org'): ConfigS
 function buildService(horizonOverride?: any) {
   const health = makeHealthService();
   const config = makeConfigService();
-  const service = new StellarSubscriberService(config, health);
+  const service = new StellarSubscriberService(makeLogger(), config, health);
 
   if (horizonOverride) {
     (service as any).horizonServer = horizonOverride;

--- a/oracle/src/subscriber/stellar-subscriber.service.ts
+++ b/oracle/src/subscriber/stellar-subscriber.service.ts
@@ -168,7 +168,7 @@ export class StellarSubscriberService implements OnModuleInit, OnModuleDestroy {
     let count = 0;
 
     try {
-      let page: Horizon.Server.CollectionPage<Horizon.HorizonApi.TransactionResponse> =
+      let page: Horizon.ServerApi.CollectionPage<Horizon.ServerApi.TransactionRecord> =
         await this.horizonServer
           .transactions()
           .cursor(fromCursor)

--- a/oracle/test/audit-integration.spec.ts
+++ b/oracle/test/audit-integration.spec.ts
@@ -3,6 +3,7 @@ import { AuditLogService } from '../src/audit/audit-log.service';
 import { AuditController } from '../src/audit/audit.controller';
 import { SUPABASE_CLIENT } from '../src/audit/supabase.provider';
 import { RecordSubmissionParams, VrfAuditRecord } from '../src/audit/audit.types';
+import { OracleLoggerService } from '../src/logger/oracle-logger';
 
 describe('Audit Integration Test', () => {
   let auditLogService: AuditLogService;
@@ -26,6 +27,7 @@ describe('Audit Integration Test', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         AuditLogService,
+        { provide: OracleLoggerService, useValue: { log: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() } },
         {
           provide: SUPABASE_CLIENT,
           useValue: mockSupabase,
@@ -59,10 +61,6 @@ describe('Audit Integration Test', () => {
       supabaseClient.single.mockResolvedValueOnce({
         data: null,
         error: { code: 'PGRST116' },
-      });
-      supabaseClient.single.mockResolvedValueOnce({
-        data: null,
-        error: null,
       });
       supabaseClient.insert.mockResolvedValue({ error: null });
 
@@ -105,7 +103,7 @@ describe('Audit Integration Test', () => {
       });
 
       // Retrieve via controller
-      const result = await auditController.getAuditByQuery('456');
+      const result = await auditController.getAuditByQuery('456') as VrfAuditRecord;
 
       expect(result).toEqual(mockRecord);
       expect(result.tx_hash).toBe('0x123abc');

--- a/oracle/test/commitment.service.spec.ts
+++ b/oracle/test/commitment.service.spec.ts
@@ -1,11 +1,12 @@
 import { CommitmentService } from '../src/randomness/commitment.service';
+import { OracleLoggerService } from '../src/logger/oracle-logger';
 import * as crypto from 'crypto';
 
 describe('CommitmentService', () => {
   let service: CommitmentService;
 
   beforeEach(() => {
-    service = new CommitmentService();
+    service = new CommitmentService({ log: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() } as unknown as OracleLoggerService);
   });
 
   describe('commit', () => {

--- a/oracle/test/draw-request-ledger.service.spec.ts
+++ b/oracle/test/draw-request-ledger.service.spec.ts
@@ -5,6 +5,7 @@ import {
   DrawRequestIdentity,
   DrawRequestClaimResult,
 } from "../src/listener/draw-request-ledger.service";
+import { OracleLoggerService } from "../src/logger/oracle-logger";
 
 /**
  * Unit tests for DrawRequestLedgerService
@@ -49,6 +50,7 @@ describe("DrawRequestLedgerService", () => {
       const module: TestingModule = await Test.createTestingModule({
         providers: [
           DrawRequestLedgerService,
+          { provide: OracleLoggerService, useValue: { log: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() } },
           { provide: ConfigService, useValue: mockConfigService },
         ],
       }).compile();
@@ -172,6 +174,7 @@ describe("DrawRequestLedgerService", () => {
       const module: TestingModule = await Test.createTestingModule({
         providers: [
           DrawRequestLedgerService,
+          { provide: OracleLoggerService, useValue: { log: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() } },
           { provide: ConfigService, useValue: mockConfigService },
         ],
       }).compile();
@@ -200,6 +203,7 @@ describe("DrawRequestLedgerService", () => {
       const module: TestingModule = await Test.createTestingModule({
         providers: [
           DrawRequestLedgerService,
+          { provide: OracleLoggerService, useValue: { log: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() } },
           { provide: ConfigService, useValue: mockConfigService },
         ],
       }).compile();
@@ -259,6 +263,7 @@ describe("DrawRequestLedgerService", () => {
       const module: TestingModule = await Test.createTestingModule({
         providers: [
           DrawRequestLedgerService,
+          { provide: OracleLoggerService, useValue: { log: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() } },
           { provide: ConfigService, useValue: mockConfigService },
         ],
       }).compile();

--- a/oracle/test/event-listener.service.spec.ts
+++ b/oracle/test/event-listener.service.spec.ts
@@ -10,6 +10,7 @@ import { LagMonitorService } from '../src/health/lag-monitor.service';
 import { CommitRevealWorker } from '../src/queue/commit-reveal.worker';
 import { DrawRequestLedgerService } from '../src/listener/draw-request-ledger.service';
 import { CircuitBreakerService } from '../src/listener/circuit-breaker.service';
+import { OracleLoggerService } from '../src/logger/oracle-logger';
 
 // ─── Constants ───────────────────────────────────────────────────────────────
 const RAFFLE_CONTRACT_ID = 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4';
@@ -181,6 +182,7 @@ describe('EventListenerService', () => {
         const module: TestingModule = await Test.createTestingModule({
             providers: [
                 EventListenerService,
+                { provide: OracleLoggerService, useValue: { log: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() } },
                 { provide: ConfigService, useValue: mockConfigService },
                 { provide: RandomnessWorker, useValue: mockRandomnessWorker },
                 { provide: CommitRevealWorker, useValue: mockCommitRevealWorker },

--- a/oracle/test/prng.service.spec.ts
+++ b/oracle/test/prng.service.spec.ts
@@ -1,11 +1,12 @@
 import { PrngService } from '../src/randomness/prng.service';
+import { OracleLoggerService } from '../src/logger/oracle-logger';
 import * as crypto from 'crypto';
 
 describe('PrngService', () => {
   let service: PrngService;
 
   beforeEach(() => {
-    service = new PrngService();
+    service = new PrngService({ log: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() } as unknown as OracleLoggerService);
   });
 
   describe('output format', () => {

--- a/oracle/test/randomness.worker.spec.ts
+++ b/oracle/test/randomness.worker.spec.ts
@@ -9,6 +9,11 @@ import { HealthService } from '../src/health/health.service';
 import { LagMonitorService } from '../src/health/lag-monitor.service';
 import { OracleRegistryService } from '../src/multi-oracle/oracle-registry.service';
 import { MultiOracleCoordinatorService } from '../src/multi-oracle/multi-oracle-coordinator.service';
+import { JobStateManager } from '../src/queue/job-state-manager';
+import { RandomnessProcessorService } from '../src/queue/randomness-processor.service';
+import { AuditLogService } from '../src/audit/audit-log.service';
+import { AlertingService } from '../src/health/alerting.service';
+import { OracleLoggerService } from '../src/logger/oracle-logger';
 import { ConfigService } from '@nestjs/config';
 
 describe('RandomnessWorker', () => {
@@ -22,6 +27,11 @@ describe('RandomnessWorker', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         RandomnessWorker,
+        { provide: OracleLoggerService, useValue: { log: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() } },
+        { provide: JobStateManager, useValue: {} },
+        { provide: RandomnessProcessorService, useValue: {} },
+        { provide: AuditLogService, useValue: { record: jest.fn().mockResolvedValue(undefined) } },
+        { provide: AlertingService, useValue: { fire: jest.fn().mockResolvedValue(undefined), resolve: jest.fn().mockResolvedValue(undefined) } },
         {
           provide: ContractService,
           useValue: {
@@ -45,6 +55,7 @@ describe('RandomnessWorker', () => {
           provide: TxSubmitterService,
           useValue: {
             submitRandomness: jest.fn(),
+            keyService: { getPublicKey: jest.fn().mockResolvedValue('GORACLETESTADDRESS') },
           },
         },
         {
@@ -110,7 +121,7 @@ describe('RandomnessWorker', () => {
       };
 
       jest.spyOn(contractService, 'isRandomnessSubmitted').mockResolvedValue(false);
-      jest.spyOn(contractService, 'getRaffleData').mockResolvedValue({ prizeAmount: 100 });
+      jest.spyOn(contractService, 'getRaffleData').mockResolvedValue({ raffleId: 1, prizeAmount: 100, status: 'DRAWING' });
       prngService.compute.mockResolvedValue({
         seed: 'prng-seed',
         proof: '0'.repeat(128),
@@ -141,7 +152,7 @@ describe('RandomnessWorker', () => {
       };
 
       jest.spyOn(contractService, 'isRandomnessSubmitted').mockResolvedValue(false);
-      jest.spyOn(contractService, 'getRaffleData').mockResolvedValue({ prizeAmount: 1000 });
+      jest.spyOn(contractService, 'getRaffleData').mockResolvedValue({ raffleId: 2, prizeAmount: 1000, status: 'DRAWING' });
       vrfService.compute.mockResolvedValue({
         seed: 'vrf-seed',
         proof: 'vrf-proof',
@@ -203,7 +214,7 @@ describe('RandomnessWorker', () => {
       };
 
       jest.spyOn(contractService, 'isRandomnessSubmitted').mockResolvedValue(false);
-      jest.spyOn(contractService, 'getRaffleData').mockResolvedValue({ prizeAmount: 100 });
+      jest.spyOn(contractService, 'getRaffleData').mockResolvedValue({ raffleId: 4, prizeAmount: 100, status: 'DRAWING' });
       prngService.compute.mockResolvedValue({
         seed: 'seed',
         proof: '0'.repeat(128),
@@ -248,7 +259,7 @@ describe('RandomnessWorker', () => {
       };
 
       jest.spyOn(contractService, 'isRandomnessSubmitted').mockResolvedValue(false);
-      jest.spyOn(contractService, 'getRaffleData').mockResolvedValue({ prizeAmount: 100 });
+      jest.spyOn(contractService, 'getRaffleData').mockResolvedValue({ raffleId: 6, prizeAmount: 100, status: 'DRAWING' });
       prngService.compute.mockResolvedValue({
         seed: 'seed',
         proof: '0'.repeat(128),

--- a/oracle/test/stellar-subscriber.service.spec.ts
+++ b/oracle/test/stellar-subscriber.service.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
 import { StellarSubscriberService } from '../src/subscriber/stellar-subscriber.service';
 import { HealthService } from '../src/health/health.service';
+import { OracleLoggerService } from '../src/logger/oracle-logger';
 
 describe('StellarSubscriberService', () => {
   let service: StellarSubscriberService;
@@ -11,6 +12,7 @@ describe('StellarSubscriberService', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         StellarSubscriberService,
+        { provide: OracleLoggerService, useValue: { log: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() } },
         {
           provide: ConfigService,
           useValue: {

--- a/oracle/test/tx-submitter.service.spec.ts
+++ b/oracle/test/tx-submitter.service.spec.ts
@@ -2,6 +2,8 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { TxSubmitterService } from '../src/submitter/tx-submitter.service';
 import { KeyService } from '../src/keys/key.service';
 import { FeeEstimatorService } from '../src/submitter/fee-estimator.service';
+import { CostEstimatorService } from '../src/submitter/cost-estimator.service';
+import { OracleLoggerService } from '../src/logger/oracle-logger';
 import { ConfigService } from '@nestjs/config';
 
 describe('TxSubmitterService', () => {
@@ -37,6 +39,7 @@ describe('TxSubmitterService', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         TxSubmitterService,
+        { provide: OracleLoggerService, useValue: { log: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() } },
         { provide: ConfigService, useValue: { get: jest.fn().mockImplementation((k: string, defaultVal?: any) => {
           if (k === 'RAFFLE_CONTRACT_ID') return 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4';
           if (k === 'SOROBAN_RPC_URL') return 'https://example.com';
@@ -44,6 +47,14 @@ describe('TxSubmitterService', () => {
         }) } },
         { provide: FeeEstimatorService, useValue: feeEstimator },
         { provide: KeyService, useValue: keyService },
+        {
+          provide: CostEstimatorService,
+          useValue: {
+            recordRevealCost: jest.fn(),
+            recordSubmissionRetry: jest.fn(),
+            recordSubmissionFailure: jest.fn(),
+          },
+        },
       ],
     }).compile();
 

--- a/oracle/test/vrf.service.spec.ts
+++ b/oracle/test/vrf.service.spec.ts
@@ -2,6 +2,9 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { VrfService } from '../src/randomness/vrf.service';
 import { KeyService } from '../src/keys/key.service';
 import { OracleRegistryService } from '../src/multi-oracle/oracle-registry.service';
+import { MetricsService } from '../src/metrics/metrics.service';
+import { AlertingService } from '../src/health/alerting.service';
+import { OracleLoggerService } from '../src/logger/oracle-logger';
 import { ConfigService } from '@nestjs/config';
 import { Keypair } from '@stellar/stellar-sdk';
 import { ed25519 } from '@noble/curves/ed25519';
@@ -11,12 +14,14 @@ describe('VrfService', () => {
   let service: VrfService;
   let keyService: KeyService;
   let oracleRegistry: OracleRegistryService;
+  let alertingService: jest.Mocked<AlertingService>;
   const mockSecret = Keypair.random().secret();
 
     beforeEach(async () => {
         const module: TestingModule = await Test.createTestingModule({
             providers: [
                 VrfService,
+                { provide: OracleLoggerService, useValue: { log: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() } },
                 {
                     provide: ConfigService,
                     useValue: {
@@ -32,12 +37,15 @@ describe('VrfService', () => {
                         getLocalOracleId: jest.fn().mockReturnValue('oracle-001'),
                     },
                 },
+                { provide: MetricsService, useValue: { recordVrfProofSuccess: jest.fn(), recordVrfFailure: jest.fn() } },
+                { provide: AlertingService, useValue: { fire: jest.fn().mockResolvedValue(undefined), resolve: jest.fn().mockResolvedValue(undefined) } },
             ],
         }).compile();
 
     service = module.get<VrfService>(VrfService);
     keyService = module.get<KeyService>(KeyService);
     oracleRegistry = module.get<OracleRegistryService>(OracleRegistryService);
+    alertingService = module.get(AlertingService);
     await keyService.onModuleInit();
   });
 
@@ -311,6 +319,29 @@ describe('VrfService', () => {
       await expect(service.computeForOracle(requestId, oracleId)).rejects.toThrow(
         `Oracle not found: ${oracleId}`,
       );
+    });
+  });
+
+  describe('VRF key unavailable alerting', () => {
+    it('fires a critical alert when the signing key is unavailable', async () => {
+      jest.spyOn(keyService, 'sign').mockRejectedValueOnce(new Error('KMS access denied'));
+
+      await expect(service.compute('req-alert', 5)).rejects.toThrow('KMS access denied');
+
+      expect(alertingService.fire).toHaveBeenCalledWith(
+        expect.objectContaining({
+          severity: 'critical',
+          summary: expect.stringContaining('VRF signing key unavailable'),
+          dedupKey: 'vrf-key-unavailable',
+          context: expect.objectContaining({ raffle_id: 5, request_id: 'req-alert' }),
+        }),
+      );
+    });
+
+    it('resolves the alert after a subsequent successful computation', async () => {
+      await service.compute('req-ok');
+
+      expect(alertingService.resolve).toHaveBeenCalledWith('vrf-key-unavailable');
     });
   });
 


### PR DESCRIPTION
## Summary

Closes #921.

- `AlertingService` already dispatched to PagerDuty/Opsgenie via `fire()`/`resolve()`, but nothing in the oracle actually called it, and there was no generic webhook option. Adds `ALERT_WEBHOOK_URL` (optional): when set, `AlertingService` POSTs a Slack-compatible payload, independently of (and alongside) `ALERTING_PROVIDER`.
- `AlertPayload` gains an optional `context` bag (`oracle_id`, `raffle_id`, `request_id`, ...) included in both the webhook attachment fields and the PagerDuty `custom_details`, so an operator can diagnose the incident without SSH access.
- Wires the three trigger points the issue asked for, none of which previously alerted anywhere outside local logs:
  - `CircuitBreakerService` fires on closed→open and half-open→open, resolves on half-open→closed.
  - `RandomnessWorker` fires when a job is dead-lettered and the DLQ depth reaches `DLQ_DEPTH_ALERT_THRESHOLD` (default 5, configurable).
  - `VrfService` fires when the signing key is unavailable (`KeyService.sign()` throws), resolves after the next successful computation.
- New `alerting.service.spec.ts` covers the webhook payload shape, the "both provider and webhook fire" case, and PagerDuty `custom_details` context; each trigger site has its own alert-specific tests (`circuit-breaker.service.spec.ts`, `randomness.worker.spec.ts`, `vrf.service.spec.ts`).

### Unrelated pre-existing breakage fixed as a prerequisite

Before any of the above could be written or tested, `oracle`'s build and test suite were broken on `master`, unrelated to alerting. Confirmed via `gh api .../check-runs` that this predates this PR — even the last merged PR touching this code (#913) shows `Oracle - Lint, Test, Build: failure`. Fixed since nothing here could otherwise be verified:

- Several files (`job-state-manager.ts`, `tx-submitter.service.ts`, `health.controller.ts`, key providers, `rescue.cli.ts`, etc.) had invalid syntax (`function` keyword inside class bodies), a duplicate constructor, a duplicate method implementation, or missing imports.
- **Most impactful**: `AppModule` never imported `LoggerModule`, so `OracleLoggerService` — required by nearly every service's constructor — was never provided anywhere in the DI graph. The app could not have booted in this state.
- ~25 spec files' mocked `TestingModule` providers were never updated to include `OracleLoggerService` after it was introduced, so their suites failed before any assertion ran.

`pnpm run build` and `pnpm run lint` are now clean. `pnpm run test` goes from 236 failing/60 passing to 45 failing/506 passing (0 new alerting tests failing). The remaining 5 failing suites are unrelated, pre-existing issues left out of scope for this PR:

- `config.loader.spec.ts` — a config validation gap (empty `NETWORK_PASSPHRASE` / negative `VRF_THRESHOLD_XLM` don't throw as the test expects).
- `oracle-config.service.spec.ts` — `OracleConfigModule`'s `ConfigModule.forRoot({ load: [loadOracleConfig] })` wiring doesn't expose config the way `OracleConfigService.getConfig()` expects.
- `tx-submitter.service.spec.ts` (both copies) — test fixtures use `'CTEST'` as a contract ID, which fails real `@stellar/stellar-base` address validation.
- `e2e-oracle-flow.spec.ts` — crashes the Jest worker process; needs real infrastructure to diagnose.

## Test plan

- [x] `pnpm run build` — clean
- [x] `pnpm run lint` — 0 errors (62 pre-existing warnings)
- [x] `pnpm run test` — 506/559 passing; all new alerting tests pass; remaining failures are the pre-existing issues listed above
- [x] Manually traced the webhook Slack-payload shape and PagerDuty `custom_details` context against the acceptance criteria