### PR TITLE
feat(sdk): validate network configuration at client construction

### DIFF
--- a/sdk/src/network/index.ts
+++ b/sdk/src/network/index.ts
@@ -1,3 +1,4 @@
+export * from './network-config.error';
 export * from './network.config';
 export * from './network.module';
 export * from './rpc.service';

--- a/sdk/src/network/network-config.error.ts
+++ b/sdk/src/network/network-config.error.ts
@@ -1,0 +1,36 @@
+/**
+ * Typed configuration error for network setup (issue #1096).
+ *
+ * Distinct from a generic `Error` so callers can branch on it — a malformed
+ * config is a programming mistake to be fixed at the call site, not a
+ * transient network failure to be retried. Throwing plain `Error` forces
+ * callers to string-match the message to tell the two apart.
+ */
+export class NetworkConfigError extends Error {
+  /** The config field that failed validation, e.g. `rpcUrl`. */
+  readonly field: string;
+
+  /** The value that was rejected, for the message and for logging. */
+  readonly value: unknown;
+
+  constructor(field: string, value: unknown, reason: string) {
+    super(`Invalid network configuration: "${field}" ${reason} (received: ${formatValue(value)})`);
+    this.name = 'NetworkConfigError';
+    this.field = field;
+    this.value = value;
+
+    // Without this, `instanceof NetworkConfigError` fails when the package is
+    // compiled to ES5 — extending built-ins breaks the prototype chain, and
+    // the whole point of a typed error is that callers can test for it.
+    Object.setPrototypeOf(this, NetworkConfigError.prototype);
+  }
+}
+
+/** Render a rejected value for the error message without dumping huge objects. */
+function formatValue(value: unknown): string {
+  if (value === undefined) return 'undefined';
+  if (value === null) return 'null';
+  if (typeof value === 'string') return value === '' ? '""' : `"${value}"`;
+  if (typeof value === 'object') return '[object]';
+  return String(value);
+}

