### PR TITLE
fix(sdk): make --json emit clean, stable JSON on stdout with logs on stderr

### DIFF
--- a/sdk/bin/tikka.cjs
+++ b/sdk/bin/tikka.cjs
@@ -20,6 +20,18 @@ const formatError = (err, json = false) => {
 };
 
 /**
+ * Helper: human-facing chatter (issue #1095).
+ *
+ * Always goes to stderr, never stdout. In --json mode stdout must carry the
+ * JSON document and nothing else, or `tikka list --json | jq` fails on the
+ * decorative header. Writing to stderr keeps the message visible in a terminal
+ * while leaving the pipe clean, so there is no reason to suppress it entirely.
+ */
+const logHuman = (message) => {
+  process.stderr.write(`${message}\n`);
+};
+
+/**
  * Helper: Initialize SDK based on CLI flags
  */
 const getSDK = (network) => {
@@ -33,7 +45,15 @@ const getSDK = (network) => {
  */
 const outputResult = (data, json = false) => {
   if (json) {
-    console.log(JSON.stringify(data, null, 2));
+    // Stable envelope: every JSON response has the same top-level shape, so a
+    // script can test `.ok` without knowing which command produced it. Raw
+    // payloads varied per command before — an array from `list`, an object
+    // from `info`, `{success:false,error}` on failure.
+    const envelope =
+      data && typeof data === 'object' && 'error' in data
+        ? { ok: false, error: data.error, data: null }
+        : { ok: true, error: null, data };
+    process.stdout.write(`${JSON.stringify(envelope, null, 2)}\n`);
   } else {
     console.log(data);
   }
@@ -221,7 +241,7 @@ program
     const { network, json } = program.opts();
     try {
       const sdk = getSDK(network);
-      console.log(`\n📋 Active Raffles on ${network}:`);
+      logHuman(`\n📋 Active Raffles on ${network}:`);
       try {
         const list = await sdk.raffle.listActive();
         outputResult(list, json);
@@ -248,9 +268,7 @@ program
     const { network, json } = program.opts();
     try {
       const sdk = getSDK(network);
-      if (!json) {
-        console.log(`\n🔍 Fetching Info for ${network.toUpperCase()}...`);
-      }
+      logHuman(`\n🔍 Fetching Info for ${network.toUpperCase()}...`);
       try {
         const status = await sdk.contract.getStatus();
         outputResult(status, json);
@@ -294,7 +312,7 @@ program
       ]);
 
       if (answers.confirm) {
-        if (!json) console.log('🚀 Deploying raffle...');
+        logHuman('🚀 Deploying raffle...');
         // Placeholder for actual deployment
         const result = { success: true, message: 'Raffle deployment started' };
         outputResult(result, json);
@@ -326,11 +344,9 @@ program
         { type: 'number', name: 'quantity', message: 'Number of tickets:' },
       ]);
 
-      if (!json) {
-        console.log(
-          `🎟️ Purchasing ${answers.quantity} tickets for #${answers.raffleId}`
-        );
-      }
+      logHuman(
+        `🎟️ Purchasing ${answers.quantity} tickets for #${answers.raffleId}`
+      );
       // Placeholder for actual purchase
       const result = {
         success: true,


### PR DESCRIPTION
Closes #1095

A `--json` flag already existed — but it didn't satisfy the acceptance criterion that output be parseable by `jq`.

## The bug

**`tikka list --json | jq` failed today.** The command printed its decorative header with an unguarded `console.log`:

```js
const sdk = getSDK(network);
console.log(`\n📋 Active Raffles on ${network}:`);   // ← straight to stdout
```

So stdout carried `📋 Active Raffles on testnet:` *before* the JSON document. `info` guarded the same line behind `if (!json)` — so the two read-commands didn't even behave alike.

## Guarding is the wrong fix

The issue asks for **logs on stderr**, not for logs to disappear. A human running the command still wants the header; stderr keeps it visible in a terminal while leaving the pipe clean.

Added `logHuman()`, which always writes to stderr, and routed every decorative message through it — `list`, `info`, `deploy`, `buy`.

## Stable envelope

JSON shape varied per command: `list` emitted a bare array, `info` an object, failures `{success:false,error}`. A script had to know which command it invoked before it could read the result.

Now every JSON response is the same shape:

```json
{ "ok": true,  "error": null,      "data": <payload> }
{ "ok": false, "error": "message", "data": null }
```

so a caller can test `.ok` uniformly. **Exit codes are unchanged**, as the issue requires — failures still exit 1 while emitting the envelope.

Also switched JSON output from `console.log` to `process.stdout.write`, so nothing else can interleave into the document.

## Verification — this one I did run

Captured both streams and parsed the result:

```
stdout parses as JSON: true
envelope keys: ok,error,data
ok: true items: 1
stderr got the header: true
```

I exercised the helpers directly rather than the full binary, since `bin/tikka.cjs` requires `../dist/index` and the SDK isn't built in my checkout. Worth a real `tikka list --json | jq .` on review to confirm end to end.

## Acceptance criteria

- [x] Commands with `--json` emit valid JSON parseable by `jq`
- [x] Exit codes unchanged
- [x] Read commands covered first — `list` and `info`; `deploy` and `buy` came along since they share the same helpers