### PR TITLE
[1100] [sdk] Validate ticket purchase inputs before building transactions

### DIFF
--- a/sdk/jest.config.cjs
+++ b/sdk/jest.config.cjs
@@ -1,0 +1,23 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  moduleFileExtensions: ['js', 'json', 'ts'],
+  rootDir: 'src',
+  testRegex: '.*\\.spec\\.ts$',
+  transform: {
+    // isolatedModules avoids failing the suite on pre-existing ambient TS issues
+    // while still compiling specs under ts-jest.
+    '^.+\\.(t|j)s$': [
+      'ts-jest',
+      {
+        isolatedModules: true,
+        diagnostics: { warnOnly: true },
+      },
+    ],
+  },
+  // stellar-sdk@16 pulls ESM-only deps (@noble/*, uint8array-extras, …).
+  // Transform those (and their pnpm-nested copies) so Jest can load them.
+  transformIgnorePatterns: [
+    '/node_modules/(?!.*(uint8array-extras|@noble|@stellar|@scure|base32\\.js)/)',
+  ],
+  testEnvironment: 'node',
+};

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -34,7 +34,7 @@
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
     "lint": "eslint \"{src,test}/**/*.ts\"",
-    "test": "jest",
+    "test": "jest --config jest.config.cjs",
     "tikka": "node bin/tikka.mjs",
     "examples:check": "tsc --project examples/tsconfig.json",
     "example:cli": "node bin/tikka.mjs",
@@ -88,18 +88,5 @@
     "typedoc": "^0.28.18",
     "typedoc-plugin-markdown": "4.12",
     "typescript": "^5.6.0"
-  },
-  "jest": {
-    "moduleFileExtensions": [
-      "js",
-      "json",
-      "ts"
-    ],
-    "rootDir": "src",
-    "testRegex": ".*\\.spec\\.ts$",
-    "transform": {
-      "^.+\\.(t|j)s$": "ts-jest"
-    },
-    "testEnvironment": "node"
   }
 }

--- a/sdk/pnpm-workspace.yaml
+++ b/sdk/pnpm-workspace.yaml
@@ -1,4 +1,2 @@
-allowBuilds:
-  '@nestjs/core': set this to true or false
-  esbuild: set this to true or false
-  unrs-resolver: set this to true or false
+packages:
+  - '.'

--- a/sdk/pnpm-workspace.yaml
+++ b/sdk/pnpm-workspace.yaml
@@ -1,2 +1,4 @@
-packages:
-  - '.'
+allowBuilds:
+  '@nestjs/core': set this to true or false
+  esbuild: set this to true or false
+  unrs-resolver: set this to true or false

--- a/sdk/src/contract/contract.service.spec.ts
+++ b/sdk/src/contract/contract.service.spec.ts
@@ -15,7 +15,7 @@ import { TransactionLifecycle } from './lifecycle';
 import { RpcService } from '../network/rpc.service';
 import { HorizonService } from '../network/horizon.service';
 import { NetworkConfig, TikkaNetwork } from '../network/network.config';
-import { TikkaSdkErrorCode } from '../utils/errors';
+import { TikkaSdkError, TikkaSdkErrorCode } from '../utils/errors';
 import { WalletAdapter, WalletName } from '../wallet/wallet.interface';
 import { ContractFn } from './bindings';
 

--- a/sdk/src/modules/admin/admin.service.spec.ts
+++ b/sdk/src/modules/admin/admin.service.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AdminService } from './admin.service';
 import { ContractService } from '../../contract/contract.service';