--- a/sdk/src/network/network.config.spec.ts
+++ b/sdk/src/network/network.config.spec.ts
@@ -1,0 +1,159 @@
+import { Networks } from '@stellar/stellar-sdk';
+import {
+  resolveNetworkConfig,
+  validateNetworkConfig,
+  NETWORK_PRESETS,
+  SUPPORTED_NETWORKS,
+  type NetworkConfig,
+} from './network.config';
+import { NetworkConfigError } from './network-config.error';
+
+/**
+ * Tests for fail-fast network config validation (issue #1096).
+ *
+ * The behaviour under test is that a bad config throws at construction with a
+ * message naming the offending field — not at the first request, where it is
+ * indistinguishable from the endpoint being down.
+ */
+
+const validTestnet: NetworkConfig = {
+  network: 'testnet',
+  rpcUrl: 'https://soroban-testnet.stellar.org',
+  horizonUrl: 'https://horizon-testnet.stellar.org',
+  networkPassphrase: Networks.TESTNET,
+};
+
+describe('network presets', () => {
+  it('exposes a preset for every supported network', () => {
+    for (const name of SUPPORTED_NETWORKS) {
+      expect(NETWORK_PRESETS[name]).toBeDefined();
+    }
+  });
+
+  it('every shipped preset passes its own validation', () => {
+    // Guards against a preset being edited into an invalid state — the presets
+    // exist so users never hand-write config, so they must be correct.
+    for (const name of SUPPORTED_NETWORKS) {
+      expect(() => validateNetworkConfig(NETWORK_PRESETS[name])).not.toThrow();
+    }
+  });
+
+  it('resolves a preset by name', () => {
+    expect(resolveNetworkConfig('testnet')).toEqual(validTestnet);
+  });
+
+  it('returns a copy so callers cannot mutate the shared preset', () => {
+    const cfg = resolveNetworkConfig('testnet');
+    cfg.rpcUrl = 'https://evil.example';
+    expect(resolveNetworkConfig('testnet').rpcUrl).toBe('https://soroban-testnet.stellar.org');
+  });
+});
+
+describe('unknown networks', () => {
+  it('rejects an unknown network name and lists the valid ones', () => {
+    expect(() => resolveNetworkConfig('mainnnet' as never)).toThrow(NetworkConfigError);
+    try {
+      resolveNetworkConfig('mainnnet' as never);
+    } catch (err) {
+      expect((err as NetworkConfigError).field).toBe('network');
+      expect((err as Error).message).toContain('testnet');
+    }
+  });
+
+  it('rejects a config object with an unknown network', () => {
+    expect(() => resolveNetworkConfig({ network: 'devnet' as never })).toThrow(NetworkConfigError);
+  });
+});
+
+describe('URL validation', () => {
+  it.each([
+    ['not-a-url', 'is not a valid URL'],
+    ['', 'must be a non-empty string'],
+    ['ftp://example.com', 'must use http or https'],
+  ])('rejects rpcUrl %p', (rpcUrl, expected) => {
+    expect(() => resolveNetworkConfig({ network: 'testnet', rpcUrl })).toThrow(expected);
+  });
+
+  it('names rpcUrl as the offending field', () => {
+    try {
+      resolveNetworkConfig({ network: 'testnet', rpcUrl: 'nope' });
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(NetworkConfigError);
+      expect((err as NetworkConfigError).field).toBe('rpcUrl');
+    }
+  });
+
+  it('validates horizonUrl as well as rpcUrl', () => {
+    try {
+      resolveNetworkConfig({ network: 'testnet', horizonUrl: 'nope' });
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect((err as NetworkConfigError).field).toBe('horizonUrl');
+    }
+  });
+
+  it('accepts a valid custom RPC endpoint', () => {
+    const cfg = resolveNetworkConfig({
+      network: 'testnet',
+      rpcUrl: 'https://my-private-rpc.example.com/soroban',
+    });
+    expect(cfg.rpcUrl).toBe('https://my-private-rpc.example.com/soroban');
+    // Unspecified fields still come from the preset.
+    expect(cfg.networkPassphrase).toBe(Networks.TESTNET);
+  });
+
+  it('accepts http for a local standalone node', () => {
+    expect(() => resolveNetworkConfig('standalone')).not.toThrow();
+  });
+});
+
+describe('passphrase validation', () => {
+  it('rejects a passphrase that does not match the named network', () => {
+    // The dangerous case: transactions sign against the passphrase, so a
+    // mainnet passphrase under a "testnet" label yields mainnet-valid
+    // signatures. A typo must not reach that.
+    try {
+      resolveNetworkConfig({ network: 'testnet', networkPassphrase: Networks.PUBLIC });
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(NetworkConfigError);
+      expect((err as NetworkConfigError).field).toBe('networkPassphrase');
+      expect((err as Error).message).toContain('does not match network "testnet"');
+    }
+  });
+
+  it('rejects an empty passphrase', () => {
+    expect(() => resolveNetworkConfig({ network: 'testnet', networkPassphrase: '' })).toThrow(
+      NetworkConfigError,
+    );
+  });
+
+  it('accepts the matching passphrase stated explicitly', () => {
+    expect(() =>
+      resolveNetworkConfig({ network: 'testnet', networkPassphrase: Networks.TESTNET }),
+    ).not.toThrow();
+  });
+});
+
+describe('NetworkConfigError', () => {
+  it('is catchable as NetworkConfigError, not just Error', () => {
+    // Extending built-ins breaks the prototype chain under ES5 targets, which
+    // would make the typed error untestable by callers.
+    const err = new NetworkConfigError('rpcUrl', 'bad', 'is not a valid URL');
+    expect(err).toBeInstanceOf(NetworkConfigError);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe('NetworkConfigError');
+  });
+
+  it('carries the field and value for programmatic handling', () => {
+    const err = new NetworkConfigError('rpcUrl', 'bad', 'is not a valid URL');
+    expect(err.field).toBe('rpcUrl');
+    expect(err.value).toBe('bad');
+  });
+
+  it('renders undefined and empty values readably', () => {
+    expect(new NetworkConfigError('x', undefined, 'r').message).toContain('undefined');
+    expect(new NetworkConfigError('x', '', 'r').message).toContain('""');
+  });
+});

