### PR TITLE
feat(sentry): add PII scrubber redacting emails, cookies, and wallet …

### DIFF
--- a/backend/src/sentry/redaction.utils.spec.ts
+++ b/backend/src/sentry/redaction.utils.spec.ts
@@ -1,4 +1,11 @@
-import { redactSensitive, hashWallet, REDACTED_FIELDS } from './sentry';
+import {
+  redactSensitive,
+  hashWallet,
+  redactWalletAddresses,
+  scrubPii,
+  scrubSentryEvent,
+  REDACTED_FIELDS,
+} from './sentry';
 
 describe('REDACTED_FIELDS', () => {
   it('contains expected sensitive field names', () => {
@@ -100,5 +107,168 @@ describe('hashWallet', () => {
     const address = 'GRAWADDRESS123';
     const hash = hashWallet(address);
     expect(hash).not.toContain(address.toLowerCase());
+  });
+});
+
+describe('redactWalletAddresses', () => {
+  it('replaces a Stellar public key (56 base32 chars) with its hash', () => {
+    const key = 'GBRFDEK53ZB2TEJNDA223GK5C45XZS7K2V3N4M5P6Q7R8S9T0U1V2W3X4';
+    const result = redactWalletAddresses(`user ${key} made a purchase`);
+    expect(result).not.toContain(key);
+    expect(result).toMatch(/^user [0-9a-f]{16} made a purchase$/);
+  });
+
+  it('replaces a Stellar secret seed (S…) with its hash', () => {
+    const seed = 'SBRDEK53ZB2TEJNDA223GK5C45XZS7K2V3N4M5P6Q7R8S9T0U1V2W3X4';
+    const result = redactWalletAddresses(`secret: ${seed}`);
+    expect(result).not.toContain(seed);
+    expect(result).toMatch(/^secret: [0-9a-f]{16}$/);
+  });
+
+  it('leaves non-matching strings unchanged', () => {
+    const input = 'no wallet here, just text';
+    expect(redactWalletAddresses(input)).toBe(input);
+  });
+});
+
+describe('scrubPii', () => {
+  it('redacts email fields', () => {
+    const result = scrubPii({ email: 'alice@example.com', name: 'Alice' }) as Record<string, unknown>;
+    expect(result.email).toBe('[REDACTED]');
+    expect(result.name).toBe('Alice');
+  });
+
+  it('redacts emailAddress and user_email fields', () => {
+    const result = scrubPii({
+      emailAddress: 'bob@example.com',
+      user_email: 'bob@example.com',
+    }) as Record<string, unknown>;
+    expect(result.emailAddress).toBe('[REDACTED]');
+    expect(result.user_email).toBe('[REDACTED]');
+  });
+
+  it('redacts authorization and cookie headers', () => {
+    const result = scrubPii({
+      authorization: 'Bearer secret-token',
+      cookie: 'session=abc123',
+      'content-type': 'application/json',
+    }) as Record<string, unknown>;
+    expect(result.authorization).toBe('[REDACTED]');
+    expect(result.cookie).toBe('[REDACTED]');
+    expect(result['content-type']).toBe('application/json');
+  });
+
+  it('hashes Stellar wallet addresses in string values', () => {
+    const wallet = 'GBRFDEK53ZB2TEJNDA223GK5C45XZS7K2V3N4M5P6Q7R8S9T0U1V2W3X4';
+    const result = scrubPii({ address: wallet }) as Record<string, unknown>;
+    expect(result.address).not.toBe(wallet);
+    expect(result.address).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it('recursively scrubs nested objects', () => {
+    const wallet = 'GBRFDEK53ZB2TEJNDA223GK5C45XZS7K2V3N4M5P6Q7R8S9T0U1V2W3X4';
+    const result = scrubPii({
+      outer: { email: 'a@b.com', data: { wallet } },
+    }) as any;
+    expect(result.outer.email).toBe('[REDACTED]');
+    expect(result.outer.data.wallet).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it('scrubs arrays', () => {
+    const result = scrubPii([{ email: 'a@b.com' }, { token: 'secret' }]) as any[];
+    expect(result[0].email).toBe('[REDACTED]');
+    expect(result[1].token).toBe('[REDACTED]');
+  });
+
+  it('does not mutate the original object', () => {
+    const original = { email: 'a@b.com' };
+    scrubPii(original);
+    expect(original.email).toBe('a@b.com');
+  });
+});
+
+describe('scrubSentryEvent', () => {
+  const VALID_WALLET = 'GBRFDEK53ZB2TEJNDA223GK5C45XZS7K2V3N4M5P6Q7R8S9T0U1V2W3X4';
+
+  it('redacts authorization header', () => {
+    const event = {
+      request: { headers: { authorization: 'Bearer secret' } },
+    } as any;
+    const result = scrubSentryEvent(event);
+    expect(result.request!.headers!.authorization).toBe('[REDACTED]');
+  });
+
+  it('redacts cookie header', () => {
+    const event = {
+      request: { headers: { cookie: 'session=abc' } },
+    } as any;
+    const result = scrubSentryEvent(event);
+    expect(result.request!.headers!.cookie).toBe('[REDACTED]');
+  });
+
+  it('redacts email fields in user context', () => {
+    const event = {
+      user: { email: 'alice@example.com', id: '123' },
+    } as any;
+    const result = scrubSentryEvent(event);
+    expect(result.user!.email).toBe('[REDACTED]');
+    expect(result.user!.id).toBe('123');
+  });
+
+  it('deletes request body', () => {
+    const event = {
+      request: { data: { password: 'secret', token: 'abc' }, method: 'POST' },
+    } as any;
+    const result = scrubSentryEvent(event);
+    expect(result.request!.data).toBeUndefined();
+    expect(result.request!.method).toBe('POST');
+  });
+
+  it('redacts query string params', () => {
+    const event = {
+      request: { query_string: { authorization: 'Bearer x', safe: 'ok' } },
+    } as any;
+    const result = scrubSentryEvent(event);
+    expect(result.request!.query_string).toEqual({ authorization: '[REDACTED]', safe: 'ok' });
+  });
+
+  it('hashes wallet addresses in tags', () => {
+    const event = {
+      tags: { wallet: VALID_WALLET },
+    } as any;
+    const result = scrubSentryEvent(event);
+    expect(result.tags!.wallet).not.toBe(VALID_WALLET);
+    expect(result.tags!.wallet).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it('redacts email fields in extra data', () => {
+    const event = {
+      extra: { email: 'leaked@example.com', debug: true },
+    } as any;
+    const result = scrubSentryEvent(event);
+    expect(result.extra!.email).toBe('[REDACTED]');
+    expect(result.extra!.debug).toBe(true);
+  });
+
+  it('redacts email fields in contexts', () => {
+    const event = {
+      contexts: { user: { email: 'bob@example.com' } },
+    } as any;
+    const result = scrubSentryEvent(event);
+    expect(result.contexts!.user.email).toBe('[REDACTED]');
+  });
+
+  it('does not mutate the original event', () => {
+    const event = {
+      request: { headers: { authorization: 'Bearer x' } },
+    } as any;
+    scrubSentryEvent(event);
+    expect(event.request.headers.authorization).toBe('Bearer x');
+  });
+
+  it('passes through an empty event unchanged', () => {
+    const event = {} as any;
+    const result = scrubSentryEvent(event);
+    expect(result).toEqual({});
   });
 });

--- a/backend/src/sentry/sentry.spec.ts
+++ b/backend/src/sentry/sentry.spec.ts
@@ -270,6 +270,87 @@ describe('buildSentryOptions — unit tests', () => {
   });
 });
 
+describe('beforeSend — PII scrubbing', () => {
+  const VALID_WALLET = 'GBRFDEK53ZB2TEJNDA223GK5C45XZS7K2V3N4M5P6Q7R8S9T0U1V2W3X4';
+
+  function getBeforeSend() {
+    const opts = buildSentryOptions({
+      SENTRY_DSN: 'https://abc@sentry.io/123',
+      NODE_ENV: 'test',
+    });
+    return (opts as any).beforeSend as (event: any) => any;
+  }
+
+  it('redacts authorization header', () => {
+    const beforeSend = getBeforeSend();
+    const event = { request: { headers: { authorization: 'Bearer sk-secret' } } };
+    const result = beforeSend(event);
+    expect(result.request.headers.authorization).toBe('[REDACTED]');
+  });
+
+  it('redacts cookie header', () => {
+    const beforeSend = getBeforeSend();
+    const event = { request: { headers: { cookie: 'session=abc123' } } };
+    const result = beforeSend(event);
+    expect(result.request.headers.cookie).toBe('[REDACTED]');
+  });
+
+  it('redacts email fields in user object', () => {
+    const beforeSend = getBeforeSend();
+    const event = { user: { email: 'alice@corp.com', id: '42' } };
+    const result = beforeSend(event);
+    expect(result.user.email).toBe('[REDACTED]');
+    expect(result.user.id).toBe('42');
+  });
+
+  it('deletes request body (data)', () => {
+    const beforeSend = getBeforeSend();
+    const event = { request: { method: 'POST', data: { password: 'hunter2' } } };
+    const result = beforeSend(event);
+    expect(result.request.data).toBeUndefined();
+    expect(result.request.method).toBe('POST');
+  });
+
+  it('redacts query string containing sensitive fields', () => {
+    const beforeSend = getBeforeSend();
+    const event = { request: { query_string: { token: 'abc', q: 'search' } } };
+    const result = beforeSend(event);
+    expect(result.request.query_string).toEqual({ token: '[REDACTED]', q: 'search' });
+  });
+
+  it('hashes wallet addresses in tags', () => {
+    const beforeSend = getBeforeSend();
+    const event = { tags: { wallet: VALID_WALLET } };
+    const result = beforeSend(event);
+    expect(result.tags.wallet).not.toBe(VALID_WALLET);
+    expect(result.tags.wallet).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it('handles a complete event with all PII vectors', () => {
+    const beforeSend = getBeforeSend();
+    const event = {
+      request: {
+        method: 'POST',
+        headers: { authorization: 'Bearer token', cookie: 'sid=xyz' },
+        query_string: { email: 'bob@test.com' },
+        data: { secret: 'private' },
+      },
+      user: { email: 'bob@test.com' },
+      tags: { wallet: VALID_WALLET },
+      extra: { debug: true },
+    };
+    const result = beforeSend(event);
+
+    expect(result.request.headers.authorization).toBe('[REDACTED]');
+    expect(result.request.headers.cookie).toBe('[REDACTED]');
+    expect(result.request.query_string.email).toBe('[REDACTED]');
+    expect(result.request.data).toBeUndefined();
+    expect(result.user.email).toBe('[REDACTED]');
+    expect(result.tags.wallet).toMatch(/^[0-9a-f]{16}$/);
+    expect(result.extra.debug).toBe(true);
+  });
+});
+
 describe('initSentry — unit tests', () => {
   let warnMock: jest.Mock;
   let logMock: jest.Mock;

--- a/backend/src/sentry/sentry.ts
+++ b/backend/src/sentry/sentry.ts
@@ -16,7 +16,7 @@ export const REDACTED_FIELDS = [
   'authorization',
   'token',
   'signature',
-  'mnemonic', 
+  'mnemonic',
   'seed',
   'password',
   'privatekey',
@@ -26,7 +26,17 @@ export const REDACTED_FIELDS = [
   'session',
   'jwt',
   'bearer',
+  'email',
+  'emailaddress',
+  'user_email',
+  'useremail',
 ] as const;
+
+/** Regex matching Stellar public keys (G…) or secret seeds (S…), 56 base32 chars. */
+const STELLAR_ADDRESS_RE = /\b[GS][A-Z2-7]{55}\b/g;
+
+/** Non-global variant for single-match testing without mutating lastIndex. */
+const STELLAR_ADDRESS_TEST = /\b[GS][A-Z2-7]{55}\b/;
 
 /**
  * Recursively redact sensitive fields from an object or array.
@@ -85,6 +95,94 @@ export function hashWallet(address: string | null | undefined): string | null {
   return hash.substring(0, 16);
 }
 
+/**
+ * Replace Stellar wallet addresses (G…/S…, 56 base32 chars) found in a string
+ * with their hashed representation via `hashWallet`.
+ */
+export function redactWalletAddresses(value: string): string {
+  return value.replace(STELLAR_ADDRESS_RE, (match) => hashWallet(match) ?? match);
+}
+
+/**
+ * Recursively walk an object/array, redacting sensitive field values and
+ * hashing any Stellar wallet address strings found.
+ * Returns a new structure without mutating the original.
+ */
+export function scrubPii(input: unknown, depth = 0): unknown {
+  if (depth >= 10) {
+    return '[DEPTH_LIMIT]';
+  }
+
+  if (input === null || input === undefined) {
+    return input;
+  }
+
+  if (typeof input === 'string') {
+    return typeof input === 'string' && STELLAR_ADDRESS_TEST.test(input)
+      ? redactWalletAddresses(input)
+      : input;
+  }
+
+  if (Array.isArray(input)) {
+    return input.map((item) => scrubPii(item, depth + 1));
+  }
+
+  if (typeof input === 'object') {
+    const redactSet = new Set(REDACTED_FIELDS.map((f) => f.toLowerCase()));
+    const result: Record<string, unknown> = {};
+
+    for (const [key, value] of Object.entries(input as Record<string, unknown>)) {
+      if (redactSet.has(key.toLowerCase())) {
+        result[key] = '[REDACTED]';
+      } else {
+        result[key] = scrubPii(value, depth + 1);
+      }
+    }
+    return result;
+  }
+
+  return input;
+}
+
+/**
+ * Walk a Sentry event and redact PII:
+ *  - sensitive fields (authorization, cookies, emails, …) → [REDACTED]
+ *  - Stellar wallet addresses → first 16 hex chars of SHA-256
+ */
+export function scrubSentryEvent(event: Sentry.Event): Sentry.Event {
+  const e = { ...event };
+
+  if (e.request?.headers) {
+    e.request = { ...e.request, headers: scrubPii(e.request.headers) as Record<string, string> };
+  }
+  if (e.request?.query_string) {
+    e.request = {
+      ...e.request,
+      query_string: scrubPii(e.request.query_string) as string | Record<string, string>,
+    };
+  }
+  // Drop request body — may contain signatures, tokens, or PII
+  if (e.request?.data !== undefined) {
+    const { data: _, ...rest } = e.request;
+    e.request = rest;
+  }
+
+  if (e.user) {
+    e.user = scrubPii(e.user) as Sentry.Event['user'];
+  }
+  if (e.tags) {
+    e.tags = scrubPii(e.tags) as Sentry.Event['tags'];
+  }
+  if (e.contexts) {
+    e.contexts = scrubPii(e.contexts) as Sentry.Event['contexts'];
+  }
+  if (e.extra) {
+    e.extra = scrubPii(e.extra) as Sentry.Event['extra'];
+  }
+
+  return e;
+}
+
 export interface IngestionErrorContext {
   /** Stellar ledger sequence number. Omitted from tags if undefined. */
   ledger?: number;
@@ -127,21 +225,7 @@ export function buildSentryOptions(envInput: {
      * This is a defence-in-depth measure on top of per-scope redaction.
      */
     beforeSend(event) {
-      // Redact request headers
-      if (event.request?.headers) {
-        event.request.headers = redactSensitive(event.request.headers) as Record<string, string>;
-      }
-      // Drop request body entirely — may contain signatures, tokens, or PII
-      if (event.request) {
-        delete event.request.data;
-      }
-      // Redact query string params
-      if (event.request?.query_string) {
-        event.request.query_string = redactSensitive(event.request.query_string) as
-          | string
-          | Record<string, string>;
-      }
-      return event;
+      return scrubSentryEvent(event);
     },
   };
 }


### PR DESCRIPTION
closes  #1081

- Add email fields (email, emailAddress, user_email) to REDACTED_FIELDS
- Add scrubPii(): recursively redacts sensitive fields and hashes Stellar wallet addresses
- Add scrubSentryEvent(): scrubs headers, user, tags, contexts, extra; drops request body
- Add redactWalletAddresses(): replaces G…/S… addresses with SHA-256 hashes
- Fix regex lastIndex bug by using non-global regex for .test() checks
- Add unit tests for scrubPii, scrubSentryEvent, redactWalletAddresses
- Add beforeSend integration tests asserting PII is redacted before event leaves process