### PR TITLE
[1082] [backend] Add unit tests for auth guards on admin routes

### DIFF
--- a/backend/src/api/rest/monitor/admin.guard.spec.ts
+++ b/backend/src/api/rest/monitor/admin.guard.spec.ts
@@ -1,0 +1,302 @@
+import {
+  ExecutionContext,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { AdminGuard } from './admin.guard';
+import { MonitorService } from './monitor.service';
+
+describe('AdminGuard', () => {
+  const ADMIN_TOKEN = 'secret-admin-token';
+
+  let guard: AdminGuard;
+  let mockConfigService: { get: jest.Mock };
+  let mockMonitorService: { logAudit: jest.Mock };
+
+  beforeEach(() => {
+    mockConfigService = {
+      get: jest.fn().mockImplementation((key: string, defaultVal?: unknown) => {
+        if (key === 'ADMIN_TOKEN') return ADMIN_TOKEN;
+        if (key === 'ADMIN_IP_ALLOWLIST') return '';
+        return defaultVal;
+      }),
+    };
+
+    mockMonitorService = {
+      logAudit: jest.fn().mockResolvedValue(undefined),
+    };
+
+    guard = new AdminGuard(
+      mockConfigService as unknown as ConfigService,
+      mockMonitorService as unknown as MonitorService,
+    );
+  });
+
+  const createMockContext = (
+    headers: Record<string, string | string[] | undefined> = {},
+    options: {
+      ip?: string;
+      url?: string;
+      originalUrl?: string;
+      method?: string;
+      remoteAddress?: string | null;
+    } = {},
+  ): ExecutionContext => {
+    const {
+      ip = '127.0.0.1',
+      url = '/monitor/jobs',
+      originalUrl,
+      method = 'GET',
+      remoteAddress,
+    } = options;
+
+    const request = {
+      headers,
+      ip: remoteAddress === null ? undefined : ip,
+      url,
+      originalUrl,
+      method,
+      raw: {
+        socket: {
+          remoteAddress:
+            remoteAddress === null
+              ? undefined
+              : (remoteAddress ?? ip),
+        },
+      },
+    };
+
+    return {
+      switchToHttp: () => ({
+        getRequest: () => request,
+      }),
+    } as unknown as ExecutionContext;
+  };
+
+  describe('valid admin token', () => {
+    it('allows access when X-Admin-Token matches ADMIN_TOKEN', () => {
+      const context = createMockContext({
+        'x-admin-token': ADMIN_TOKEN,
+      });
+
+      expect(guard.canActivate(context)).toBe(true);
+      expect(mockMonitorService.logAudit).not.toHaveBeenCalled();
+    });
+
+    it('allows access when IP allowlist is empty/whitespace', () => {
+      mockConfigService.get.mockImplementation(
+        (key: string, defaultVal?: unknown) => {
+          if (key === 'ADMIN_TOKEN') return ADMIN_TOKEN;
+          if (key === 'ADMIN_IP_ALLOWLIST') return '   ';
+          return defaultVal;
+        },
+      );
+
+      const context = createMockContext({
+        'x-admin-token': ADMIN_TOKEN,
+      });
+
+      expect(guard.canActivate(context)).toBe(true);
+    });
+
+    it('allows access from an IP on ADMIN_IP_ALLOWLIST', () => {
+      mockConfigService.get.mockImplementation(
+        (key: string, defaultVal?: unknown) => {
+          if (key === 'ADMIN_TOKEN') return ADMIN_TOKEN;
+          if (key === 'ADMIN_IP_ALLOWLIST') return '192.168.1.100, 10.0.0.1';
+          return defaultVal;
+        },
+      );
+
+      const context = createMockContext(
+        { 'x-admin-token': ADMIN_TOKEN },
+        { ip: '10.0.0.1' },
+      );
+
+      expect(guard.canActivate(context)).toBe(true);
+      expect(mockMonitorService.logAudit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('ordinary / non-admin credentials (unauthorized)', () => {
+    it('rejects a wrong admin token (ordinary user / role escalation attempt)', () => {
+      const context = createMockContext({
+        'x-admin-token': 'user-session-token',
+      });
+
+      expect(() => guard.canActivate(context)).toThrow(UnauthorizedException);
+      expect(() => guard.canActivate(context)).toThrow(
+        'Invalid or missing admin token',
+      );
+      expect(mockMonitorService.logAudit).toHaveBeenCalled();
+    });
+
+    it('rejects a token that is only a prefix of the real admin token', () => {
+      const context = createMockContext({
+        'x-admin-token': 'secret-admin',
+      });
+
+      expect(() => guard.canActivate(context)).toThrow(UnauthorizedException);
+      expect(() => guard.canActivate(context)).toThrow(
+        'Invalid or missing admin token',
+      );
+    });
+
+    it('rejects when token case does not match (no silent privilege escalation)', () => {
+      const context = createMockContext({
+        'x-admin-token': ADMIN_TOKEN.toUpperCase(),
+      });
+
+      expect(() => guard.canActivate(context)).toThrow(UnauthorizedException);
+    });
+  });
+
+  describe('missing / malformed token (401)', () => {
+    it('rejects when X-Admin-Token header is missing', () => {
+      const context = createMockContext({});
+
+      expect(() => guard.canActivate(context)).toThrow(UnauthorizedException);
+      expect(() => guard.canActivate(context)).toThrow(
+        'Invalid or missing admin token',
+      );
+    });
+
+    it('rejects when X-Admin-Token is an empty string', () => {
+      const context = createMockContext({ 'x-admin-token': '' });
+
+      expect(() => guard.canActivate(context)).toThrow(UnauthorizedException);
+      expect(() => guard.canActivate(context)).toThrow(
+        'Invalid or missing admin token',
+      );
+    });
+
+    it('rejects when ADMIN_TOKEN is unset and any client token is presented', () => {
+      mockConfigService.get.mockImplementation(
+        (key: string, defaultVal?: unknown) => {
+          if (key === 'ADMIN_TOKEN') return undefined;
+          if (key === 'ADMIN_IP_ALLOWLIST') return '';
+          return defaultVal;
+        },
+      );
+
+      const context = createMockContext({
+        'x-admin-token': 'anything',
+      });
+
+      expect(() => guard.canActivate(context)).toThrow(UnauthorizedException);
+    });
+
+    it('writes a 401 audit log with admin id, method, and route on failure', () => {
+      const context = createMockContext(
+        {
+          'x-admin-token': 'wrong',
+          'x-admin-id': 'auditor-42',
+        },
+        {
+          method: 'POST',
+          originalUrl: '/admin/raffles/archived',
+        },
+      );
+
+      expect(() => guard.canActivate(context)).toThrow(UnauthorizedException);
+
+      expect(mockMonitorService.logAudit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          adminId: 'auditor-42',
+          method: 'POST',
+          route: '/admin/raffles/archived',
+          statusCode: 401,
+        }),
+      );
+      const payload = mockMonitorService.logAudit.mock.calls[0][0];
+      expect(typeof payload.timestamp).toBe('string');
+      expect(Number.isNaN(Date.parse(payload.timestamp))).toBe(false);
+    });
+
+    it('falls back to unknown-admin and url when admin id / originalUrl are absent', () => {
+      const context = createMockContext(
+        { 'x-admin-token': 'wrong' },
+        { url: '/monitor/stats', method: 'GET' },
+      );
+
+      expect(() => guard.canActivate(context)).toThrow(UnauthorizedException);
+
+      expect(mockMonitorService.logAudit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          adminId: 'unknown-admin',
+          route: '/monitor/stats',
+          method: 'GET',
+          statusCode: 401,
+        }),
+      );
+    });
+
+    it('trims whitespace-only x-admin-id to unknown-admin', () => {
+      const context = createMockContext({
+        'x-admin-token': 'wrong',
+        'x-admin-id': '   ',
+      });
+
+      expect(() => guard.canActivate(context)).toThrow(UnauthorizedException);
+      expect(mockMonitorService.logAudit).toHaveBeenCalledWith(
+        expect.objectContaining({ adminId: 'unknown-admin' }),
+      );
+    });
+  });
+
+  describe('IP allowlist enforcement', () => {
+    beforeEach(() => {
+      mockConfigService.get.mockImplementation(
+        (key: string, defaultVal?: unknown) => {
+          if (key === 'ADMIN_TOKEN') return ADMIN_TOKEN;
+          if (key === 'ADMIN_IP_ALLOWLIST') return '192.168.1.100, 10.0.0.1';
+          return defaultVal;
+        },
+      );
+    });
+
+    it('rejects a valid token from a non-allowlisted IP', () => {
+      const context = createMockContext(
+        { 'x-admin-token': ADMIN_TOKEN },
+        { ip: '203.0.113.50' },
+      );
+
+      expect(() => guard.canActivate(context)).toThrow(UnauthorizedException);
+      expect(() => guard.canActivate(context)).toThrow('IP address not allowed');
+      expect(mockMonitorService.logAudit).toHaveBeenCalledWith(
+        expect.objectContaining({ statusCode: 401 }),
+      );
+    });
+
+    it('falls back to socket remoteAddress when request.ip is missing', () => {
+      const context = createMockContext(
+        { 'x-admin-token': ADMIN_TOKEN },
+        { remoteAddress: null },
+      );
+      // Override: no request.ip, but socket has allowlisted address
+      const request = (
+        context.switchToHttp().getRequest as () => Record<string, unknown>
+      )();
+      (request as { ip?: string }).ip = undefined;
+      (request as { raw: { socket: { remoteAddress: string } } }).raw.socket =
+        { remoteAddress: '192.168.1.100' };
+
+      expect(guard.canActivate(context)).toBe(true);
+    });
+
+    it('rejects when neither request.ip nor socket address is allowlisted', () => {
+      const context = createMockContext(
+        { 'x-admin-token': ADMIN_TOKEN },
+        { remoteAddress: null },
+      );
+      const request = (
+        context.switchToHttp().getRequest as () => Record<string, unknown>
+      )();
+      (request as { ip?: string }).ip = undefined;
+      (request as { raw: { socket: { remoteAddress?: string } } }).raw.socket =
+        { remoteAddress: undefined };
+
+      expect(() => guard.canActivate(context)).toThrow('IP address not allowed');
+    });
+  });
+});

--- a/backend/src/auth/decorators/public.decorator.spec.ts
+++ b/backend/src/auth/decorators/public.decorator.spec.ts
@@ -1,0 +1,26 @@
+import { IS_PUBLIC_KEY, Public } from './public.decorator';
+
+describe('Public decorator', () => {
+  it('exports IS_PUBLIC_KEY used by JwtAuthGuard metadata checks', () => {
+    expect(IS_PUBLIC_KEY).toBe('isPublic');
+  });
+
+  it('returns a SetMetadata decorator factory for isPublic=true', () => {
+    const decorator = Public();
+    expect(typeof decorator).toBe('function');
+
+    // Apply to a dummy handler to verify Nest metadata is set
+    class TestController {
+      @Public()
+      adminRoute() {
+        return true;
+      }
+    }
+
+    const metadata = Reflect.getMetadata(
+      IS_PUBLIC_KEY,
+      TestController.prototype.adminRoute,
+    );
+    expect(metadata).toBe(true);
+  });
+});

--- a/backend/src/auth/guards/jwt-auth.guard.spec.ts
+++ b/backend/src/auth/guards/jwt-auth.guard.spec.ts
@@ -1,6 +1,10 @@
-import { ExecutionContext, UnauthorizedException } from '@nestjs/common';
+import {
+  ExecutionContext,
+  UnauthorizedException,
+} from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { JwtAuthGuard } from './jwt-auth.guard';
+import { IS_PUBLIC_KEY } from '../decorators/public.decorator';
 
 const mockExecutionContext = (handler = {}, klass = {}) =>
   ({
@@ -16,6 +20,53 @@ describe('JwtAuthGuard', () => {
     reflector = { getAllAndOverride: jest.fn() } as unknown as Reflector;
   });
 
+  describe('decorator metadata (@Public)', () => {
+    it('honors @Public() metadata and skips passport auth', () => {
+      (reflector.getAllAndOverride as jest.Mock).mockReturnValue(true);
+      const guard = new JwtAuthGuard(reflector);
+      const handler = { name: 'adminRoute' };
+      const klass = { name: 'AdminRafflesController' };
+      const ctx = mockExecutionContext(handler, klass);
+
+      expect(guard.canActivate(ctx)).toBe(true);
+      expect(reflector.getAllAndOverride).toHaveBeenCalledWith(IS_PUBLIC_KEY, [
+        handler,
+        klass,
+      ]);
+    });
+
+    it('does not short-circuit when @Public() metadata is absent/false', () => {
+      (reflector.getAllAndOverride as jest.Mock).mockReturnValue(false);
+      const guard = new JwtAuthGuard(reflector);
+      const superCanActivate = jest
+        .spyOn(
+          Object.getPrototypeOf(Object.getPrototypeOf(guard)),
+          'canActivate',
+        )
+        .mockReturnValue(true);
+
+      const ctx = mockExecutionContext();
+      expect(guard.canActivate(ctx)).toBe(true);
+      expect(superCanActivate).toHaveBeenCalledWith(ctx);
+    });
+
+    it('treats undefined public metadata as protected (delegates to passport)', () => {
+      (reflector.getAllAndOverride as jest.Mock).mockReturnValue(undefined);
+      const guard = new JwtAuthGuard(reflector);
+      const superCanActivate = jest
+        .spyOn(
+          Object.getPrototypeOf(Object.getPrototypeOf(guard)),
+          'canActivate',
+        )
+        .mockReturnValue('passport-result' as unknown as boolean);
+
+      expect(guard.canActivate(mockExecutionContext())).toBe(
+        'passport-result' as unknown as boolean,
+      );
+      expect(superCanActivate).toHaveBeenCalled();
+    });
+  });
+
   describe('canActivate', () => {
     it('returns true without calling super when route is @Public()', () => {
       (reflector.getAllAndOverride as jest.Mock).mockReturnValue(true);
@@ -28,8 +79,11 @@ describe('JwtAuthGuard', () => {
     it('delegates to passport when route is not @Public()', () => {
       (reflector.getAllAndOverride as jest.Mock).mockReturnValue(false);
       const guard = new JwtAuthGuard(reflector);
-      // Stub AuthGuard's canActivate so we don't need a real Passport setup
-      jest.spyOn(Object.getPrototypeOf(Object.getPrototypeOf(guard)), 'canActivate')
+      jest
+        .spyOn(
+          Object.getPrototypeOf(Object.getPrototypeOf(guard)),
+          'canActivate',
+        )
         .mockReturnValue(true);
 
       const ctx = mockExecutionContext();
@@ -37,22 +91,53 @@ describe('JwtAuthGuard', () => {
     });
   });
 
-  describe('handleRequest', () => {
-    it('returns the user when present and no error', () => {
+  describe('handleRequest — authorized user', () => {
+    it('returns the user when present and no error (valid token path)', () => {
       const guard = new JwtAuthGuard(reflector);
       const user = { address: 'GXYZ', iat: 1, exp: 9999999999 };
       expect(guard.handleRequest(null, user)).toBe(user);
     });
+  });
 
-    it('throws UnauthorizedException when user is falsy', () => {
+  describe('handleRequest — missing / expired / malformed token (401)', () => {
+    it('throws UnauthorizedException when user is missing (no token)', () => {
       const guard = new JwtAuthGuard(reflector);
-      expect(() => guard.handleRequest(null, null)).toThrow(UnauthorizedException);
+      expect(() => guard.handleRequest(null, null)).toThrow(
+        UnauthorizedException,
+      );
+      expect(() => guard.handleRequest(null, null)).toThrow(
+        'Invalid or missing token',
+      );
     });
 
-    it('re-throws the original error when one is provided', () => {
+    it('throws UnauthorizedException when user is undefined', () => {
       const guard = new JwtAuthGuard(reflector);
-      const err = new UnauthorizedException('token expired');
+      expect(() => guard.handleRequest(null, undefined as never)).toThrow(
+        UnauthorizedException,
+      );
+    });
+
+    it('re-throws expired-token errors from passport', () => {
+      const guard = new JwtAuthGuard(reflector);
+      const err = new UnauthorizedException('jwt expired');
       expect(() => guard.handleRequest(err, null)).toThrow(err);
+      expect(() => guard.handleRequest(err, null)).toThrow('jwt expired');
+    });
+
+    it('re-throws malformed-token errors from passport', () => {
+      const guard = new JwtAuthGuard(reflector);
+      const err = new UnauthorizedException('jwt malformed');
+      expect(() => guard.handleRequest(err, false as never)).toThrow(err);
+      expect(() => guard.handleRequest(err, false as never)).toThrow(
+        'jwt malformed',
+      );
+    });
+
+    it('prefers the original error over a present user (error wins)', () => {
+      const guard = new JwtAuthGuard(reflector);
+      const err = new UnauthorizedException('invalid signature');
+      const user = { address: 'GABC' };
+      expect(() => guard.handleRequest(err, user)).toThrow(err);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Add dedicated `AdminGuard` unit tests covering valid admin token, wrong/ordinary credentials, missing/malformed tokens, IP allowlist enforcement, and 401 audit logging.
- Expand `JwtAuthGuard` unit tests for `@Public()` decorator metadata, valid users, and missing/expired/malformed token error paths.
- Add `Public` decorator metadata unit tests so admin routes that skip JWT via `@Public()` stay covered.

Closes #1082

## Test plan
- [x] `pnpm run test -- --ci --testPathPattern=admin.guard.spec|jwt-auth.guard.spec|public.decorator.spec` in `backend/` (28 passed)
- [ ] Confirm Backend CI on this PR