--- a/sdk/src/network/network.config.ts
+++ b/sdk/src/network/network.config.ts
@@ -1,4 +1,5 @@
 import { Networks } from '@stellar/stellar-sdk';
+import { NetworkConfigError } from './network-config.error';
 
 export type TikkaNetwork = 'testnet' | 'mainnet' | 'standalone';
 
@@ -81,23 +82,124 @@ const NETWORK_CONFIGS: Record<TikkaNetwork, NetworkConfig> = {
   },
 };
 
+/** Named presets, so most callers never hand-write a config (issue #1096). */
+export const NETWORK_PRESETS = Object.freeze({ ...NETWORK_CONFIGS });
+
+/** The network names accepted by `resolveNetworkConfig`. */
+export const SUPPORTED_NETWORKS = Object.keys(NETWORK_CONFIGS) as TikkaNetwork[];
+
+/** Passphrase each network must carry, keyed by name. */
+const EXPECTED_PASSPHRASES: Record<TikkaNetwork, string> = {
+  testnet: Networks.TESTNET,
+  mainnet: Networks.PUBLIC,
+  standalone: Networks.STANDALONE,
+};
+
+/**
+ * Validate a fully-resolved network config (issue #1096).
+ *
+ * Runs at construction rather than at first request. A malformed RPC URL
+ * previously surfaced as a fetch failure on the first call — far from the line
+ * that actually caused it, and indistinguishable from the endpoint being down.
+ *
+ * Every failure names the offending field, so the message points at the fix.
+ *
+ * @throws {NetworkConfigError}
+ */
+export function validateNetworkConfig(config: NetworkConfig): NetworkConfig {
+  if (!config || typeof config !== 'object') {
+    throw new NetworkConfigError('config', config, 'must be an object');
+  }
+
+  if (!SUPPORTED_NETWORKS.includes(config.network)) {
+    throw new NetworkConfigError(
+      'network',
+      config.network,
+      `must be one of: ${SUPPORTED_NETWORKS.join(', ')}`,
+    );
+  }
+
+  assertUrl('rpcUrl', config.rpcUrl);
+  assertUrl('horizonUrl', config.horizonUrl);
+
+  if (typeof config.networkPassphrase !== 'string' || config.networkPassphrase.trim() === '') {
+    throw new NetworkConfigError('networkPassphrase', config.networkPassphrase, 'must be a non-empty string');
+  }
+
+  // A passphrase that does not match the named network is the dangerous case:
+  // transactions sign against the passphrase, so a mainnet passphrase under a
+  // "testnet" label produces signatures valid on mainnet. That must not be
+  // reachable by a typo, and it is not something a first request would reveal.
+  const expected = EXPECTED_PASSPHRASES[config.network];
+  if (config.networkPassphrase !== expected) {
+    throw new NetworkConfigError(
+      'networkPassphrase',
+      config.networkPassphrase,
+      `does not match network "${config.network}" (expected: "${expected}")`,
+    );
+  }
+
+  return config;
+}
+
+/** Assert a field is a syntactically valid http(s) URL. */
+function assertUrl(field: string, value: unknown): void {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new NetworkConfigError(field, value, 'must be a non-empty string');
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new NetworkConfigError(field, value, 'is not a valid URL');
+  }
+
+  // Anything other than http(s) cannot be fetched. Rejecting here is clearer
+  // than letting the transport fail later with a protocol error.
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new NetworkConfigError(field, value, 'must use http or https');
+  }
+}
+
 /**
  * Resolves a NetworkConfig by name, or accepts a custom override.
+ *
+ * The result is validated before it is returned (issue #1096), so an invalid
+ * config fails here rather than on the first request.
+ *
+ * @throws {NetworkConfigError}
  */
 export function resolveNetworkConfig(
   networkOrConfig: TikkaNetwork | NetworkConfig | (Partial<NetworkConfig> & { network: TikkaNetwork }),
 ): NetworkConfig {
   if (typeof networkOrConfig === 'string') {
     const cfg = NETWORK_CONFIGS[networkOrConfig];
-    if (!cfg) throw new Error(`Unknown network: ${networkOrConfig}`);
+    if (!cfg) {
+      throw new NetworkConfigError(
+        'network',
+        networkOrConfig,
+        `must be one of: ${SUPPORTED_NETWORKS.join(', ')}`,
+      );
+    }
+    // Presets are known-good, so this is a copy rather than a re-validation.
     return { ...cfg };
   }
 
-  const base = NETWORK_CONFIGS[networkOrConfig.network];
-  if (!base) throw new Error(`Unknown network: ${networkOrConfig.network}`);
+  if (!networkOrConfig || typeof networkOrConfig !== 'object') {
+    throw new NetworkConfigError('config', networkOrConfig, 'must be a network name or a config object');
+  }
 
-  return {
-    ...base,
-    ...networkOrConfig,
-  };
+  const base = NETWORK_CONFIGS[networkOrConfig.network];
+  if (!base) {
+    throw new NetworkConfigError(
+      'network',
+      networkOrConfig.network,
+      `must be one of: ${SUPPORTED_NETWORKS.join(', ')}`,
+    );
+  }
+
+  // Overrides are validated: spreading user input over a preset is exactly how
+  // a bad URL or a mismatched passphrase used to get through unnoticed.
+  return validateNetworkConfig({ ...base, ...networkOrConfig });
 }


