### PR TITLE
feat(raffles): add cache headers and ETag support to hot read endpoints

### DIFF
--- a/backend/src/api/rest/raffles/cache-headers.interceptor.spec.ts
+++ b/backend/src/api/rest/raffles/cache-headers.interceptor.spec.ts
@@ -1,0 +1,169 @@
+import { ExecutionContext, CallHandler } from "@nestjs/common";
+import { of } from "rxjs";
+import {
+  CacheHeadersInterceptor,
+  CACHE_MAX_AGE_KEY,
+} from "./cache-headers.interceptor";
+
+function createMockContext(overrides: {
+  method?: string;
+  url?: string;
+  headers?: Record<string, string>;
+} = {}) {
+  const headers: Record<string, string> = overrides.headers ?? {};
+  const method = overrides.method ?? "GET";
+  const url = overrides.url ?? "/raffles";
+
+  const request = {
+    method,
+    originalUrl: url,
+    url,
+    headers,
+  };
+
+  const headerStore: Record<string, string> = {};
+  let statusCode = 200;
+  let ended = false;
+  const response = {
+    raw: {
+      setHeader: (k: string, v: string) => {
+        headerStore[k] = v;
+      },
+      writeHead: (code: number, _headers?: Record<string, string>) => {
+        statusCode = code;
+      },
+      end: () => {
+        ended = true;
+      },
+    },
+    header: (_k: string, _v: string) => {},
+  };
+
+  const ctx = {
+    switchToHttp: () => ({
+      getRequest: () => request,
+      getResponse: () => response,
+    }),
+    getHandler: () => () => {},
+  } as unknown as ExecutionContext;
+
+  return { ctx, headerStore, getStatusCode: () => statusCode, isEnded: () => ended };
+}
+
+function createMockCallHandler(body: unknown = { raffles: [] }): CallHandler {
+  return { handle: () => of(body) };
+}
+
+describe("CacheHeadersInterceptor", () => {
+  const interceptor = new CacheHeadersInterceptor();
+
+  it("sets Cache-Control and ETag headers on GET responses", (done) => {
+    const { ctx, headerStore } = createMockContext({ method: "GET", url: "/raffles" });
+    const handler = createMockCallHandler({ raffles: [{ id: 1 }] });
+
+    interceptor.intercept(ctx, handler).subscribe({
+      next: (value) => {
+        expect(value).toEqual({ raffles: [{ id: 1 }] });
+        expect(headerStore["Cache-Control"]).toBe(
+          "public, max-age=10, stale-while-revalidate=30",
+        );
+        expect(headerStore["ETag"]).toBeDefined();
+        expect(headerStore["ETag"]).toMatch(/^"[a-f0-9]{16}"$/);
+        done();
+      },
+    });
+  });
+
+  it("reads maxAge from method metadata (default 10)", (done) => {
+    const handler = () => {};
+    Reflect.defineMetadata(CACHE_MAX_AGE_KEY, 30, handler);
+    const { ctx, headerStore } = createMockContext({
+      method: "GET",
+      url: "/raffles/42",
+    });
+    const overrideCtx = {
+      ...ctx,
+      getHandler: () => handler,
+    } as unknown as ExecutionContext;
+
+    interceptor.intercept(overrideCtx, createMockCallHandler({ id: 42 })).subscribe({
+      next: () => {
+        expect(headerStore["Cache-Control"]).toBe(
+          "public, max-age=30, stale-while-revalidate=90",
+        );
+        done();
+      },
+    });
+  });
+
+  it("returns 304 when If-None-Match matches the stored ETag", (done) => {
+    const body = { raffles: [{ id: 1 }] };
+    const handler = () => {};
+
+    // First request — stores the ETag
+    const firstCtx = createMockContext({ method: "GET", url: "/raffles?status=open" });
+    interceptor
+      .intercept(firstCtx.ctx, createMockCallHandler(body))
+      .subscribe({
+        next: () => {
+          const etag = firstCtx.headerStore["ETag"];
+          expect(etag).toBeDefined();
+
+          // Second request — matching If-None-Match
+          const secondCtx = createMockContext({
+            method: "GET",
+            url: "/raffles?status=open",
+            headers: { "if-none-match": etag },
+          });
+          const { headerStore, getStatusCode, isEnded } = secondCtx;
+
+          interceptor
+            .intercept(secondCtx.ctx, createMockCallHandler(body))
+            .subscribe({
+              next: () => {
+                // For 304, we returned EMPTY so next should not fire
+                done(new Error("Expected no next emission for 304"));
+              },
+              complete: () => {
+                expect(getStatusCode()).toBe(304);
+                expect(headerStore["ETag"]).toBe(etag);
+                expect(isEnded()).toBe(true);
+                done();
+              },
+            });
+        },
+      });
+  });
+
+  it("returns full response when If-None-Match does not match", (done) => {
+    const body = { raffles: [{ id: 2 }] };
+    const { ctx, headerStore } = createMockContext({
+      method: "GET",
+      url: "/raffles/2",
+      headers: { "if-none-match": '"stale-etag-value"' },
+    });
+
+    interceptor.intercept(ctx, createMockCallHandler(body)).subscribe({
+      next: (value) => {
+        expect(value).toEqual(body);
+        expect(headerStore["ETag"]).toBeDefined();
+        expect(headerStore["ETag"]).not.toBe('"stale-etag-value"');
+        done();
+      },
+    });
+  });
+
+  it("skips caching for non-GET requests", (done) => {
+    const { ctx, headerStore } = createMockContext({ method: "POST", url: "/raffles" });
+    const handler = createMockCallHandler({ created: true });
+
+    interceptor.intercept(ctx, handler).subscribe({
+      next: (value) => {
+        expect(value).toEqual({ created: true });
+        expect(headerStore["ETag"]).toBeUndefined();
+        expect(headerStore["Cache-Control"]).toBeUndefined();
+        done();
+      },
+    });
+  });
+});

