### PR TITLE
[1101] [sdk] Document the bundle-size budget and size-check workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,6 +88,19 @@ File: `sdk/src/test/rpc-integration.spec.ts`
 These are currently mock-based and run as part of the normal unit test suite.
 A future issue will convert them to use a real Soroban testnet endpoint.
 
+## SDK bundle size
+
+The SDK enforces gzip size budgets on the read-only and light entry points via
+`size-limit`. See [sdk/README.md — Bundle size budget and size-check workflow](./sdk/README.md#bundle-size-budget-and-size-check-workflow)
+for current limits, how to run `pnpm --filter sdk size-check`, and remediation
+steps when a PR grows the bundle.
+
+```bash
+pnpm --filter sdk run build:read
+pnpm --filter sdk run build:light
+pnpm --filter sdk run size-check
+```
+
 ## Pull request checklist
 
 - [ ] `pnpm test` passes with no new failures.
@@ -96,3 +109,5 @@ A future issue will convert them to use a real Soroban testnet endpoint.
 - [ ] New public APIs include JSDoc.
 - [ ] Integration tests (if added) are gated behind `TEST_INTEGRATION=true`.
 - [ ] `CONTRIBUTING.md` is updated if new integration test setup is required.
+- [ ] SDK PRs that touch public exports or read/light entry graphs:
+  `pnpm --filter sdk size-check` passes (see SDK bundle size section above).

--- a/sdk/LIGHT_VERSION.md
+++ b/sdk/LIGHT_VERSION.md
@@ -4,7 +4,7 @@ A lightweight, framework-agnostic version of the Tikka SDK designed for mobile a
 
 ## Features
 - **Zero NestJS Overheads**: No decorators or dependency injection logic.
-- **Small Footprint**: Target < 50kb gzipped.
+- **Small Footprint**: Soft target < 50 kB gzipped; enforced budget **25 kB** gzip via `pnpm run size-check` (see [README — Bundle size budget](./README.md#bundle-size-budget-and-size-check-workflow)).
 - **ESM Ready**: Optimized for modern bundlers (Vite, Webpack 5).
 
 ## Usage

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -73,6 +73,74 @@ cd sdk
 pnpm run build:read   # outputs to dist/read/
 ```
 
+## Bundle size budget and size-check workflow
+
+The SDK keeps browser-facing entry points small. Contributors whose PRs grow
+these bundles should know the limit and how to remediate before merging.
+
+### Budgets (enforced by `size-limit`)
+
+Budgets are defined in `sdk/package.json` under the `"size-limit"` key. Sizes are
+**minified + gzipped**, with NestJS / Stellar / RxJS peer-style dependencies
+ignored so the check measures first-party SDK code (what consumers pay for on
+top of deps they already ship).
+
+| Entry | Build output | Budget | Typical size (approx.) |
+|-------|--------------|--------|------------------------|
+| `@tikka/sdk/read` | `dist/read/index.read.js` | **50 kB** gzip | ~7 kB |
+| Light SDK (`index.light`) | `dist/light/index.light.js` | **25 kB** gzip | ~3 kB |
+
+The light entry also has a historical soft target of < 50 kB gzip documented in
+[`LIGHT_VERSION.md`](./LIGHT_VERSION.md); the **25 kB** limit above is the
+enforced budget based on current measured size with headroom for growth.
+
+The full NestJS entry (`@tikka/sdk`) is not size-gated — prefer `@tikka/sdk/read`
+or the light entry for browser/mobile consumers.
+
+### Running the checks
+
+```bash
+cd sdk
+pnpm install
+
+# Build the entries under test (required before size-check)
+pnpm run build:read
+pnpm run build:light
+
+# Enforced budgets (fails the process if over limit)
+pnpm run size-check
+
+# Legacy helper: prints the raw byte length of dist/light/index.light.js only
+# (no budget assertion — useful for a quick local sanity check on Windows)
+pnpm run size-check:legacy
+```
+
+CI currently runs SDK lint/test/build/docs; run `size-check` locally (or in a
+PR follow-up job) whenever you change SDK public exports, network/RPC code, or
+anything imported by the read/light entry points.
+
+### When `size-check` fails
+
+1. Confirm you rebuilt: `pnpm run build:read` and/or `pnpm run build:light`.
+2. Re-run `pnpm run size-check` and note which entry exceeded its budget.
+3. **Audit imports** on the failing entry:
+   - Prefer `@tikka/sdk/read` or the light entry over the full `@tikka/sdk` barrel.
+   - Do not pull wallet adapters, signing, SEP-10, fee estimation, or NestJS
+     modules into the read/light graphs.
+   - Avoid new heavy dependencies in files reachable from `index.read.ts` /
+     `index.light.ts`.
+4. Split write-only helpers behind the main or `./write` entry so tree-shaking
+   can drop them from read/light consumers.
+5. If the growth is intentional and justified, update the matching `"limit"` in
+   `package.json` `"size-limit"` in the same PR and explain why in the PR body.
+
+### Changing a budget
+
+Edit the `"size-limit"` array in `sdk/package.json`, keep `"gzip": true`, and
+leave peer-style packages in `"ignore"` unless you intentionally want them
+counted. After changing a limit, run the build + `size-check` commands above and
+document the rationale in the PR.
+
 ## Project Structure
 
 - `src/network/` — Customizable Soroban RPC and Horizon services.

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -53,7 +53,29 @@
       "name": "@tikka/sdk/read",
       "path": "dist/read/index.read.js",
       "limit": "50 kB",
-      "gzip": true
+      "gzip": true,
+      "ignore": [
+        "@nestjs/common",
+        "@nestjs/core",
+        "@stellar/stellar-sdk",
+        "rxjs",
+        "reflect-metadata",
+        "bignumber.js"
+      ]
+    },
+    {
+      "name": "@tikka/sdk light",
+      "path": "dist/light/index.light.js",
+      "limit": "25 kB",
+      "gzip": true,
+      "ignore": [
+        "@nestjs/common",
+        "@nestjs/core",
+        "@stellar/stellar-sdk",
+        "rxjs",
+        "reflect-metadata",
+        "bignumber.js"
+      ]
     }
   ],
   "dependencies": {

--- a/sdk/src/modules/user/user.read.service.ts
+++ b/sdk/src/modules/user/user.read.service.ts
@@ -64,7 +64,7 @@ export class ReadOnlyUserService {
   async getHistory(address: string): Promise<ContractResponse<number[]>> {
     assertValidPublicKey(address);
     const profile = await this.getProfile(address);
-    if (!profile.success) return profile as ContractResponse<number[]>;
+    if (!profile.success) return profile as unknown as ContractResponse<number[]>;
     return { success: true, value: profile.value!.raffleIds };
   }
 

--- a/sdk/src/modules/user/user.service.ts
+++ b/sdk/src/modules/user/user.service.ts
@@ -237,7 +237,7 @@ export class UserService {
    * @param address - The winner's Stellar public key
    * @returns Array of WinningEntry objects, one per won raffle
    */
-  async getWinnings(address: string): Promise {
+  async getWinnings(address: string): Promise<ContractResponse<WinningEntry[]>> {
     assertValidPublicKey(address);
 
     const activityResult = await this.getActivitySummary({ address });


### PR DESCRIPTION
## Summary
- Document SDK bundle-size budgets and the `size-check` / `size-check:legacy` workflow in `sdk/README.md`, with a pointer from `CONTRIBUTING.md`.
- Keep the existing **50 kB** gzip budget for `@tikka/sdk/read`, and propose/enforce a **25 kB** gzip budget for the light entry based on current measured size (~3 kB).
- Make `size-limit` ignore peer-style NestJS/Stellar/RxJS deps so `pnpm run size-check` actually runs, and fix two small TypeScript issues that blocked a clean `build` / `build:read`.

Closes #1101

## Test plan
- [x] `pnpm --filter sdk run build`
- [x] `pnpm --filter sdk run build:read` and `build:light`
- [x] `pnpm --filter sdk run size-check` (read ~7.16 kB / 50 kB; light ~3.05 kB / 25 kB)
- [ ] Review docs in `sdk/README.md` and `CONTRIBUTING.md`