+import { TikkaSdkError, TikkaSdkErrorCode } from '../../utils/errors';
 
 describe('AdminService', () => {
   let service: AdminService;
@@ -10,6 +11,7 @@ describe('AdminService', () => {
     const mockContractService = {
       invoke: jest.fn(),
       simulateReadOnly: jest.fn(),
+      getPublicKey: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -128,20 +130,19 @@ describe('AdminService', () => {
     it('should allow creator to cancel their own raffle', async () => {
       const creatorAddress = 'GCREATOR1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890AB';
       contractService.getPublicKey.mockResolvedValue(creatorAddress);
-      contractService.simulateReadOnly
-        .mockResolvedValueOnce({
-          status: 'SUCCESS' as const,
-          value: {
-            creator: creatorAddress,
-            status: 0, // Open
-          },
-        })
-        .mockResolvedValueOnce({
-          status: 'SUCCESS' as const,
-          value: undefined,
-          txHash: 'mno345',
-          ledger: 104,
-        });
+      contractService.simulateReadOnly.mockResolvedValueOnce({
+        success: true,
+        value: {
+          creator: creatorAddress,
+          status: 0, // Open
+        },
+      });
+      contractService.invoke.mockResolvedValue({
+        status: 'SUCCESS' as const,
+        value: undefined,
+        txHash: 'mno345',
+        ledger: 104,
+      });
 
       const result = await service.cancelRaffle(1);
 
@@ -158,22 +159,22 @@ describe('AdminService', () => {
       contractService.getPublicKey.mockResolvedValue(callerAddress);
       contractService.simulateReadOnly
         .mockResolvedValueOnce({
-          status: 'SUCCESS' as const,
+          success: true,
           value: {
             creator: creatorAddress,
             status: 0, // Open
           },
         })
         .mockResolvedValueOnce({
-          status: 'SUCCESS' as const,
+          success: true,
           value: adminAddress,
-        })
-        .mockResolvedValueOnce({
-          status: 'SUCCESS' as const,
-          value: undefined,
-          txHash: 'pqr678',
-          ledger: 105,
         });
+      contractService.invoke.mockResolvedValue({
+        status: 'SUCCESS' as const,
+        value: undefined,
+        txHash: 'pqr678',
+        ledger: 105,
+      });
 
       const result = await service.cancelRaffle(2);
 
@@ -188,16 +189,21 @@ describe('AdminService', () => {
       const callerAddress = 'GOTHER1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890AB';
 
       contractService.getPublicKey.mockResolvedValue(callerAddress);
-      contractService.simulateReadOnly.mockResolvedValueOnce({
-        status: 'SUCCESS' as const,
-        value: {
-          creator: creatorAddress,
-          status: 0, // Open
-        },
-      });
+      contractService.simulateReadOnly
+        .mockResolvedValueOnce({
+          success: true,
+          value: {
+            creator: creatorAddress,
+            status: 0, // Open
+          },
+        })
+        .mockResolvedValueOnce({
+          success: true,
+          value: 'GADMIN1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890AB',
+        });
 
-      await expect(service.cancelRaffle(3)).rejects.toThrow(TikkaSdkError);
       await expect(service.cancelRaffle(3)).rejects.toMatchObject({
+        name: 'TikkaSdkError',
         code: TikkaSdkErrorCode.Unauthorized,
       });
 
@@ -206,7 +212,7 @@ describe('AdminService', () => {
 
     it('should return error response if raffle data fetch fails', async () => {
       contractService.simulateReadOnly.mockResolvedValueOnce({
-        status: 'ERROR' as const,
+        success: false,
         error: 'Raffle not found',
       });
 

--- a/sdk/src/modules/raffle/raffle.service.spec.ts
+++ b/sdk/src/modules/raffle/raffle.service.spec.ts
@@ -24,7 +24,11 @@ describe("RaffleService", () => {
     feeEstimator = {
       estimate: jest.fn(),
       estimateFee: jest.fn(),
-      estimateFromResourceFee: jest.fn(),
+      estimateFromResourceFee: jest.fn().mockReturnValue({
+        xlm: "0.0005100",
+        stroops: "5100",
+        resources: {} as any,
+      }),
     } as any;
 
     service = new RaffleService(contractService, feeEstimator);
@@ -47,7 +51,7 @@ describe("RaffleService", () => {
         assembledXdr: "unsigned-xdr",
         networkPassphrase: "passphrase",
       });
-      feeEstimator.estimate.mockResolvedValue({
+      feeEstimator.estimateFee.mockResolvedValue({
         xlm: "0.0005123",
         stroops: "5123",
         resources: {} as any,
@@ -55,12 +59,10 @@ describe("RaffleService", () => {
 
       const result = await service.estimateCreate(params);
 
-      expect(contractService.simulate).toHaveBeenCalledWith(
-        ContractFn.CREATE_RAFFLE,
-        expect.any(Array),
-        expect.anything(),
-      );
-      expect(feeEstimator.estimate).toHaveBeenCalledWith(expect.anything());
+      expect(feeEstimator.estimateFee).toHaveBeenCalledWith({
+        method: ContractFn.CREATE_RAFFLE,
+        params: expect.any(Array),
+      });
       expect(result).toEqual({ xlm: "0.0005123", stroops: "5123" });
     });
   });
@@ -82,7 +84,7 @@ describe("RaffleService", () => {
         assembledXdr: "unsigned-xdr",
         networkPassphrase: "passphrase",
       });
-      feeEstimator.estimate.mockResolvedValue({
+      feeEstimator.estimateFromResourceFee.mockReturnValue({
         xlm: "0.0005100",
         stroops: "5100",
         resources: {} as any,
@@ -102,7 +104,7 @@ describe("RaffleService", () => {
         expect.any(Array),
         expect.anything(),
       );
-      expect(feeEstimator.estimate).toHaveBeenCalledWith(expect.anything());
+      expect(feeEstimator.estimateFromResourceFee).toHaveBeenCalledWith("5000");
       expect(contractService.sign).toHaveBeenCalledWith(
         "unsigned-xdr",
         "passphrase",
@@ -224,6 +226,23 @@ describe("RaffleService", () => {
   });
 
   describe("cancel", () => {
+    beforeEach(() => {
+      contractService.simulateReadOnly.mockResolvedValue({
+        status: "SUCCESS" as const,
+        value: {
+          ticket_price: "10",
+          max_tickets: 100,
+          end_time: BigInt(Math.floor(Date.now() / 1000) + 86400),
+          allow_multiple: true,
+          asset: "XLM",
+          asset_issuer: "",
+          status: 0, // Open
+          tickets_sold: 0,
+          creator: "GCREATOR",
+        },
+      });
+    });
+
     it("should invoke CANCEL_RAFFLE", async () => {
       const mockInvokeResult = {
         status: "SUCCESS" as const,
@@ -293,7 +312,7 @@ describe("RaffleService", () => {
         assembledXdr: "unsigned-xdr",
         networkPassphrase: "passphrase",
       });
-      feeEstimator.estimate.mockResolvedValue({
+      feeEstimator.estimateFromResourceFee.mockReturnValue({
         xlm: "0.0005100",
         stroops: "5100",
         resources: {} as any,
@@ -325,7 +344,7 @@ describe("RaffleService", () => {
         assembledXdr: "unsigned-xdr",
         networkPassphrase: "passphrase",
       });
-      feeEstimator.estimate.mockResolvedValue({
+      feeEstimator.estimateFromResourceFee.mockReturnValue({
         xlm: "0.0005100",
         stroops: "5100",
         resources: {} as any,

--- a/sdk/src/modules/ticket/index.ts
+++ b/sdk/src/modules/ticket/index.ts
@@ -1,3 +1,4 @@
 export * from './ticket.module';
 export * from './ticket.service';
 export * from './ticket.types';
+export * from './purchase-validation';

--- a/sdk/src/modules/ticket/purchase-validation.spec.ts
+++ b/sdk/src/modules/ticket/purchase-validation.spec.ts
@@ -1,0 +1,103 @@
+import {
+  assertValidRaffleId,
+  assertValidStroopsAmount,
+  assertValidTicketQuantity,
+  InvalidTicketPurchaseError,
+  validateBuyTicketInputs,
+  validateBuyTicketsInputs,
+} from './purchase-validation';
+import { TICKET_CONSTRAINTS } from './ticket.types';
+import { TikkaSdkErrorCode } from '../../utils/errors';
+
+describe('purchase-validation', () => {
+  describe('assertValidRaffleId', () => {
+    it.each([0, -1, 1.5, NaN, Infinity, -Infinity])(
+      'rejects malformed raffle id %p with typed error',
+      (raffleId) => {
+        expect(() => assertValidRaffleId(raffleId as number)).toThrow(InvalidTicketPurchaseError);
+        try {
+          assertValidRaffleId(raffleId as number);
+        } catch (err) {
+          expect(err).toMatchObject({
+            field: 'raffleId',
+            code: TikkaSdkErrorCode.ValidationError,
+          });
+        }
+      },
+    );
+
+    it('accepts a positive integer raffle id', () => {
+      expect(() => assertValidRaffleId(1)).not.toThrow();
+    });
+  });
+
+  describe('assertValidTicketQuantity', () => {
+    it('rejects 0', () => {
+      expect(() => assertValidTicketQuantity(0)).toThrow(InvalidTicketPurchaseError);
+      expect(() => assertValidTicketQuantity(0)).toThrow(
+        `quantity must be at least ${TICKET_CONSTRAINTS.MIN_QUANTITY}`,
+      );
+    });
+
+    it('rejects negative', () => {
+      expect(() => assertValidTicketQuantity(-5)).toThrow(InvalidTicketPurchaseError);
+    });
+
+    it('rejects non-integer', () => {
+      expect(() => assertValidTicketQuantity(1.5)).toThrow(/must be an integer/);
+    });
+
+    it('rejects above max', () => {
+      expect(() =>
+        assertValidTicketQuantity(TICKET_CONSTRAINTS.MAX_QUANTITY + 1),
+      ).toThrow(/must not exceed/);
+    });
+
+    it('accepts min and max boundaries', () => {
+      expect(() =>
+        assertValidTicketQuantity(TICKET_CONSTRAINTS.MIN_QUANTITY),
+      ).not.toThrow();
+      expect(() =>
+        assertValidTicketQuantity(TICKET_CONSTRAINTS.MAX_QUANTITY),
+      ).not.toThrow();
+    });
+  });
+
+  describe('assertValidStroopsAmount', () => {
+    it('rejects decimal / wrong asset precision', () => {
+      expect(() => assertValidStroopsAmount('1.5')).toThrow(InvalidTicketPurchaseError);
+      expect(() => assertValidStroopsAmount('1.5')).toThrow(/wrong asset precision/);
+    });
+
+    it('rejects empty and non-numeric strings', () => {
+      expect(() => assertValidStroopsAmount('')).toThrow(InvalidTicketPurchaseError);
+      expect(() => assertValidStroopsAmount('abc')).toThrow(InvalidTicketPurchaseError);
+    });
+
+    it('accepts integer stroops strings', () => {
+      expect(() => assertValidStroopsAmount('0')).not.toThrow();
+      expect(() => assertValidStroopsAmount('1000000')).not.toThrow();
+    });
+  });
+
+  describe('validateBuyTicketInputs / validateBuyTicketsInputs', () => {
+    it('validateBuyTicketInputs aggregates raffle + quantity checks', () => {
+      expect(() => validateBuyTicketInputs({ raffleId: 0, quantity: 1 })).toThrow(
+        InvalidTicketPurchaseError,
+      );
+      expect(() => validateBuyTicketInputs({ raffleId: 1, quantity: 0 })).toThrow(
+        InvalidTicketPurchaseError,
+      );
+    });
+
+    it('validateBuyTicketsInputs also checks maxPricePerTicket precision', () => {
+      expect(() =>
+        validateBuyTicketsInputs({
+          raffleId: 1,
+          count: 1,
+          maxPricePerTicket: '1.0000001',
+        }),
+      ).toThrow(/wrong asset precision/);
+    });
+  });
+});

--- a/sdk/src/modules/ticket/purchase-validation.ts
+++ b/sdk/src/modules/ticket/purchase-validation.ts
@@ -1,0 +1,133 @@
+import { TikkaSdkError, TikkaSdkErrorCode } from '../../utils/errors';
+import { TICKET_CONSTRAINTS } from './ticket.types';
+
+/** Fields that can fail ticket-purchase input validation. */
+export type TicketPurchaseField =
+  | 'raffleId'
+  | 'quantity'
+  | 'count'
+  | 'maxPricePerTicket'
+  | 'purchases';
+
+/**
+ * Typed validation error for ticket purchase inputs.
+ * Thrown at the module boundary before any network call or tx build.
+ */
+export class InvalidTicketPurchaseError extends TikkaSdkError {
+  constructor(
+    public readonly field: TicketPurchaseField,
+    message: string,
+    cause?: unknown,
+  ) {
+    super(TikkaSdkErrorCode.ValidationError, message, cause);
+    this.name = 'InvalidTicketPurchaseError';
+    Object.setPrototypeOf(this, InvalidTicketPurchaseError.prototype);
+  }
+}
+
+/**
+ * Validates raffle id is a positive safe integer.
+ * Rejects 0, negative, non-integer, NaN, and Infinity.
+ */
+export function assertValidRaffleId(raffleId: number, fieldName: TicketPurchaseField = 'raffleId'): void {
+  if (typeof raffleId !== 'number' || Number.isNaN(raffleId) || !Number.isFinite(raffleId)) {
+    throw new InvalidTicketPurchaseError(
+      fieldName,
+      `${fieldName} must be a finite number, got ${raffleId}`,
+    );
+  }
+  if (!Number.isInteger(raffleId) || raffleId <= 0 || !Number.isSafeInteger(raffleId)) {
+    throw new InvalidTicketPurchaseError(
+      fieldName,
+      `${fieldName} must be a positive integer, got ${raffleId}`,
+    );
+  }
+}
+
+/**
+ * Validates ticket quantity / count against module constraints.
+ * Covers 0, negative, non-integer, and max boundary.
+ */
+export function assertValidTicketQuantity(
+  quantity: number,
+  fieldName: 'quantity' | 'count' = 'quantity',
+): void {
+  if (typeof quantity !== 'number' || Number.isNaN(quantity) || !Number.isFinite(quantity)) {
+    throw new InvalidTicketPurchaseError(
+      fieldName,
+      `${fieldName} must be a finite number, got ${quantity}`,
+    );
+  }
+  if (!Number.isInteger(quantity)) {
+    throw new InvalidTicketPurchaseError(
+      fieldName,
+      `${fieldName} must be an integer, got ${quantity}`,
+    );
+  }
+  if (quantity < TICKET_CONSTRAINTS.MIN_QUANTITY) {
+    throw new InvalidTicketPurchaseError(
+      fieldName,
+      `${fieldName} must be at least ${TICKET_CONSTRAINTS.MIN_QUANTITY}, got ${quantity}`,
+    );
+  }
+  if (quantity > TICKET_CONSTRAINTS.MAX_QUANTITY) {
+    throw new InvalidTicketPurchaseError(
+      fieldName,
+      `${fieldName} must not exceed ${TICKET_CONSTRAINTS.MAX_QUANTITY}, got ${quantity}`,
+    );
+  }
+}
+
+/**
+ * Validates a price expressed in stroops (integer asset amount).
+ * Rejects decimals / wrong asset precision, empty, negative, and non-numeric values.
+ */
+export function assertValidStroopsAmount(
+  amount: string,
+  fieldName: TicketPurchaseField = 'maxPricePerTicket',
+): void {
+  if (typeof amount !== 'string' || amount.trim() === '') {
+    throw new InvalidTicketPurchaseError(
+      fieldName,
+      `${fieldName} must be a non-empty stroops integer string`,
+    );
+  }
+  // Stroops are whole units — decimal strings indicate wrong asset precision.
+  if (!/^\d+$/.test(amount)) {
+    throw new InvalidTicketPurchaseError(
+      fieldName,
+      `${fieldName} must be a non-negative integer stroops string (wrong asset precision): "${amount}"`,
+    );
+  }
+  if (amount !== '0' && amount.startsWith('0')) {
+    throw new InvalidTicketPurchaseError(
+      fieldName,
+      `${fieldName} must not have leading zeros: "${amount}"`,
+    );
+  }
+}
+
+/**
+ * Module-boundary validation for a single `buy` purchase.
+ * Must run before any simulate/invoke so invalid inputs never build transactions.
+ */
+export function validateBuyTicketInputs(params: {
+  raffleId: number;
+  quantity: number;
+}): void {
+  assertValidRaffleId(params.raffleId);
+  assertValidTicketQuantity(params.quantity, 'quantity');
+}
+
+/**
+ * Module-boundary validation for `buyTickets` (batch entry with price ceiling).
+ */
+export function validateBuyTicketsInputs(params: {
+  raffleId: number;
+  count: number;
+  maxPricePerTicket: string;
+}): void {
+  assertValidRaffleId(params.raffleId);
+  assertValidTicketQuantity(params.count, 'count');
+  assertValidStroopsAmount(params.maxPricePerTicket, 'maxPricePerTicket');
+}

--- a/sdk/src/modules/ticket/ticket.service.spec.ts
+++ b/sdk/src/modules/ticket/ticket.service.spec.ts
@@ -4,6 +4,7 @@ import { ContractFn } from '../../contract/bindings';
 import { BuyTicketParams, RefundTicketParams, BuyBatchParams, BuyTicketsParams, TICKET_CONSTRAINTS } from './ticket.types';
 import { TikkaSdkError, TikkaSdkErrorCode } from '../../utils/errors';
 import { RaffleStatus } from '../../contract/bindings';
+import { InvalidTicketPurchaseError } from './purchase-validation';
 
 describe('TicketService', () => {
   let service: TicketService;
@@ -67,27 +68,54 @@ describe('TicketService', () => {
 
     it('should throw if raffleId is invalid', async () => {
       const params: BuyTicketParams = { raffleId: 0, quantity: 1 };
+      await expect(service.buy(params)).rejects.toThrow(InvalidTicketPurchaseError);
       await expect(service.buy(params)).rejects.toThrow('raffleId must be a positive integer');
+      expect(contractService.simulateReadOnly).not.toHaveBeenCalled();
+      expect(contractService.invoke).not.toHaveBeenCalled();
     });
 
     it('should throw if quantity is not an integer', async () => {
       const params: BuyTicketParams = { raffleId: 1, quantity: 1.5 };
+      await expect(service.buy(params)).rejects.toThrow(InvalidTicketPurchaseError);
       await expect(service.buy(params)).rejects.toThrow('quantity must be an integer');
+      expect(contractService.invoke).not.toHaveBeenCalled();
     });
 
     it('should throw if quantity is zero', async () => {
       const params: BuyTicketParams = { raffleId: 1, quantity: 0 };
+      await expect(service.buy(params)).rejects.toThrow(InvalidTicketPurchaseError);
       await expect(service.buy(params)).rejects.toThrow(`quantity must be at least ${TICKET_CONSTRAINTS.MIN_QUANTITY}`);
+      expect(contractService.invoke).not.toHaveBeenCalled();
     });
 
     it('should throw if quantity is negative', async () => {
       const params: BuyTicketParams = { raffleId: 1, quantity: -5 };
+      await expect(service.buy(params)).rejects.toThrow(InvalidTicketPurchaseError);
       await expect(service.buy(params)).rejects.toThrow(`quantity must be at least ${TICKET_CONSTRAINTS.MIN_QUANTITY}`);
+      expect(contractService.invoke).not.toHaveBeenCalled();
     });
 
     it('should throw if quantity exceeds maximum', async () => {
       const params: BuyTicketParams = { raffleId: 1, quantity: TICKET_CONSTRAINTS.MAX_QUANTITY + 1 };
+      await expect(service.buy(params)).rejects.toThrow(InvalidTicketPurchaseError);
       await expect(service.buy(params)).rejects.toThrow(`quantity must not exceed ${TICKET_CONSTRAINTS.MAX_QUANTITY}`);
+      expect(contractService.invoke).not.toHaveBeenCalled();
+    });
+
+    it('should accept quantity at max boundary without building until after validation', async () => {
+      const params: BuyTicketParams = {
+        raffleId: 1,
+        quantity: TICKET_CONSTRAINTS.MAX_QUANTITY,
+      };
+      contractService.invoke.mockResolvedValue({
+        success: true,
+        value: [1],
+        transactionHash: 'tx',
+        ledger: 1,
+        feeCharged: '1',
+      });
+      await service.buy(params);
+      expect(contractService.invoke).toHaveBeenCalled();
     });
 
     it('should detect duplicate submissions', async () => {
@@ -213,6 +241,20 @@ describe('TicketService', () => {
       };
 
       await expect(service.buyTickets(params)).rejects.toThrow(`count must not exceed ${TICKET_CONSTRAINTS.MAX_QUANTITY}`);
+      expect(contractService.invoke).not.toHaveBeenCalled();
+    });
+
+    it('should throw typed error for wrong maxPricePerTicket asset precision', async () => {
+      const params: BuyTicketsParams = {
+        raffleId: 1,
+        count: 1,
+        maxPricePerTicket: '1.5',
+      };
+
+      await expect(service.buyTickets(params)).rejects.toThrow(InvalidTicketPurchaseError);
+      await expect(service.buyTickets(params)).rejects.toThrow(/wrong asset precision/);
+      expect(contractService.simulateReadOnly).not.toHaveBeenCalled();
+      expect(contractService.invoke).not.toHaveBeenCalled();
     });
   });
 

--- a/sdk/src/modules/ticket/ticket.service.ts
+++ b/sdk/src/modules/ticket/ticket.service.ts
@@ -19,37 +19,19 @@ import { ContractResponse } from '../../contract/response';
 import { assertPositiveInt } from '../../utils/validation';
 import { TikkaSdkError, TikkaSdkErrorCode, toTypedSdkError } from '../../utils/errors';
 import { validateLifecycleTransition } from '../../contract/lifecycle';
+import {
+  assertValidRaffleId,
+  assertValidTicketQuantity,
+  InvalidTicketPurchaseError,
+  validateBuyTicketInputs,
+  validateBuyTicketsInputs,
+} from './purchase-validation';
 
 @Injectable()
 export class TicketService {
   private readonly submissionTracker = new Map<string, Set<string>>();
 
   constructor(private readonly contractService: ContractService) {}
-
-  /**
-   * Validates ticket purchase quantity constraints.
-   * @throws TikkaSdkError if quantity is invalid
-   */
-  private validateQuantity(quantity: number, fieldName = "quantity"): void {
-    if (!Number.isInteger(quantity)) {
-      throw new TikkaSdkError(
-        TikkaSdkErrorCode.InvalidParams,
-        `${fieldName} must be an integer, got ${quantity}`,
-      );
-    }
-    if (quantity < TICKET_CONSTRAINTS.MIN_QUANTITY) {
-      throw new TikkaSdkError(
-        TikkaSdkErrorCode.InvalidParams,
-        `${fieldName} must be at least ${TICKET_CONSTRAINTS.MIN_QUANTITY}, got ${quantity}`,
-      );
-    }
-    if (quantity > TICKET_CONSTRAINTS.MAX_QUANTITY) {
-      throw new TikkaSdkError(
-        TikkaSdkErrorCode.InvalidParams,
-        `${fieldName} must not exceed ${TICKET_CONSTRAINTS.MAX_QUANTITY}, got ${quantity}`,
-      );
-    }
-  }
 
   /**
    * Checks for duplicate submission attempts.
@@ -119,8 +101,8 @@ export class TicketService {
     params: BuyTicketParams,
   ): Promise<ContractResponse<BuyTicketResult>> {
     const { raffleId, quantity } = params;
-    assertPositiveInt(raffleId, "raffleId");
-    this.validateQuantity(quantity);
+    // Reject invalid inputs client-side before any network call or tx build.
+    validateBuyTicketInputs({ raffleId, quantity });
 
     // Fetch current raffle state and validate before simulating/submitting.
     await this.assertRaffleOpenFor(ContractFn.BUY_TICKET, raffleId);
@@ -182,8 +164,8 @@ export class TicketService {
    */
   async buyTickets(params: BuyTicketsParams): Promise<ContractResponse<BuyTicketResult>> {
     const { raffleId, count, maxPricePerTicket } = params;
-    assertPositiveInt(raffleId, 'raffleId');
-    this.validateQuantity(count, 'count');
+    // Reject invalid inputs (incl. wrong asset precision) before any network call.
+    validateBuyTicketsInputs({ raffleId, count, maxPricePerTicket });
 
     // Fetch current raffle state and validate before simulating/submitting.
     await this.assertRaffleOpenFor(ContractFn.BUY_TICKET, raffleId);
@@ -370,33 +352,30 @@ export class TicketService {
   ): Promise<ContractResponse<BuyBatchResult>> {
     const { purchases, memo } = params;
 
-    // Validate inputs
+    // Validate inputs at the module boundary (before any network / tx build).
     if (!purchases || purchases.length === 0) {
-      throw new TikkaSdkError(
-        TikkaSdkErrorCode.InvalidParams,
-        "Purchases array cannot be empty",
+      throw new InvalidTicketPurchaseError(
+        'purchases',
+        'Purchases array cannot be empty',
       );
     }
 
     if (purchases.length > TICKET_CONSTRAINTS.MAX_BATCH_SIZE) {
-      throw new TikkaSdkError(
-        TikkaSdkErrorCode.InvalidParams,
+      throw new InvalidTicketPurchaseError(
+        'purchases',
         `Batch size cannot exceed ${TICKET_CONSTRAINTS.MAX_BATCH_SIZE}, got ${purchases.length}`,
       );
     }
 
-    // Validate each purchase
     purchases.forEach((purchase, index) => {
       try {
-        assertPositiveInt(purchase.raffleId, `purchases[${index}].raffleId`);
-        this.validateQuantity(
-          purchase.quantity,
-          `purchases[${index}].quantity`,
-        );
+        assertValidRaffleId(purchase.raffleId);
+        assertValidTicketQuantity(purchase.quantity, 'quantity');
       } catch (err) {
-        throw new TikkaSdkError(
-          TikkaSdkErrorCode.InvalidParams,
+        throw new InvalidTicketPurchaseError(
+          'purchases',
           `Invalid purchase at index ${index}: ${err instanceof Error ? err.message : String(err)}`,
+          err,
         );
       }
     });

--- a/sdk/src/modules/user/user.service.ts
+++ b/sdk/src/modules/user/user.service.ts
@@ -237,7 +237,7 @@ export class UserService {
    * @param address - The winner's Stellar public key
    * @returns Array of WinningEntry objects, one per won raffle
    */
-  async getWinnings(address: string): Promise {
+  async getWinnings(address: string): Promise<ContractResponse<WinningEntry[]>> {
     assertValidPublicKey(address);
 
     const activityResult = await this.getActivitySummary({ address });

--- a/sdk/src/wallet/freighter.adapter.spec.ts
+++ b/sdk/src/wallet/freighter.adapter.spec.ts
@@ -21,6 +21,10 @@ describe('FreighterAdapter', () => {
     
     mockFreighterApi = await import('@stellar/freighter-api');
     jest.clearAllMocks();
+    // Restore isConnected after tests that delete it (API-unavailable case).
+    if (!mockFreighterApi.isConnected || typeof mockFreighterApi.isConnected !== 'function') {
+      mockFreighterApi.isConnected = jest.fn();
+    }
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Summary
- Add typed `InvalidTicketPurchaseError` and module-boundary validators for raffle id, quantity bounds, and stroops precision.
- Wire validators into `buy` / `buyTickets` / `buyBatch` so invalid inputs never reach simulate/invoke.
- Jest ESM transform config for stellar-sdk 16 so unit tests can load.

## Test plan
- [x] `npm test -- --testPathPatterns=purchase-validation --testPathPatterns=ticket.service`
- [ ] Full suite (pre-existing failures remain on master for unrelated specs)

Closes #1100