--- a/backend/src/api/rest/raffles/cache-headers.interceptor.ts
+++ b/backend/src/api/rest/raffles/cache-headers.interceptor.ts
@@ -1,0 +1,115 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+} from "@nestjs/common";
+import { Observable, EMPTY } from "rxjs";
+import { map } from "rxjs/operators";
+import { createHash } from "crypto";
+import { FastifyReply, FastifyRequest } from "fastify";
+
+export const CACHE_MAX_AGE_KEY = "cache-max-age";
+
+/**
+ * Compute a short ETag from a JSON-serialisable body.
+ */
+function computeETag(body: unknown): string {
+  const raw = JSON.stringify(body);
+  const hash = createHash("sha1").update(raw).digest("hex");
+  return `"${hash.slice(0, 16)}"`;
+}
+
+interface ETagEntry {
+  etag: string;
+  expiresAt: number;
+}
+
+/**
+ * Lightweight in-process ETag store keyed by route + query string.
+ * Entries expire after `maxAge * 3` so stale entries are reclaimed.
+ */
+const etagStore = new Map<string, ETagEntry>();
+const STORE_SWEEP_INTERVAL_MS = 60_000;
+let lastSweep = Date.now();
+
+function storeKey(route: string): string {
+  return route;
+}
+
+function sweepStore(now: number): void {
+  if (now - lastSweep < STORE_SWEEP_INTERVAL_MS) return;
+  lastSweep = now;
+  for (const [key, entry] of etagStore) {
+    if (now > entry.expiresAt) etagStore.delete(key);
+  }
+}
+
+/**
+ * NestJS interceptor that adds Cache-Control headers and ETag support to GET
+ * responses.
+ *
+ * Usage:
+ * ```ts
+ * @UseInterceptors(CacheHeadersInterceptor)
+ * @SetMetadata(CACHE_MAX_AGE_KEY, 15)
+ * ```
+ *
+ * TTL is read from the `CACHE_MAX_AGE_KEY` method-level metadata.  If absent,
+ * defaults to 10 seconds.
+ *
+ * Clients sending `If-None-Match` that matches the current ETag receive a
+ * `304 Not Modified` with no body.
+ */
+@Injectable()
+export class CacheHeadersInterceptor implements NestInterceptor {
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    const request = context.switchToHttp().getRequest<FastifyRequest>();
+    const response = context.switchToHttp().getResponse<FastifyReply>();
+    const rawRes = response.raw;
+
+    // Only cache GET requests
+    if (request.method !== "GET") {
+      return next.handle();
+    }
+
+    // Read TTL from method metadata; default 10s
+    const reflector = context.getHandler();
+    const maxAge: number =
+      Reflect.getMetadata(CACHE_MAX_AGE_KEY, reflector) ?? 10;
+
+    const route = request.originalUrl ?? request.url ?? "";
+    const cacheKey = storeKey(route);
+    const now = Date.now();
+    sweepStore(now);
+
+    // Check existing ETag
+    const ifNoneMatch = request.headers["if-none-match"];
+    const existing = etagStore.get(cacheKey);
+    if (existing && existing.etag === ifNoneMatch) {
+      rawRes.writeHead(304, {
+        ETag: existing.etag,
+        "Cache-Control": `public, max-age=${maxAge}, stale-while-revalidate=${maxAge * 3}`,
+      });
+      rawRes.end();
+      return EMPTY;
+    }
+
+    return next.handle().pipe(
+      map((body) => {
+        const etag = computeETag(body);
+        etagStore.set(cacheKey, {
+          etag,
+          expiresAt: now + maxAge * 3 * 1000,
+        });
+
+        rawRes.setHeader("ETag", etag);
+        rawRes.setHeader(
+          "Cache-Control",
+          `public, max-age=${maxAge}, stale-while-revalidate=${maxAge * 3}`,
+        );
+        return body;
+      }),
+    );
+  }
+}

