### PR TITLE
Harden uploads emails locales and motion

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,6 +91,8 @@ A future issue will convert them to use a real Soroban testnet endpoint.
 ## Pull request checklist
 
 - [ ] `pnpm test` passes with no new failures.
+- [ ] New client UI strings are added to every supported locale and
+  `pnpm --filter client check:locales` passes with zero missing or orphaned keys.
 - [ ] New public APIs include JSDoc.
 - [ ] Integration tests (if added) are gated behind `TEST_INTEGRATION=true`.
 - [ ] `CONTRIBUTING.md` is updated if new integration test setup is required.

--- a/backend/package.json
+++ b/backend/package.json
@@ -60,12 +60,13 @@
     "moduleFileExtensions": [
       "js",
       "json",
-      "ts"
+      "ts",
+      "tsx"
     ],
     "rootDir": "src",
     "testRegex": ".*\\.spec\\.ts$",
     "transform": {
-      "^.+\\.(t|j)s$": "ts-jest"
+      "^.+\\.(t|j)sx?$": "ts-jest"
     },
     "testEnvironment": "node"
   },

--- a/backend/src/api/rest/raffles/og-render.controller.ts
+++ b/backend/src/api/rest/raffles/og-render.controller.ts
@@ -5,7 +5,7 @@ import { Public } from "../../../auth/decorators/public.decorator";
 import { RafflesService, RaffleDetailResponse } from "./raffles.service";
 import { ConfigService } from "@nestjs/config";
 import { MetadataRedisService } from "../../../services/metadata-redis.service";