### PR DESCRIPTION
Closes #1096

## Problem

`resolveNetworkConfig` spread caller-supplied overrides straight over a preset and returned the result **unchecked**:

```ts
return { ...base, ...networkOrConfig };
```

So a malformed RPC URL or a mismatched passphrase surfaced as a fetch failure on the *first request* — far from the line that caused it, and indistinguishable from the endpoint simply being down.

## Validation now runs at construction

Every failure names the offending field:

| Field | Rule |
|---|---|
| `rpcUrl`, `horizonUrl` | non-empty, parses as a URL, uses http or https |
| `network` | one of the supported names — the error lists them |
| `networkPassphrase` | non-empty **and matches the named network** |

Non-http protocols are rejected rather than left to fail later in the transport with a protocol error.

### The passphrase check is the one that matters

Transactions sign against the passphrase, so a **mainnet passphrase under a `"testnet"` label produces signatures valid on mainnet**. That must not be reachable by a typo — and no first request would reveal it, because the call would succeed against the wrong network.

```ts
resolveNetworkConfig({ network: 'testnet', networkPassphrase: Networks.PUBLIC });
// NetworkConfigError: "networkPassphrase" does not match network "testnet"
```

## Typed error

`NetworkConfigError` carries `field` and `value` so callers can branch on it programmatically. A malformed config is a **programming mistake to fix at the call site**, not a transient failure to retry — and throwing plain `Error` forces callers to string-match the message to tell those apart.

The prototype is restored explicitly: extending built-ins breaks `instanceof` under ES5 targets, and a typed error nobody can test for is no better than a generic one. There's a test for that.

## Presets

They already existed but weren't exported. `NETWORK_PRESETS` and `SUPPORTED_NETWORKS` are now public, so most users never hand-write a config — the issue's second acceptance criterion.

Preset lookups by name skip re-validation (they're known-good), but a test asserts **every shipped preset passes its own validator**, so a preset can't be edited into an invalid state unnoticed.

## Backwards compatibility

Valid configs behave exactly as before. The only behaviour change is that previously-invalid configs now throw at construction instead of failing later — which is the point of the issue. Worth noting in case any consumer was unknowingly relying on a mismatched passphrase.

## Acceptance criteria

- [x] Bad config fails fast with a message naming the invalid field
- [x] Presets documented and exported

## Verification

**Not executed.** The `sdk/` directory has no `node_modules` in my checkout and I didn't install dependencies, so the 18 tests are written but unrun. They follow the repo's existing Jest conventions, matching the neighbouring `rpc.service.spec.ts`, and are the first thing worth running on review.