--- a/backend/src/api/rest/raffles/raffles.controller.ts
+++ b/backend/src/api/rest/raffles/raffles.controller.ts
@@ -51,6 +51,8 @@ import {
 import { Throttle } from "@nestjs/throttler";
 import { IdempotencyInterceptor } from "../../../common/idempotency/idempotency.interceptor";
 import { IdempotencyService } from "../../../common/idempotency/idempotency.service";
+import { CacheHeadersInterceptor, CACHE_MAX_AGE_KEY } from "./cache-headers.interceptor";
+import { SetMetadata } from "@nestjs/common";
 import * as fileType from "file-type";
 
 interface FastifyRequestWithMultipart extends FastifyRequest {
@@ -78,6 +80,8 @@ export class RafflesController {
   @Get()
   @ApiOperation({ summary: "List raffles with optional filters and pagination" })
   @ApiResponse({ status: 200, description: "Raffles list retrieved successfully" })
+  @UseInterceptors(CacheHeadersInterceptor)
+  @SetMetadata(CACHE_MAX_AGE_KEY, 10)
   @UsePipes(new (createZodPipe(ListRafflesQuerySchema))())
   async list(@Query() filters: ListRafflesQueryDto) {
     return this.rafflesService.list(filters);
@@ -92,6 +96,8 @@ export class RafflesController {
   @Get('metadata')
   @ApiOperation({ summary: "Batch fetch off-chain metadata for up to 100 raffle IDs" })
   @ApiResponse({ status: 200, description: "Batch metadata retrieved successfully" })
+  @UseInterceptors(CacheHeadersInterceptor)
+  @SetMetadata(CACHE_MAX_AGE_KEY, 15)
   @UsePipes(new (createZodPipe(BatchMetadataQuerySchema))())
   async getBatchMetadata(@Query() query: BatchMetadataQueryDto) {
     return this.rafflesService.getBatchMetadata(query.ids);
@@ -105,6 +111,8 @@ export class RafflesController {
   @ApiOperation({ summary: "Get raffle detail by ID" })
   @ApiParam({ name: "id", description: "Internal raffle ID" })
   @ApiResponse({ status: 200, description: "Raffle details retrieved successfully" })
+  @UseInterceptors(CacheHeadersInterceptor)
+  @SetMetadata(CACHE_MAX_AGE_KEY, 30)
   async getById(@Param("id", ParseIntPipe) id: number) {
     return this.rafflesService.getById(id);
   }
@@ -122,6 +130,8 @@ export class RafflesController {
   @ApiQuery({ name: "limit", required: false, type: Number, description: "Max 100, default 20" })
   @ApiQuery({ name: "offset", required: false, type: Number, description: "Offset for pagination, default 0" })
   @ApiResponse({ status: 200, description: "Participants list retrieved successfully", type: ParticipantListResponseDto })
+  @UseInterceptors(CacheHeadersInterceptor)
+  @SetMetadata(CACHE_MAX_AGE_KEY, 30)
   @UsePipes(new (createZodPipe(ParticipantListQuerySchema))())
   async getParticipants(
     @Param("id", ParseIntPipe) id: number,


### PR DESCRIPTION
closes #1079
Add CacheHeadersInterceptor that sets Cache-Control and ETag headers on GET responses, and returns 304 Not Modified when If-None-Match matches.

Applied to four hot raffle endpoints with per-route TTLs:
- GET /raffles (list): max-age=10s
- GET /raffles/metadata (batch): max-age=15s
- GET /raffles/:id (detail): max-age=30s
- GET /raffles/:id/participants: max-age=30s

Each response includes stale-while-revalidate=3x the max-age to allow background revalidation while serving stale content.