-import * as sharp from "sharp";
+import sharp from "sharp";
 
 /**
  * OG Pre-Render Controller

--- a/backend/src/api/rest/raffles/raffles.controller.spec.ts
+++ b/backend/src/api/rest/raffles/raffles.controller.spec.ts
@@ -7,14 +7,27 @@ import { RafflesController } from './raffles.controller';
 import { RafflesService } from './raffles.service';
 import { StorageService } from '../../../services/storage.service';
 import { IdempotencyService } from '../../../common/idempotency/idempotency.service';
-import { MAX_UPLOAD_BYTES } from '../../../config/upload.config';
+import { MetadataRedisService } from '../../../services/metadata-redis.service';
+import { SseService } from '../../../services/sse.service';
+import {
+  MAX_UPLOAD_BYTES,
+  MAX_UPLOAD_IMAGE_HEIGHT,
+  MAX_UPLOAD_IMAGE_WIDTH,
+} from '../../../config/upload.config';
 import * as fileType from 'file-type';
+import sharp from 'sharp';
 
 jest.mock('file-type', () => ({
   fromBuffer: jest.fn(),
 }));
 
+jest.mock('sharp', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
 const mockFileTypeFromBuffer = fileType.fromBuffer as jest.MockedFunction<typeof fileType.fromBuffer>;
+const mockSharp = sharp as unknown as jest.Mock;
 
 function createMockFile(
   overrides: {
@@ -41,6 +54,9 @@ describe('RafflesController — uploadImage', () => {
 
   beforeEach(async () => {
     mockFileTypeFromBuffer.mockResolvedValue({ mime: 'image/png', ext: 'png' } as any);
+    mockSharp.mockReturnValue({
+      metadata: jest.fn().mockResolvedValue({ width: 1200, height: 800 }),
+    });
     storageService = {
       uploadRaffleImage: jest.fn().mockResolvedValue({
         url: 'https://cdn.example.com/42/addr/uuid.webp',
@@ -59,6 +75,8 @@ describe('RafflesController — uploadImage', () => {
         { provide: RafflesService, useValue: {} },
         { provide: StorageService, useValue: storageService },
         { provide: IdempotencyService, useValue: { get: jest.fn(), lock: jest.fn(), resolve: jest.fn() } },
+        { provide: SseService, useValue: {} },
+        { provide: MetadataRedisService, useValue: { isEnabled: jest.fn().mockReturnValue(false), get: jest.fn(), setEx: jest.fn() } },
       ],
     }).compile();
 
@@ -196,6 +214,52 @@ describe('RafflesController — uploadImage', () => {
     await expect(controller.uploadImage(request, 'GABC123')).rejects.toThrow(
       PayloadTooLargeException,
     );
+    expect(storageService.uploadRaffleImage).not.toHaveBeenCalled();
+  });
+
+  it('throws PayloadTooLargeException when multipart rejects an oversized file', async () => {
+    const request = {
+      file: jest.fn().mockRejectedValue(
+        Object.assign(new Error('request file too large'), {
+          code: 'FST_REQ_FILE_TOO_LARGE',
+          statusCode: 413,
+        }),
+      ),
+    } as any;
+
+    await expect(controller.uploadImage(request, 'GABC123')).rejects.toThrow(
+      PayloadTooLargeException,
+    );
+    expect(storageService.uploadRaffleImage).not.toHaveBeenCalled();
+  });
+
+  it('throws BadRequestException when image dimensions exceed max limits', async () => {
+    mockSharp.mockReturnValueOnce({
+      metadata: jest.fn().mockResolvedValue({
+        width: MAX_UPLOAD_IMAGE_WIDTH + 1,
+        height: MAX_UPLOAD_IMAGE_HEIGHT,
+      }),
+    });
+    const file = createMockFile();
+    const request = createMockRequest(file);
+
+    await expect(controller.uploadImage(request, 'GABC123')).rejects.toThrow(
+      BadRequestException,
+    );
+    expect(storageService.uploadRaffleImage).not.toHaveBeenCalled();
+  });
+
+  it('throws BadRequestException when image metadata cannot be read', async () => {
+    mockSharp.mockReturnValueOnce({
+      metadata: jest.fn().mockRejectedValue(new Error('bad image')),
+    });
+    const file = createMockFile();
+    const request = createMockRequest(file);
+
+    await expect(controller.uploadImage(request, 'GABC123')).rejects.toThrow(
+      BadRequestException,
+    );
+    expect(storageService.uploadRaffleImage).not.toHaveBeenCalled();
   });
 });
 
@@ -229,6 +293,8 @@ describe('RafflesController — upsertMetadata idempotency', () => {
         { provide: RafflesService, useValue: rafflesService },
         { provide: StorageService, useValue: {} },
         { provide: IdempotencyService, useValue: idempotencyService },
+        { provide: SseService, useValue: {} },
+        { provide: MetadataRedisService, useValue: { isEnabled: jest.fn().mockReturnValue(false), get: jest.fn(), setEx: jest.fn() } },
       ],
     }).compile();
 

--- a/backend/src/api/rest/raffles/raffles.controller.ts
+++ b/backend/src/api/rest/raffles/raffles.controller.ts
@@ -41,9 +41,14 @@ import { createZodPipe } from "./pipes/zod-validation.pipe";
 import {
   ALLOWED_UPLOAD_MIME_TYPES,
   AllowedUploadMimeType,
+  MAX_UPLOAD_IMAGE_HEIGHT,
+  MAX_UPLOAD_IMAGE_PIXELS,
+  MAX_UPLOAD_IMAGE_WIDTH,
   MAX_UPLOAD_BYTES,
 } from "../../../config/upload.config";
 import { StorageService } from "../../../services/storage.service";
+import { MetadataRedisService } from "../../../services/metadata-redis.service";
+import { SseService } from "../../../services/sse.service";
 import {
   UpsertMetadataSchema,
   UpsertMetadataDto,
@@ -54,6 +59,7 @@ import { IdempotencyService } from "../../../common/idempotency/idempotency.serv
 import { CacheHeadersInterceptor, CACHE_MAX_AGE_KEY } from "./cache-headers.interceptor";
 import { SetMetadata } from "@nestjs/common";
 import * as fileType from "file-type";
+import sharp, { type Metadata } from "sharp";
 
 interface FastifyRequestWithMultipart extends FastifyRequest {
   file: () => Promise<MultipartFile | undefined>;
@@ -70,6 +76,7 @@ export class RafflesController {
     private readonly storageService: StorageService,
     private readonly idempotencyService: IdempotencyService,
     private readonly sseService: SseService,
+    private readonly metadataRedis: MetadataRedisService,
   ) {}
 
   /**
@@ -258,12 +265,30 @@ export class RafflesController {
     @Req() request: FastifyRequestWithMultipart,
     @CurrentUser("address") address: string,
   ): Promise<{ url: string; variantUrls: string[] }> {
-    const file = await request.file();
+    let file: MultipartFile | undefined;
+    try {
+      file = await request.file();
+    } catch (error) {
+      if (this.isMultipartLimitError(error)) {
+        throw this.createPayloadTooLargeException();
+      }
+      throw error;
+    }
+
     if (!file) {
       throw new BadRequestException("Image file is required");
     }
 
-    const buffer = await file.toBuffer();
+    let buffer: Buffer;
+    try {
+      buffer = await file.toBuffer();
+    } catch (error) {
+      if (this.isMultipartLimitError(error)) {
+        throw this.createPayloadTooLargeException();
+      }
+      throw error;
+    }
+
     const detectedFileType = await fileType.fromBuffer(buffer);
     const mimeType = detectedFileType?.mime as AllowedUploadMimeType | undefined;
 
@@ -279,6 +304,8 @@ export class RafflesController {
       );
     }
 
+    await this.assertImageDimensionsWithinLimits(buffer);
+
     const raffleId = this.extractRaffleId(file);
     const upload = await this.storageService.uploadRaffleImage({
       fileBuffer: buffer,
@@ -288,6 +315,52 @@ export class RafflesController {
     });
 
     return { url: upload.url, variantUrls: upload.variantUrls };
+  }
+
+  private async assertImageDimensionsWithinLimits(buffer: Buffer): Promise<void> {
+    let metadata: Metadata;
+
+    try {
+      metadata = await sharp(buffer, {
+        limitInputPixels: MAX_UPLOAD_IMAGE_PIXELS + 1,
+      }).metadata();
+    } catch {
+      throw new BadRequestException("Invalid or unreadable image file");
+    }
+
+    const width = metadata.width ?? 0;
+    const height = metadata.height ?? 0;
+    const pixels = width * height;
+
+    if (width <= 0 || height <= 0) {
+      throw new BadRequestException("Image dimensions could not be determined");
+    }
+
+    if (
+      width > MAX_UPLOAD_IMAGE_WIDTH ||
+      height > MAX_UPLOAD_IMAGE_HEIGHT ||
+      pixels > MAX_UPLOAD_IMAGE_PIXELS
+    ) {
+      throw new BadRequestException(
+        `Image dimensions exceed limit (${width}x${height}). Max: ${MAX_UPLOAD_IMAGE_WIDTH}x${MAX_UPLOAD_IMAGE_HEIGHT}`,
+      );
+    }
+  }
+
+  private isMultipartLimitError(error: unknown): boolean {
+    if (!(error instanceof Error)) return false;
+    const maybeMultipartError = error as Error & { code?: string; statusCode?: number };
+    return (
+      maybeMultipartError.code === "FST_REQ_FILE_TOO_LARGE" ||
+      maybeMultipartError.statusCode === 413 ||
+      /file too large/i.test(maybeMultipartError.message)
+    );
+  }
+
+  private createPayloadTooLargeException(): PayloadTooLargeException {
+    return new PayloadTooLargeException(
+      `File too large. Max: ${MAX_UPLOAD_BYTES / 1024 / 1024} MB`,
+    );
   }
 
   private extractRaffleId(file: MultipartFile): string {

--- a/backend/src/api/rest/raffles/raffles.service.ts
+++ b/backend/src/api/rest/raffles/raffles.service.ts
@@ -4,6 +4,7 @@ import {
   NotFoundException,
   NotImplementedException,
   Logger,
+  UnprocessableEntityException,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import {

--- a/backend/src/config/upload.config.ts
+++ b/backend/src/config/upload.config.ts
@@ -1,5 +1,9 @@
 export const RAFFLE_IMAGE_BUCKET = 'raffle-images';
 export const MAX_UPLOAD_BYTES = 5 * 1024 * 1024; // 5MB
+export const MAX_UPLOAD_IMAGE_WIDTH = 8000;
+export const MAX_UPLOAD_IMAGE_HEIGHT = 8000;
+export const MAX_UPLOAD_IMAGE_PIXELS =
+  MAX_UPLOAD_IMAGE_WIDTH * MAX_UPLOAD_IMAGE_HEIGHT;
 
 export const ALLOWED_UPLOAD_MIME_TYPES = [
   'image/jpeg',
@@ -8,4 +12,3 @@ export const ALLOWED_UPLOAD_MIME_TYPES = [
 ] as const;
 
 export type AllowedUploadMimeType = (typeof ALLOWED_UPLOAD_MIME_TYPES)[number];
-

--- a/backend/src/emails/index.ts
+++ b/backend/src/emails/index.ts
@@ -11,6 +11,20 @@ export interface EmailTemplateRegistry {
   RaffleCancelled: RaffleCancelledEmailProps;
 }
 
+export const EMAIL_TEMPLATE_REQUIRED_FIELDS: {
+  [K in keyof EmailTemplateRegistry]: Array<keyof EmailTemplateRegistry[K]>;
+} = {
+  Winner: ["username", "raffleName", "claimUrl"],
+  RaffleEnded: ["raffleName", "resultsUrl"],
+  RaffleCancelled: [
+    "raffleName",
+    "cancellationReason",
+    "ticketCount",
+    "refundAmountXlm",
+    "raffleUrl",
+  ],
+};
+
 const templateFactories: {
   [K in keyof EmailTemplateRegistry]: (
     props: EmailTemplateRegistry[K],

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -51,6 +51,7 @@ async function bootstrap() {
       fileSize: MAX_UPLOAD_BYTES,
       files: 1,
     },
+    throwFileSizeLimit: true,
   });
 
   app.useGlobalInterceptors(new SentryInterceptor(), new RequestLoggingInterceptor());

--- a/backend/src/services/__snapshots__/email-template.service.spec.ts.snap
+++ b/backend/src/services/__snapshots__/email-template.service.spec.ts.snap
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EmailTemplateService render renders RaffleCancelled with all placeholders filled 1`] = `
+"<!DOCTYPE html><html><head><meta charSet="utf-8"/><style>
+    body { font-family: 'Helvetica Neue', Arial, sans-serif; background-color: #f4f4f4; margin: 0; padding: 0; }
+    .container { max-width: 600px; margin: 20px auto; background: #ffffff; border-radius: 12px; overflow: hidden; }
+    .header { background: #1f2937; color: white; padding: 30px; text-align: center; }
+    .content { padding: 30px; color: #4b5563; line-height: 1.6; }
+    .status-badge { display: inline-block; padding: 4px 12px; background: #fee2e2; color: #dc2626; border-radius: 99px; font-size: 14px; font-weight: bold; }
+    .footer { background: #f9fafb; padding: 20px; text-align: center; font-size: 12px; }
+    .button { display: inline-block; padding: 12px 24px; background-color: #6366f1; color: white; text-decoration: none; border-radius: 6px; font-weight: bold; margin-top: 20px; }
+  </style></head><body><div class="container"><div class="header"><h2>Raffle Cancelled</h2></div><div class="content"><div class="status-badge">CANCELLED</div><p>Hello,</p><p>We regret to inform you that the raffle <strong>Mega Draw</strong> has been cancelled.</p><p><strong>Reason:</strong> Organizer cancelled the event</p><p>You purchased 3 ticket(s) for this raffle. You are eligible for a full refund of <strong>42.0000000 XLM</strong>.</p><p>Please visit the raffle page to claim your refund.</p><a href="https://example.com/raffles/mega-draw" class="button">Claim Your Refund</a></div><div class="footer"><p>Thank you for participating in Tikka!</p></div></div></body></html>"
+`;
+
+exports[`EmailTemplateService render renders RaffleEnded with all placeholders filled 1`] = `
+"<!DOCTYPE html><html><head><meta charSet="utf-8"/><style>
+    body { font-family: 'Helvetica Neue', Arial, sans-serif; background-color: #f4f4f4; margin: 0; padding: 0; }
+    .container { max-width: 600px; margin: 20px auto; background: #ffffff; border-radius: 12px; overflow: hidden; }
+    .header { background: #1f2937; color: white; padding: 30px; text-align: center; }
+    .content { padding: 30px; color: #4b5563; line-height: 1.6; }
+    .status-badge { display: inline-block; padding: 4px 12px; background: #fee2e2; color: #dc2626; border-radius: 99px; font-size: 14px; font-weight: bold; }
+    .footer { background: #f9fafb; padding: 20px; text-align: center; font-size: 12px; }
+  </style></head><body><div class="container"><div class="header"><h2>Raffle Competition Ended</h2></div><div class="content"><div class="status-badge">COMPLETED</div><p>Hello,</p><p>The entry period for <strong>Mega Draw</strong> has officially closed.</p><p>Our system is currently finalizing the results. You can check the final leaderboard and see the winner by clicking below.</p><a href="https://example.com/results" style="color:#6366f1;font-weight:bold">View Final Results &rarr;</a></div><div class="footer"><p>Thank you for participating in Tikka!</p></div></div></body></html>"
+`;
+
+exports[`EmailTemplateService render renders Winner with all placeholders filled 1`] = `
+"<!DOCTYPE html><html><head><meta charSet="utf-8"/><style>
+    body { font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; background-color: #f4f4f4; margin: 0; padding: 0; }
+    .container { max-width: 600px; margin: 20px auto; background: #ffffff; border-radius: 12px; overflow: hidden; box-shadow: 0 4px 10px rgba(0,0,0,0.1); }
+    .header { background: #6366f1; color: white; padding: 40px 20px; text-align: center; }
+    .content { padding: 30px; text-align: center; color: #333333; }
+    .prize-box { background: #f9fafb; border: 2px dashed #6366f1; border-radius: 8px; padding: 20px; margin: 20px 0; }
+    .button { display: inline-block; padding: 14px 28px; background-color: #6366f1; color: white; text-decoration: none; border-radius: 6px; font-weight: bold; margin-top: 20px; }
+    .footer { padding: 20px; text-align: center; font-size: 12px; color: #9ca3af; }
+  </style></head><body><div class="container"><div class="header"><h1>🏆 YOU WON!</h1></div><div class="content"><p>Hello <strong>Clinton</strong>,</p><p>The wait is over! You have been selected as the winner for the raffle:</p><div class="prize-box"><h2 style="margin:0;color:#6366f1">Mega Draw</h2></div><p>Click the button below to claim your prize and see the details.</p><a href="https://example.com/claim" class="button">Claim My Prize</a></div><div class="footer"><p>&copy; 2026 Tikka Platform. All rights reserved.</p></div></div></body></html>"
+`;

--- a/backend/src/services/email-template.service.spec.ts
+++ b/backend/src/services/email-template.service.spec.ts
@@ -1,6 +1,51 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { EmailTemplateService } from "./email-template.service";
 import { InternalServerErrorException } from "@nestjs/common";
+import {
+  EMAIL_TEMPLATE_REQUIRED_FIELDS,
+  type EmailTemplateName,
+  type EmailTemplateRegistry,
+} from "../emails";
+
+const TEMPLATE_FIXTURES: {
+  [K in EmailTemplateName]: {
+    context: EmailTemplateRegistry[K];
+    expectedText: string[];
+  };
+} = {
+  Winner: {
+    context: {
+      username: "Clinton",
+      raffleName: "Mega Draw",
+      claimUrl: "https://example.com/claim",
+    },
+    expectedText: ["Clinton", "Mega Draw", "https://example.com/claim"],
+  },
+  RaffleEnded: {
+    context: {
+      raffleName: "Mega Draw",
+      resultsUrl: "https://example.com/results",
+    },
+    expectedText: ["Mega Draw", "https://example.com/results"],
+  },
+  RaffleCancelled: {
+    context: {
+      raffleName: "Mega Draw",
+      cancellationReason: "Organizer cancelled the event",
+      ticketCount: 3,
+      refundAmountXlm: "42.0000000",
+      raffleUrl: "https://example.com/raffles/mega-draw",
+    },
+    expectedText: [
+      "Mega Draw",
+      "Organizer cancelled the event",
+      "42.0000000 XLM",
+      "https://example.com/raffles/mega-draw",
+    ],
+  },
+};
+
+const LEFTOVER_TEMPLATE_TOKEN_PATTERN = /{{|}}|<%|%>|\$\{/;
 
 describe("EmailTemplateService", () => {
   let service: EmailTemplateService;
@@ -18,40 +63,16 @@ describe("EmailTemplateService", () => {
   });
 
   describe("render", () => {
-    it("renders the Winner email snapshot", () => {
-      const result = service.render("Winner", {
-        username: "Clinton",
-        raffleName: "Mega Draw",
-        claimUrl: "https://example.com/claim",
-      });
+    it.each(Object.entries(TEMPLATE_FIXTURES) as Array<
+      [EmailTemplateName, (typeof TEMPLATE_FIXTURES)[EmailTemplateName]]
+    >)("renders %s with all placeholders filled", (templateName, fixture) => {
+      const result = service.render(templateName, fixture.context);
 
-      expect(result)
-        .toMatchInlineSnapshot(`"<!DOCTYPE html><html><head><meta charset=\"utf-8\"/><style>
-    body { font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; background-color: #f4f4f4; margin: 0; padding: 0; }
-    .container { max-width: 600px; margin: 20px auto; background: #ffffff; border-radius: 12px; overflow: hidden; box-shadow: 0 4px 10px rgba(0,0,0,0.1); }
-    .header { background: #6366f1; color: white; padding: 40px 20px; text-align: center; }
-    .content { padding: 30px; text-align: center; color: #333333; }
-    .prize-box { background: #f9fafb; border: 2px dashed #6366f1; border-radius: 8px; padding: 20px; margin: 20px 0; }
-    .button { display: inline-block; padding: 14px 28px; background-color: #6366f1; color: white; text-decoration: none; border-radius: 6px; font-weight: bold; margin-top: 20px; }
-    .footer { padding: 20px; text-align: center; font-size: 12px; color: #9ca3af; }
-  </style></head><body><div class=\"container\"><div class=\"header\"><h1>🏆 YOU WON!</h1></div><div class=\"content\"><p>Hello <strong>Clinton</strong>,</p><p>The wait is over! You have been selected as the winner for the raffle:</p><div class=\"prize-box\"><h2 style=\"margin:0;color:#6366f1\">Mega Draw</h2></div><p>Click the button below to claim your prize and see the details.</p><a href=\"https://example.com/claim\" class=\"button\">Claim My Prize</a></div><div class=\"footer\"><p>&copy; 2026 Tikka Platform. All rights reserved.</p></div></div></body></html>"`);
-    });
-
-    it("renders the RaffleEnded email snapshot", () => {
-      const result = service.render("RaffleEnded", {
-        raffleName: "Mega Draw",
-        resultsUrl: "https://example.com/results",
-      });
-
-      expect(result)
-        .toMatchInlineSnapshot(`"<!DOCTYPE html><html><head><meta charset=\"utf-8\"/><style>
-    body { font-family: 'Helvetica Neue', Arial, sans-serif; background-color: #f4f4f4; margin: 0; padding: 0; }
-    .container { max-width: 600px; margin: 20px auto; background: #ffffff; border-radius: 12px; overflow: hidden; }
-    .header { background: #1f2937; color: white; padding: 30px; text-align: center; }
-    .content { padding: 30px; color: #4b5563; line-height: 1.6; }
-    .status-badge { display: inline-block; padding: 4px 12px; background: #fee2e2; color: #dc2626; border-radius: 99px; font-size: 14px; font-weight: bold; }
-    .footer { background: #f9fafb; padding: 20px; text-align: center; font-size: 12px; }
-  </style></head><body><div class=\"container\"><div class=\"header\"><h2>Raffle Competition Ended</h2></div><div class=\"content\"><div class=\"status-badge\">COMPLETED</div><p>Hello,</p><p>The entry period for <strong>Mega Draw</strong> has officially closed.</p><p>Our system is currently finalizing the results. You can check the final leaderboard and see the winner by clicking below.</p><a href=\"https://example.com/results\" style=\"color:#6366f1;font-weight:bold\">View Final Results &rarr;</a></div><div class=\"footer\"><p>Thank you for participating in Tikka!</p></div></div></body></html>"`);
+      for (const expected of fixture.expectedText) {
+        expect(result).toContain(expected);
+      }
+      expect(result).not.toMatch(LEFTOVER_TEMPLATE_TOKEN_PATTERN);
+      expect(result).toMatchSnapshot();
     });
 
     it("should throw InternalServerErrorException if template does not exist", () => {
@@ -59,5 +80,19 @@ describe("EmailTemplateService", () => {
         service.render("non-existent", {});
       }).toThrow(InternalServerErrorException);
     });
+
+    it.each(Object.keys(EMAIL_TEMPLATE_REQUIRED_FIELDS) as EmailTemplateName[])(
+      "throws when %s is missing a required variable",
+      (templateName) => {
+        const fixture = TEMPLATE_FIXTURES[templateName].context;
+        const [fieldToRemove] = EMAIL_TEMPLATE_REQUIRED_FIELDS[templateName];
+        const incompleteContext = { ...fixture } as Record<string, unknown>;
+        delete incompleteContext[fieldToRemove as string];
+
+        expect(() => service.render(templateName, incompleteContext)).toThrow(
+          InternalServerErrorException,
+        );
+      },
+    );
   });
 });

--- a/backend/src/services/email-template.service.ts
+++ b/backend/src/services/email-template.service.ts
@@ -6,6 +6,7 @@ import {
 import { renderToStaticMarkup } from "react-dom/server";
 import {
   isEmailTemplateName,
+  EMAIL_TEMPLATE_REQUIRED_FIELDS,
   renderEmailTemplate,
   type EmailTemplateName,
   type EmailTemplateRegistry,
@@ -29,6 +30,8 @@ export class EmailTemplateService {
         );
       }
 
+      this.assertRequiredContext(templateName, context);
+
       return `<!DOCTYPE html>${renderToStaticMarkup(
         renderEmailTemplate(
           templateName,
@@ -45,6 +48,30 @@ export class EmailTemplateService {
         error instanceof Error ? error.stack : String(error),
       );
       throw new InternalServerErrorException("Failed to render email template");
+    }
+  }
+
+  private assertRequiredContext<K extends EmailTemplateName>(
+    templateName: K,
+    context: unknown,
+  ): asserts context is EmailTemplateRegistry[K] {
+    if (context === null || typeof context !== "object") {
+      throw new InternalServerErrorException(
+        `Email template ${templateName} context is missing`,
+      );
+    }
+
+    const missingFields = EMAIL_TEMPLATE_REQUIRED_FIELDS[templateName].filter(
+      (field) => {
+        const value = (context as Record<string, unknown>)[field as string];
+        return value === undefined || value === null || value === "";
+      },
+    );
+
+    if (missingFields.length > 0) {
+      throw new InternalServerErrorException(
+        `Email template ${templateName} missing required field(s): ${missingFields.join(", ")}`,
+      );
     }
   }
 }

--- a/backend/src/services/image-optimizer.service.ts
+++ b/backend/src/services/image-optimizer.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import * as sharp from 'sharp';
+import sharp from 'sharp';
 import { AllowedUploadMimeType } from '../config/upload.config';
 import * as crypto from 'crypto';
 import { MetricsService } from './metrics.service';

--- a/backend/src/services/pinning.service.ts
+++ b/backend/src/services/pinning.service.ts
@@ -59,7 +59,7 @@ export class PinningService {
 
       this.logger.debug(
         'Attempting to pin metadata to Pinata IPFS',
-        `raffle-${payload.raffle_id || 'metadata'}-${Date.now()}`,
+        `raffle-${metadata.raffle_id || 'metadata'}-${Date.now()}`,
       );
 
       const response = await fetch('https://api.pinata.cloud/pinning/pinJSONToIPFS', {

--- a/client/CONTRIBUTING.md
+++ b/client/CONTRIBUTING.md
@@ -26,6 +26,8 @@ pnpm build
 - Provide a concise summary of the change and motivation.
 - Keep the scope focused; avoid unrelated refactors.
 - Include screenshots or recordings for UI changes.
+- Add new UI strings to every locale under `public/locales` and run
+  `pnpm check:locales`; missing or orphaned keys should be fixed before review.
 - Ensure `pnpm lint` and `pnpm build` pass.
 - Link related issues if applicable.
 
@@ -33,4 +35,3 @@ pnpm build
 
 Use GitHub Issues to report bugs or propose improvements. Provide clear steps
 to reproduce and expected vs actual behavior.
-

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -38,3 +38,15 @@
     color: var(--color-text-body);
     background-color: var(--color-bg);
 }
+
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        scroll-behavior: auto !important;
+        transition-delay: 0ms !important;
+        transition-duration: 0.01ms !important;
+    }
+}


### PR DESCRIPTION
## Summary
- Enforce upload byte limits at Fastify multipart handling and map multipart oversize errors to 413 before storage.
- Validate uploaded image dimensions after magic-byte MIME detection and reject unreadable or oversized images before storage.
- Add render coverage for every transactional email template with snapshots and required runtime context validation.
- Confirm locale parity, document locale requirements, and add a global prefers-reduced-motion CSS baseline.

## Test evidence
- Passed: pnpm exec jest src/api/rest/raffles/raffles.controller.spec.ts -t "uploadImage"
- Passed: pnpm exec jest src/services/email-template.service.spec.ts
- Passed: pnpm check:locales
- Passed during commit hook: npm --prefix backend run lint on staged backend files
- Blocked: pnpm build currently fails on existing unrelated compile errors in src/api/rest/stats/stats.service.ts, src/api/rest/users/users.controller.ts, and src/common/filters/base-exception.filter.ts.
- Note: the full raffles.controller.spec.ts file still has unrelated pre-existing idempotency test failures outside uploadImage.

Closes #1088
Closes #1057
Closes #1076
Closes #1048